### PR TITLE
 [DO NOT MERGE !] Debug libtool version issue for docker builds on travis 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,9 @@ addons:
 compiler:
     - g++
 
+services:
+    - docker
+
 #Build steps
 before_install:
     - sudo unlink /usr/bin/gcc && sudo ln -s /usr/bin/gcc-5 /usr/bin/gcc
@@ -26,3 +29,4 @@ script:
     - ./autogen.sh
     - CFLAGS="$CFLAGS -w -fuse-ld=gold" CXXFLAGS="$CXXFLAGS -w -fuse-ld=gold" ./configure --enable-silent-rules
     - make
+    - ./docker_build.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,6 @@ before_install:
     - sudo unlink /usr/bin/g++ && sudo ln -s /usr/bin/g++-5 /usr/bin/g++
 
 script: 
-    - ./autogen.sh
-    - CFLAGS="$CFLAGS -w -fuse-ld=gold" CXXFLAGS="$CXXFLAGS -w -fuse-ld=gold" ./configure --enable-silent-rules
-    - make
-    - ./docker_build.sh
+    - ./show_system_libtool_version.sh
+    - ./show_docker_libtool_version.sh
+    - ./force_fail.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,29 +3,14 @@
 ################################################################################
 FROM ubuntu:16.04 as builder
 
+RUN echo && echo "Docker libtoolize version BEFORE apt-get:" \
+    && libtoolize --version || echo "libtoolize not found" ; echo
+
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         libsdl1.2-dev libsdl-mixer1.2-dev libsdl-image1.2-dev gtk+-2.0-dev \
         byacc gcc-5 g++-5 automake libtool unzip flex
 
-ENV USERNAME builder
+RUN echo && echo "Docker libtoolize version AFTER apt-get:" \
+    && libtoolize --version || echo "libtoolize not found" ; echo
 
-RUN useradd -m $USERNAME \
-    && echo "$USERNAME:$USERNAME" | chpasswd \
-    && usermod --shell /bin/bash $USERNAME \
-    && usermod -aG video,audio $USERNAME
-
-ENV HOME /opt
-RUN chown -R $USERNAME:$USERNAME /opt/
-USER $USERNAME
-
-COPY --chown=builder:builder ./ /ctp2/
-
-RUN cd /ctp2 \
-    && ./autogen.sh \
-    && CC=/usr/bin/gcc-5 CXX=/usr/bin/g++-5 \
-        CFLAGS="$CFLAGS -w -fuse-ld=gold" CXXFLAGS="$CXXFLAGS -w -fuse-ld=gold" \
-        ./configure --prefix=/opt/ctp2 \
-        --bindir=/opt/ctp2/ctp2_program/ctp --enable-silent-rules \
-    && make \
-    && make install

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+################################################################################
+# builder
+################################################################################
+FROM ubuntu:16.04 as builder
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        libsdl1.2-dev libsdl-mixer1.2-dev libsdl-image1.2-dev gtk+-2.0-dev \
+        byacc gcc-5 g++-5 automake libtool unzip flex
+
+ENV USERNAME builder
+
+RUN useradd -m $USERNAME \
+    && echo "$USERNAME:$USERNAME" | chpasswd \
+    && usermod --shell /bin/bash $USERNAME \
+    && usermod -aG video,audio $USERNAME
+
+ENV HOME /opt
+RUN chown -R $USERNAME:$USERNAME /opt/
+USER $USERNAME
+
+COPY --chown=builder:builder ./ /ctp2/
+
+RUN cd /ctp2 \
+    && ./autogen.sh \
+    && CC=/usr/bin/gcc-5 CXX=/usr/bin/g++-5 \
+        CFLAGS="$CFLAGS -w -fuse-ld=gold" CXXFLAGS="$CXXFLAGS -w -fuse-ld=gold" \
+        ./configure --prefix=/opt/ctp2 \
+        --bindir=/opt/ctp2/ctp2_program/ctp --enable-silent-rules \
+    && make \
+    && make install

--- a/docker_build.sh
+++ b/docker_build.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+tag="civctp2/civctp2:build"
+echo "Building $tag"
+docker build -t "$tag" . -f Dockerfile

--- a/force_fail.sh
+++ b/force_fail.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+echo
+echo "Forcing failure..."
+exit 1

--- a/show_docker_libtool_version.sh
+++ b/show_docker_libtool_version.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+tag="civctp2/civctp2:show_docker_libtoolize_version"
+echo "Building $tag"
+docker build -t "$tag" . -f Dockerfile

--- a/show_system_libtool_version.sh
+++ b/show_system_libtool_version.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+echo "System libtoolize version:"
+libtoolize --version || echo "libtoolize not found"


### PR DESCRIPTION
NOTE: This PR is not meant to be merged!
It's only purpose is to debug libtool version issue when building in docker by travis-ci.

The issue is that it fails with following error [[1]](https://travis-ci.com/civctp2/civctp2/builds/89881012#L4895):
```
make[3]: Entering directory '/ctp2/ctp2_code/os/nowin32'
  CXX      nowin32.lo
libtool: Version mismatch error.  This is libtool 2.4.6 Debian-2.4.6-0.1, but the
libtool: definition of this LT_INIT comes from libtool 2.4.2.
libtool: You should recreate aclocal.m4 with macros from libtool 2.4.6 Debian-2.4.6-0.1
libtool: and run autoconf again.
Makefile:448: recipe for target 'nowin32.lo' failed
make[3]: *** [nowin32.lo] Error 63
```

[1] https://travis-ci.com/civctp2/civctp2/builds/89881012#L4895