### PR TITLE
Docker builder fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,9 @@ addons:
 compiler:
     - g++
 
+services:
+    - docker
+
 #Build steps
 before_install:
     - sudo unlink /usr/bin/gcc && sudo ln -s /usr/bin/gcc-5 /usr/bin/gcc
@@ -26,3 +29,4 @@ script:
     - ./autogen.sh
     - CFLAGS="$CFLAGS -w -fuse-ld=gold" CXXFLAGS="$CXXFLAGS -w -fuse-ld=gold" ./configure --enable-silent-rules
     - make
+    - ./docker_build.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+################################################################################
+# builder
+################################################################################
+FROM ubuntu:16.04 as builder
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        libsdl1.2-dev libsdl-mixer1.2-dev libsdl-image1.2-dev gtk+-2.0-dev \
+        byacc gcc-5 g++-5 automake libtool unzip flex
+
+ENV USERNAME builder
+
+RUN useradd -m $USERNAME \
+    && echo "$USERNAME:$USERNAME" | chpasswd \
+    && usermod --shell /bin/bash $USERNAME \
+    && usermod -aG video,audio $USERNAME
+
+ENV HOME /opt
+RUN chown -R $USERNAME:$USERNAME /opt/
+USER $USERNAME
+
+COPY --chown=builder:builder ./ /ctp2/
+
+RUN cd /ctp2 \
+    && ./autogen.sh \
+    && CC=/usr/bin/gcc-5 CXX=/usr/bin/g++-5 \
+        CFLAGS="$CFLAGS -w -fuse-ld=gold" CXXFLAGS="$CXXFLAGS -w -fuse-ld=gold" \
+        ./configure --prefix=/opt/ctp2 \
+        --bindir=/opt/ctp2/ctp2_program/ctp --enable-silent-rules \
+    && make \
+    && make install

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ bootstrap: bootstrap-anet
 	autoheader
 	libtoolize --force --copy
 	automake --foreign --add-missing --copy
-	autoconf
+	autoreconf --force --install
 	@echo " "
 	@echo "Bootstraping complete."
 	@echo " "

--- a/docker_build.sh
+++ b/docker_build.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+tag="civctp2/civctp2:build"
+echo "Building $tag"
+docker build -t "$tag" . -f Dockerfile


### PR DESCRIPTION
For some reason travis-ci docker build failed (despite building fine on
other system) with the following error [1]:

```
      CXX      nowin32.lo
    libtool: Version mismatch error.  This is libtool 2.4.6 Debian-2.4.6-0.1, but the
    libtool: definition of this LT_INIT comes from libtool 2.4.2.
    libtool: You should recreate aclocal.m4 with macros from libtool 2.4.6 Debian-2.4.6-0.1
    libtool: and run autoconf again.
    Makefile:448: recipe for target 'nowin32.lo' failed
```

[1] https://travis-ci.com/civctp2/civctp2/builds/89085604

Fix based on this SO post:
https://stackoverflow.com/questions/3096989/libtool-version-mismatch-error