### PR TITLE
revert some changes from commit 88eb70652910a3bbbae that cause a segfault

### DIFF
--- a/ctp2_code/robot/aibackdoor/dynarr.h
+++ b/ctp2_code/robot/aibackdoor/dynarr.h
@@ -125,7 +125,7 @@ public:
 
 	sint32 Find(const T &me) ;
 
-	inline const sint32 Num() const  { return m_nElements; }
+	inline const sint32 Num() const  { if(!this) return 0; return m_nElements; }
     inline const sint32 ArraySize() const { return m_maxElements; }
 
     void Concat(const DynamicArray<T> & addme);


### PR DESCRIPTION
changes to:
ctp2_code/robot/aibackdoor/dynarr.h : caused a segfault of ctp2 when a new or a saved game was loaded (see tests of ctp2DF @ 6e70a4a96e82 and c45f8e9f474a)