### PR TITLE
WIP: compiling master with `--enable-debug` also under linux

### DIFF
--- a/ctp2_code/Makefile.am
+++ b/ctp2_code/Makefile.am
@@ -570,6 +570,10 @@ ui/ldl/ldl.tab.h: ui/ldl/ldl.tab.c ui/ldl
 ui/ldl/ldl.tab.c: $(ctp2_code)/ui/ldl/ldl.y ui/ldl
 	$(YACC) $(YFLAGS) $(AM_YFLAGS) -bui/ldl/ldl $<
 
+
+ctp/ctp2_utils/c3cmdline.cpp: gs/slic/ysc.tab.h
+
+
 AM_CFLAGS=\
 	$(CTP2_CFLAGS)
 

--- a/ctp2_code/gfx/spritesys/UnitActor.cpp
+++ b/ctp2_code/gfx/spritesys/UnitActor.cpp
@@ -105,8 +105,9 @@ extern PointerList<Player> *g_deadPlayer;
 #define k_SHIELD_ON_TIME        650
 #define k_SHIELD_OFF_TIME       150
 
-#ifndef _DEBUG_MEMORY
+#if !defined _DEBUG_MEMORY && defined WIN32
 #define STOMPCHECK() if (m_curAction) { Assert(_CrtIsMemoryBlock(m_curAction, sizeof(Action),NULL,NULL,NULL));}
+#endif
 #else
 #define STOMPCHECK() ;
 #endif

--- a/ctp2_code/gs/events/GameEventManager.cpp
+++ b/ctp2_code/gs/events/GameEventManager.cpp
@@ -579,7 +579,9 @@ bool GameEventManager::CheckArg(sint32 num, char got, char want)
 
 	if(got != want) {
 #ifdef _DEBUG
+#ifdef WIN32
 		c3errors_ErrorDialog("GameEventManager", "Argument %d should be of type %s.  Stack: %s", num, ArgCharToName(want), c3debug_StackTrace());
+#endif
 #endif
 		return false;
 	}
