### PR TITLE
Make the AI compare the city limit of it current government, when it …

### DIFF
--- a/ctp2_code/ai/CityManagement/governor.cpp
+++ b/ctp2_code/ai/CityManagement/governor.cpp
@@ -400,7 +400,7 @@ sint32 Governor::ComputeBestGovernment() const
 		if (player_ptr->GetNumCities() > newCityLimit)
 		{
 			sint32 const oldCityLimit =
-				strategy.GetGovernment(player_ptr->GetGovernmentType())->
+				g_theGovernmentDB->Get(player_ptr->GetGovernmentType())->
 					GetTooManyCitiesThreshold();
 
 			if (newCityLimit > oldCityLimit)

--- a/ctp2_code/ai/strategy/scheduler/Scheduler.h
+++ b/ctp2_code/ai/strategy/scheduler/Scheduler.h
@@ -115,11 +115,6 @@ public:
 
 	static void ResizeAll(const PLAYER_INDEX & newMaxPlayerId);
 
-#if 0
-	static void LoadAll(CivArchive & archive);
-	static void SaveAll(CivArchive & archive);
-#endif
-
 	static Scheduler & GetScheduler(const sint32 & playerId);
 
 	static void CleanupAll(void);

--- a/ctp2_code/ai/strategy/scheduler/scheduler.cpp
+++ b/ctp2_code/ai/strategy/scheduler/scheduler.cpp
@@ -135,27 +135,6 @@ void Scheduler::ResizeAll(const PLAYER_INDEX & newMaxPlayerId)
 	}
 }
 
-/*
-// no longer used "Reason: should be able to regenerate state from game objects."
-void Scheduler::LoadAll(CivArchive & archive)
-{
-	AI_DPRINTF(k_DBG_AI, m_playerId, -1, -1, ("\n\ncalling Scheduler::LoadAll\n\n"));
-	for(size_t i = 0; i < s_theSchedulers.size(); i++)
-	{
-		s_theSchedulers[i].Load(archive);
-	}
-}
-
-// no longer used "Reason: should be able to regenerate state from game objects."
-void Scheduler::SaveAll(CivArchive & archive)
-{
-	for(size_t i = 0; i < s_theSchedulers.size(); i++)
-	{
-		s_theSchedulers[i].Save(archive);
-	}
-}
-*/
-
 //////////////////////////////
 //
 // used mainly in ctpai to get the player's scheduler

--- a/ctp2_code/gs/gameobj/CityData.cpp
+++ b/ctp2_code/gs/gameobj/CityData.cpp
@@ -4492,20 +4492,23 @@ sint32 CityData::SupportBuildings(bool projectedOnly)
 			sint32 const    wonderLevel =
 			    wonderutil_GetDecreaseMaintenance(g_player[m_owner]->m_builtWonders);
 
-			while (IsBankrupting() && (m_built_improvements != 0))
+			if(buildingUpkeep > 0)
 			{
-				sint32 const    cheapBuilding =
-				    buildingutil_GetCheapestBuilding(m_built_improvements, wonderLevel, m_owner);
-				Assert(cheapBuilding >= 0);
-				if (cheapBuilding < 0)
-					break;
+				while(IsBankrupting() && (m_built_improvements != 0))
+				{
+					sint32 const    cheapBuilding =
+						buildingutil_GetCheapestBuilding(m_built_improvements, wonderLevel, m_owner);
+					Assert(cheapBuilding >= 0);
+					if(cheapBuilding < 0)
+						break;
 
-				SellBuilding(cheapBuilding, false);
-				SlicObject * so = new SlicObject("029NoMaint");
-				so->AddRecipient(GetOwner());
-				so->AddCity(m_home_city);
-				so->AddBuilding(cheapBuilding);
-				g_slicEngine->Execute(so);
+					SellBuilding(cheapBuilding, false);
+					SlicObject * so = new SlicObject("029NoMaint");
+					so->AddRecipient(GetOwner());
+					so->AddCity(m_home_city);
+					so->AddBuilding(cheapBuilding);
+					g_slicEngine->Execute(so);
+				}
 			}
 
 			if(IsBankrupting())

