### PR TITLE
revert "ESC show the option window again" from 6e795dc2c7efb042

### DIFF
--- a/ctp2_code/ui/aui_ctp2/keypress.cpp
+++ b/ctp2_code/ui/aui_ctp2/keypress.cpp
@@ -363,8 +363,8 @@ sint32 ui_HandleKeypress(WPARAM wParam, LPARAM lParam)
 						data->GetButton(0)->Callback();
 					}
 				}
-			} else if (g_chatBox->IsActive()) {
-				g_chatBox->SetActive(false);
+			} else if (g_chatBox) {
+			        g_chatBox->SetActive(false);
 			} else if (g_optionsWindow && g_c3ui->GetWindow(g_optionsWindow->Id())) {
 
 				optionsscreen_removeMyWindow(AUI_BUTTON_ACTION_EXECUTE);


### PR DESCRIPTION
Showing the option window should have another key than ESC.
ESC is very commonly used for closing a window, which is an action that is far more often needed during game play (e.g. showing unread messages with TAB and closing them with ESC) than opening the option window.