### PR TITLE
Video playing for master branch with SDL (linux)

### DIFF
--- a/ctp2_code/ui/aui_common/aui_movie.cpp
+++ b/ctp2_code/ui/aui_common/aui_movie.cpp
@@ -357,9 +357,17 @@ AUI_ERRCODE aui_Movie::Open(
 		//code from SDL_ffmpeg example:
 		film= SDL_ffmpegOpen(m_filename);
 		if (film){
+		    SDL_ffmpegStream *str;
+		    str = SDL_ffmpegGetVideoStream(film, 0);
+
+		    if(str->frameRate[1]) // can be zero according to SDL_ffmpeg.h
+		      m_timePerFrame = 1000.0 * str->frameRate[0] / str->frameRate[1];
+		    else
+		      m_timePerFrame = 1000.0 * str->frameRate[0];
+		    
 		    SDL_ffmpegSelectVideoStream(film, 0);
 		    SDL_ffmpegSelectAudioStream(film, 0);
-		    
+			
 		    int w,h;
 		    // we get the size from our active video stream
 		    if(SDL_ffmpegGetVideoSize(film, &w, &h))
@@ -587,7 +595,6 @@ AUI_ERRCODE aui_Movie::Process( void )
 
 	if ( m_isPlaying && !m_isPaused )
 	{
-#ifdef __AUI_USE_DIRECTX__
 		uint32 time = GetTickCount();
 		if ( time - m_lastFrameTime > m_timePerFrame )
 		{
@@ -596,6 +603,7 @@ AUI_ERRCODE aui_Movie::Process( void )
 				( m_flags & k_AUI_MOVIE_PLAYFLAG_ONSCREEN ) ?
 				g_ui->Secondary() :
 				m_surface;
+#ifdef __AUI_USE_DIRECTX__
 			uint8 *frame = (uint8 *)AVIStreamGetFrame( m_getFrame, m_curFrame );
 			Assert( frame != NULL );
 			if ( !frame ) return AUI_ERRCODE_HACK;
@@ -651,39 +659,27 @@ AUI_ERRCODE aui_Movie::Process( void )
 				if ( !(m_flags & k_AUI_MOVIE_PLAYFLAG_LOOP) )
 					m_isFinished = TRUE;
 			}
+#elif defined(USE_SDL_FFMPEG)
+			SDL_ffmpegVideoFrame* frame= 0;
+			SDL_Rect sdl_rect = { m_rect.left, m_rect.top, m_rect.right-m_rect.left, m_rect.bottom-m_rect.top };
+			aui_SDLSurface* sdl_surf = static_cast<aui_SDLSurface*>(surface);
+			
+			frame = SDL_ffmpegGetVideoFrame(film);
+			if(frame){
+			  SDL_BlitSurface(frame->buffer, 0, sdl_surf->DDS(), &sdl_rect);
+			  // we flip the double buffered screen so we might actually see something
+			  SDL_Flip(sdl_surf->DDS());
+			}
+			// end reached?
+			m_isFinished= SDL_ffmpegGetPosition(film) >= SDL_ffmpegGetDuration(film);
+#else
+			m_isFinished = TRUE;
+#endif
 
 			m_lastFrameTime = time;
 
 			retval = AUI_ERRCODE_HANDLED;
 		}
-#elif defined(USE_SDL_FFMPEG)
-		aui_Surface *surface = ( m_flags & k_AUI_MOVIE_PLAYFLAG_ONSCREEN ) ?
-		    g_ui->Primary() :
-		    m_surface;
-		
-		int s;
-		SDL_ffmpegStream *str;
-		SDL_ffmpegVideoFrame* frame= 0;
-		SDL_Rect sdl_rect = { m_rect.left, m_rect.top, m_rect.right-m_rect.left, m_rect.bottom-m_rect.top };
-		aui_SDLSurface* sdl_surf = static_cast<aui_SDLSurface*>(surface);
-		int64_t duration= SDL_ffmpegGetDuration(film);
-		
-		while(!frame && !m_isFinished){ //wait until there is a frame to be shown
-		    frame = SDL_ffmpegGetVideoFrame(film);
-		    SDL_Delay(5); //too much for 25 fps but here we have only 15 fps
-		    
-		    if(frame){
-			// we got a frame, so we better show this one
-			SDL_BlitSurface(frame->buffer, 0, sdl_surf->DDS(), &sdl_rect);
-			// we flip the double buffered screen so we might actually see something
-			SDL_Flip(sdl_surf->DDS());
-			}
-		    m_isFinished= SDL_ffmpegGetPosition(film) >= duration;
-		    }
-#else
-		m_isFinished = TRUE;
-		retval = AUI_ERRCODE_HANDLED;
-#endif
 	}
 	
 	return retval;


### PR DESCRIPTION
This PR offers the code that is needed to get basic in-game video playing with SDL (under linux).
The initial code originates from my commits to the linux branch (https://github.com/civctp2/civctp2/commit/818b8795b6ab559cdbf3619499b418467a72ff7b https://github.com/civctp2/civctp2/commit/47dcad3d17aedd1822c65dcc0232c85ad366cf44 https://github.com/civctp2/civctp2/commit/ce577097c945293ce7993627125d631873757615 https://github.com/civctp2/civctp2/commit/b9e7dc82ab49424a1175a51a49be064879a418af) using [SDL_ffmpeg](https://github.com/arjanhouben/SDL_ffmpeg) before version 0.9.0, which was alread partially included into master by ctplinuxfan (https://github.com/civctp2/civctp2/commit/2241dd2b3bce22128d66b5dc403bb9aa3e8d2382).
Both SDL_ffmpeg and the necessary ffmpeg-0.5.2 can still be compiled on ubuntu:16.04 (see https://github.com/LynxAbraxas/ctp2DF/blob/296d7f8c21e70e5729ace2fda9ad929237ad7e88/Dockerfile)
The audio quality isn't perfect yet, therefore I tried to adjust the code to closer mirror that of directx (https://github.com/civctp2/civctp2/commit/5af5346e0d7bd184c04a8c3dd4db474f578f029f) but then the video frames are not visible. Possibly some code following https://github.com/civctp2/civctp2/blob/5af5346e0d7bd184c04a8c3dd4db474f578f029f/ctp2_code/ui/aui_common/aui_movie.cpp#L508 blackens the surface again (before https://github.com/civctp2/civctp2/commit/5af5346e0d7bd184c04a8c3dd4db474f578f029f , the whole video was played in one call to `Process()`)
I reverted that commit (and not amended) to keep track of these changes for a possible later use when the video code is ported to a newer version of SDL_ffmpeg, which might also solve the audio problem (the audio handling has change quite a bit up to SDL_ffmpeg-1.3.2) and remove the need of converting the videos (as described in `README.linux`).
@ptitSeb I noticed that you also forked and worked on making SDL_ffmpeg compile with current FFmpeg. What's the current status? 