--- a/ctp2_data/default/gamedata/govern.txt
+++ b/ctp2_data/default/gamedata/govern.txt
@@ -1,3 +1,5 @@
+## 0 ##########################################################
+
 GOVERNMENT_ANARCHY {
    Icon ICON_GOV_ANARCHY
    Rank 0
@@ -68,7 +70,7 @@ GOVERNMENT_ANARCHY {
    MartialLawRank 0
 }
 
-############################################################
+## 1 ##########################################################
 
 GOVERNMENT_COMMUNISM {
    Icon ICON_GOV_COMMUNISM
@@ -141,7 +143,7 @@ GOVERNMENT_COMMUNISM {
    MartialLawRank 3
 }
 
-############################################################
+## 2 ##########################################################
 
 GOVERNMENT_CORPORATE_REPUBLIC {
    Icon ICON_GOV_CORPORATE_REPUBLIC
@@ -214,7 +216,7 @@ GOVERNMENT_CORPORATE_REPUBLIC {
    MartialLawRank 1
 }
 
-############################################################
+## 3 ##########################################################
 
 GOVERNMENT_DEMOCRACY {
    Icon ICON_GOV_DEMOCRACY
@@ -287,7 +289,7 @@ GOVERNMENT_DEMOCRACY {
    MartialLawRank 1
 }
 
-############################################################
+## 4 ##########################################################
 
 GOVERNMENT_ECOTOPIA {
    Icon ICON_GOV_ECOTOPIA
@@ -361,7 +363,7 @@ GOVERNMENT_ECOTOPIA {
    MartialLawRank 1
 }
 
-############################################################
+## 5 ##########################################################
 
 GOVERNMENT_FASCISM {
    Icon ICON_GOV_FASCISM
@@ -434,7 +436,7 @@ GOVERNMENT_FASCISM {
    MartialLawRank 3
 }
 
-############################################################
+## 6 ##########################################################
 
 GOVERNMENT_MONARCHY {
    Icon ICON_GOV_MONARCHY
@@ -507,7 +509,7 @@ GOVERNMENT_MONARCHY {
    MartialLawRank 4
 }
 
-############################################################
+## 7 ##########################################################
 
 GOVERNMENT_REPUBLIC {
    Icon ICON_GOV_REPUBLIC
@@ -580,7 +582,7 @@ GOVERNMENT_REPUBLIC {
    MartialLawRank 1
 }
 
-############################################################
+## 8 ##########################################################
 
 GOVERNMENT_TECHNOCRACY {
    Icon ICON_GOV_TECHNOCRACY
@@ -653,7 +655,7 @@ GOVERNMENT_TECHNOCRACY {
    MartialLawRank 2
 }
 
-############################################################
+## 9 ##########################################################
 
 GOVERNMENT_THEOCRACY {
    Icon ICON_GOV_THEOCRACY
@@ -726,7 +728,7 @@ GOVERNMENT_THEOCRACY {
    MartialLawRank 2
 }
 
-############################################################
+## 10 ##########################################################
 
 GOVERNMENT_TYRANNY {
    Icon ICON_GOV_TYRANNY
@@ -798,7 +800,7 @@ GOVERNMENT_TYRANNY {
    MartialLawRank 5
 }
 
-############################################################
+## 11 ##########################################################
 
 GOVERNMENT_VIRTUAL_DEMOCRACY {
    Icon ICON_GOV_VIRTUAL_DEMOCRACY


### PR DESCRIPTION
…is looking for a better government

The AI has a list of governments it will use. If it has too many cities it will look whether it contains a government that allows more cities. If so it will switch to. However, it contained a bug instead comparing the governments from the list to the current government it would compare it to another government in the list. Of course that does not allow the AI to find a better government. But it may also crash the game if the current government's index is higher than the list is long. This is a problem that occurs in the late game with developed AIs.
..\ctp2_code\ai\CityManagement\governor.cpp

Added the database indices of the governments in the comments, that is useful for debugging such as the previous problem.
..\ctp2_data\default\gamedata\govern.txt

If a city bankrupts it does not try to sell building if the maintenance of the remaining buildings is zero, such as the capitol. This actually just fixes an assert in the debug version, and give a little speed, but probably not noticeable.
..\ctp2_code\gs\gameobj\CityData.cpp

Removed some outcommented unused code (by the way commit)
..\ctp2_code\ai\strategy\scheduler\Scheduler.h
..\ctp2_code\ai\strategy\scheduler\scheduler.cpp