### PR TITLE
Minor Dockerfile updates to increase readability

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,29 +3,32 @@
 ################################################################################
 FROM ubuntu:16.04 as builder
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    libsdl1.2-dev libsdl-mixer1.2-dev libsdl-image1.2-dev byacc gtk+-2.0-dev gcc-5 g++-5 \
-    automake libtool unzip flex
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        libsdl1.2-dev libsdl-mixer1.2-dev libsdl-image1.2-dev gtk+-2.0-dev \
+        byacc gcc-5 g++-5 automake libtool unzip flex
 
-ENV USERNAME diUser
-RUN useradd -m $USERNAME && \
-    echo "$USERNAME:$USERNAME" | chpasswd && \
-    usermod --shell /bin/bash $USERNAME && \
-    usermod -aG video,audio $USERNAME
+ENV USERNAME builder
+
+RUN useradd -m $USERNAME \
+    && echo "$USERNAME:$USERNAME" | chpasswd \
+    && usermod --shell /bin/bash $USERNAME \
+    && usermod -aG video,audio $USERNAME
 
 ENV HOME /opt
 RUN chown -R $USERNAME:$USERNAME /opt/
 USER $USERNAME
 
-COPY --chown=diUser:diUser ./ /ctp2/
+# Unfortunately EVN variables expansion for the COPY command is not supported
+# at the moment (see https://github.com/moby/moby/issues/35018),
+# so the username needs to be hardcoded for now.
+COPY --chown=builder:builder ./ /ctp2/
 
-RUN cd /ctp2 && \
-    ./autogen.sh && \
-    CC=/usr/bin/gcc-5 \
-    CXX=/usr/bin/g++-5 \
-    CFLAGS="$CFLAGS -w -fuse-ld=gold" \
-    CXXFLAGS="$CXXFLAGS -w -fuse-ld=gold" \
-    ./configure --prefix=/opt/ctp2 --bindir=/opt/ctp2/ctp2_program/ctp --enable-silent-rules && \
-    make && \
-    make install
-
+RUN cd /ctp2 \
+    && ./autogen.sh \
+    && CC=/usr/bin/gcc-5 CXX=/usr/bin/g++-5 \
+        CFLAGS="$CFLAGS -w -fuse-ld=gold" CXXFLAGS="$CXXFLAGS -w -fuse-ld=gold" \
+        ./configure --prefix=/opt/ctp2 \
+        --bindir=/opt/ctp2/ctp2_program/ctp --enable-silent-rules \
+    && make \
+    && make install


### PR DESCRIPTION
This PR includes following changes to (hopefully) increase Dockerfile readability:
- try to obey 80-characters per line limit
- move '&&' shell operators the to new line, so it is easier to see
  where the next command starts
- use extra indentation for the parameters when dealing with multi-line
  commands
- change the username from to 'builder': it is not obvious to me what the `di` in `diUser ` stands for (docker image perhaps?), but by convention UNIX usernames are all lower-case, and also `builder` seems to be more explanatory
- explain in the comments why `ENV USERNAME` is not used in `COPY --chown=`