### PR TITLE
BUG: respect goods animation setting for trade routes when loading a …

### DIFF
--- a/ctp2_code/gfx/spritesys/TradeActor.cpp
+++ b/ctp2_code/gfx/spritesys/TradeActor.cpp
@@ -84,7 +84,9 @@ TradeActor::TradeActor(TradeRoute newRoute)
 
 	sint32 index = g_theResourceDB->Get(m_routeResource)->GetSpriteID();
 
-	m_goodSpriteGroup = (GoodSpriteGroup *)g_goodSpriteGroupList->GetSprite(index, type, LOADTYPE_BASIC,(GAME_ACTION)0);
+	m_goodSpriteGroup = (GoodSpriteGroup *)g_goodSpriteGroupList->GetSprite(index, type, LOADTYPE_FULL,(GAME_ACTION)0);
+	if (m_goodSpriteGroup == NULL)
+	    m_goodSpriteGroup = (GoodSpriteGroup *)g_goodSpriteGroupList->GetSprite(index, type, LOADTYPE_BASIC,(GAME_ACTION)0);
 
 	m_currentPos = m_sourcePos = m_routePath->Get(m_currentPosID);
 	m_destPos = m_routePath->Get(m_destPosID);


### PR DESCRIPTION
In addition to #24, this PR enables goods animation for trade route goods for loaded save-games. These were only animated for newly created routes but not any more after loading from a saved game.