### PR TITLE
Dockerfile for master

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "ctp2CD"]
-	path = ctp2CD
-	url = ../ctp2CD.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,9 @@ addons:
 compiler:
     - g++
 
+services:
+    - docker
+
 #Build steps
 before_install:
     - sudo unlink /usr/bin/gcc && sudo ln -s /usr/bin/gcc-5 /usr/bin/gcc
@@ -26,3 +29,4 @@ script:
     - ./autogen.sh
     - CFLAGS="$CFLAGS -w -fuse-ld=gold" CXXFLAGS="$CXXFLAGS -w -fuse-ld=gold" ./configure --enable-silent-rules
     - make
+    - ./docker_build.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,8 +25,15 @@ before_install:
     - sudo unlink /usr/bin/gcc && sudo ln -s /usr/bin/gcc-5 /usr/bin/gcc
     - sudo unlink /usr/bin/g++ && sudo ln -s /usr/bin/g++-5 /usr/bin/g++
 
-script: 
-    - ./autogen.sh
-    - CFLAGS="$CFLAGS -w -fuse-ld=gold" CXXFLAGS="$CXXFLAGS -w -fuse-ld=gold" ./configure --enable-silent-rules
-    - make
-    - ./docker_build.sh
+jobs:
+  include:
+    - stage: build
+      name: "direct build"
+      script:
+        - ./autogen.sh
+        - CFLAGS="$CFLAGS -w -fuse-ld=gold" CXXFLAGS="$CXXFLAGS -w -fuse-ld=gold" ./configure --enable-silent-rules
+        - make
+    - stage: build
+      name: "docker build"
+      script:
+        - docker build --pull .

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,6 @@ RUN chown -R $USERNAME:$USERNAME /opt/
 USER $USERNAME
 
 COPY --chown=diUser:diUser ./ /ctp2/
-COPY --chown=diUser:diUser ctp2CD/ /opt/ctp2/
 
 RUN cd /ctp2 && \
     ./autogen.sh && \
@@ -30,11 +29,3 @@ RUN cd /ctp2 && \
     make && \
     make install
 
-
-RUN cp -r /ctp2/ctp2_data/ /opt/ctp2/
-
-RUN cp -v /ctp2/ctp2_code/mapgen/.libs/*.so /opt/ctp2/ctp2_program/ctp/dll/map/
-
-WORKDIR /opt/ctp2/ctp2_program/ctp/
-
-CMD ["./ctp2"]

--- a/docker_build.sh
+++ b/docker_build.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+tag="civctp2/civctp2:build"
+echo "Building $tag"
+docker build -t "$tag" . -f Dockerfile

--- a/docker_build.sh
+++ b/docker_build.sh
@@ -1,5 +1,0 @@
-#!/bin/sh
-
-tag="civctp2/civctp2:build"
-echo "Building $tag"
-docker build -t "$tag" . -f Dockerfile


### PR DESCRIPTION
PR provides a `Dockerfile` to build and run (included `run.sh`, or e.g. [x11docker](https://github.com/mviereck/x11docker)) the game from a docker image, provided the necessary data from the CD (as described in the docs) is put into `ctp2CD/`. This can be done through a private submodule, which has to be created by one's own and then referenced by a new commit to track the different SHA of the new submodule. If both repos are pushed to GitLab, the docker image is build by GitLab CI according to the given `.gitlab-ci.yml`.
Currently, the Dockerfile is single staged (and not tuned for size) for debugging purposes and therefore results in a 700MB docker image, which could be reduced in size a lot when debugging is not needed any more. 

Current status:
Game starts (also fullscreen, i.e. `./run.sh ./ctp2 fullscreen`), supports sound and music, graphics resolution can be changed and will be saved in `userprofile.txt` to take effect the next time the game is started. `userprofile.txt` is mapped to `~/.civctp2/userprofile.txt` to persist over docker containers, however the initial settings concerning the map plugins saved by ctp2 (for an existing but empty `userprofile.txt`) are inappropriate, which leads to a assertion message window when a game's map is created. Therefore, start the game without mapping `userprofile.txt` and copy the `userprofile.txt` (created where the ctp2 executable resides) to `~/.civctp2/userprofile.txt` and then enable the mapping again.
Saved games are mapped to ~/.civctp2/save/ but ctp2 terminates (with 255) when loading a game, probably due to some assertion code. This needs some debugging.
If firefox is running when the game is started with `./run.sh` the ctp2 window is distorted, closing firefox solves this, can possibly be avoided with x11docker.