@@ -795,7 +797,9 @@ bool GameEventManager::VerifyArgs(GAME_EVENT type, const GAME_EVENT_ARGUMENT* ar
 			case GEA_End:
 				if(*(argString) != 0) {
 #ifdef _DEBUG
+#ifdef WIN32
 					c3errors_ErrorDialog("GameEventManager", "Not enough arguments.  Stack: %s", c3debug_StackTrace());
+#endif
 #endif
 					return false;
 				}

--- a/ctp2_code/gs/outcom/C3Player.cpp
+++ b/ctp2_code/gs/outcom/C3Player.cpp
@@ -52,7 +52,7 @@
 #include "DB.h"
 #include "WonderRecord.h"
 #include "ConstDB.h"
-#include "aicause.h"
+#include "AICause.h"
 
 
 #include "TradeRoute.h"

--- a/ctp2_code/gs/outcom/c3robot.cpp
+++ b/ctp2_code/gs/outcom/c3robot.cpp
@@ -25,7 +25,7 @@ extern TurnCount *g_turn;
 #include "IRobot.h"
 #include "C3GameState.h"
 
-#include "aicause.h"
+#include "AICause.h"
 
 #include "IMapGen.h"
 #include "ic3BlgDB.h"

--- a/ctp2_code/net/general/net_cheat.cpp
+++ b/ctp2_code/net/general/net_cheat.cpp
@@ -7,7 +7,7 @@
 #include "Unit.h"
 #include "UnitDynArr.h"
 #include "MapPoint.h"
-#include "aicause.h"
+#include "AICause.h"
 #include "MaterialPool.h"
 #include "XY_Coordinates.h"
 #include "World.h"

--- a/ctp2_code/os/linux/civctp2.prj
+++ b/ctp2_code/os/linux/civctp2.prj
@@ -1014,7 +1014,7 @@ module.include.files=\
 	../../../ctp2_code/user-robotcom/shared/improvementtypes.h\
 	../../../ctp2_code/user-robotcom/shared/globals.h\
 	../../../ctp2_code/user-robotcom/shared/order.h\
-	../../../ctp2_code/user-robotcom/shared/aicause.h\
+	../../../ctp2_code/user-robotcom/shared/AICause.h\
 	../../../ctp2_code/robotcom/Top/strategic_map.h\
 	../../../ctp2_code/robotcom/Top/Cont.h\
 	../../../ctp2_code/robotcom/Top/CityVertex.h\

--- a/ctp2_code/robot/aibackdoor/priorityqueue.h
+++ b/ctp2_code/robot/aibackdoor/priorityqueue.h
@@ -36,6 +36,10 @@
 
 #include "dynarr.h"
 
+#ifdef _DEBUG
+#include "World.h"                  // g_theWorld;
+#endif
+
 template <class T> class DAPriorityQueue {
 	DynamicArray<T*> m_queue;
 

--- a/ctp2_code/robotcom/Agent/CityAgent.cpp
+++ b/ctp2_code/robotcom/Agent/CityAgent.cpp
@@ -19,7 +19,7 @@
 #include "civarchive.h"
 
 #include "ic3GameState.h"
-#include "aicause.h"
+#include "AICause.h"
 #include "aicell.h"
 
 #include "aimain.h"

--- a/ctp2_code/robotcom/Agent/armyagent.cpp
+++ b/ctp2_code/robotcom/Agent/armyagent.cpp
@@ -47,7 +47,7 @@
 extern Wall_Clock *g_wall_clock;
 
 #include "order.h"
-#include "aicause.h"
+#include "AICause.h"
 #include "C3Player.h"
 #include "Foreigner.h"
 #include "ForeignCity.h"

--- a/ctp2_code/robotcom/Agent/scienceagent.cpp
+++ b/ctp2_code/robotcom/Agent/scienceagent.cpp
@@ -15,7 +15,7 @@
 #include "aicell.h"
 #include "AiMap.h"
 #include "airndcnt.h"
-#include "aicause.h"
+#include "AICause.h"
 
 #include "scienceagent.h"
 

--- a/ctp2_code/robotcom/aimgr/aimain.cpp
+++ b/ctp2_code/robotcom/aimgr/aimain.cpp
@@ -13,7 +13,7 @@
 #include "C3Player.h"
 
 #include "IMapPointData.h"
-#include "aicause.h"
+#include "AICause.h"
 #include "order.h"
 
 #include "ic3GameState.h"

--- a/ctp2_code/robotcom/goals/GoalRoad.cpp
+++ b/ctp2_code/robotcom/goals/GoalRoad.cpp
@@ -11,7 +11,7 @@
 #include "CityAgent.h"
 #include "ic3RobotAstar.h"
 #include "aimain.h"
-#include "aicause.h"
+#include "AICause.h"
 #include "scienceagent.h"
 
 extern double fz_inst_threat_threshold;

--- a/ctp2_code/robotcom/goals/OA_Repair_Installation.cpp
+++ b/ctp2_code/robotcom/goals/OA_Repair_Installation.cpp
@@ -12,7 +12,7 @@
 #include "airndcnt.h"
 #include "TerrImproveData.h"
 #include "scienceagent.h"
-#include "aicause.h"
+#include "AICause.h"
 
 extern double fz_min_num_dirty_tiles;
 

--- a/ctp2_code/user-robotcom/aimain/aimain.h
+++ b/ctp2_code/user-robotcom/aimain/aimain.h
@@ -4,7 +4,7 @@
 #define __AI_MAIN_H__ 1
 
 #include "ctp.h"
-#include "aicause.h"
+#include "AICause.h"
 #include "order.h"
 
 #include "ic3GameState.h"

--- a/ctp2_code/user-robotcom/incom/robotcom.cpp
+++ b/ctp2_code/user-robotcom/incom/robotcom.cpp
@@ -2,7 +2,7 @@
 
 #include "ctp.h"
 #include "globals.h"
-#include "aicause.h"
+#include "AICause.h"
 #include "order.h"
 
 #include "RobotCOM.h"


### PR DESCRIPTION
The porting for debug-code is not yet finished. For inspirations, see e.g. the comparison between master and linux branch for `c3debug.cpp` https://github.com/civctp2/civctp2/compare/master...civctp2:linux#diff-7bdc57e9106100930a91ac0b8f015311.
Mostly calls to the MS C++ specific `crtdbg.h` need replacements or exclusions.
Compiling with `--enable-debug` gives access to e.g. `c3cmdline` and the sprite editor.