### PR TITLE
message for pirating civ about the gold captured

### DIFF
--- a/ctp2_code/gs/gameobj/ArmyData.cpp
+++ b/ctp2_code/gs/gameobj/ArmyData.cpp
@@ -1656,9 +1656,22 @@ void ArmyData::BeginTurn()
             for(i = 0; i < cell->GetNumTradeRoutes(); i++) {
                 TradeRoute route = cell->GetTradeRoute(i);
                 if(route->GetPiratingArmy().m_id == m_id) {
-                    g_player[m_owner]->AddGold(static_cast<sint32>(route->GetValue() * g_theConstDB->Get(0)->GetPiracyWasteCoefficient()));
+		    sint32 pgold = static_cast<sint32>(route->GetValue() * g_theConstDB->Get(0)->GetPiracyWasteCoefficient());
+                    g_player[m_owner]->AddGold(pgold);
 					//added pirated strategic good?
                     piratedByMe++;
+
+		    Unit fromCity, toCity;
+		    fromCity = route.GetSource();
+		    toCity = route.GetDestination();
+
+		    SlicObject * so = new SlicObject("044TradePirateGold");
+		    so->AddRecipient(GetOwner());
+		    so->AddGold(pgold) ;
+		    so->AddCity(fromCity);
+		    so->AddCity(toCity);
+		    so->AddCivilisation(fromCity.GetOwner());
+		    g_slicEngine->Execute(so);
                 }
             }
             if(piratedByMe < 1) {

--- a/ctp2_data/chinese/gamedata/info_str.txt
+++ b/ctp2_data/chinese/gamedata/info_str.txt
@@ -152,6 +152,7 @@ WAR_OVER 				"{player[0].civ_name_plural}与{player[1].civ_name_plural}战争结束。
 
 ## Trade Messages ##
 TRADE_PIRATED 				"{player[0].sir_cap}，我{city[0].name}至{city[1].name}的贸易路线遭到{player[1].civ_name_plural}的抢劫。"
+TRADE_PIRATE_GOLD			"{gold[0].value} gold was pirated on the trade route from {city[0].name} to {city[1].name} owned by {player[0].civ_name_plural}."
 TRADE_ROUTES_BROKEN_BY_EMBARGO		"{player[0].sir_cap}，{player[1].civ_name_plural}对我采取贸易禁运，通往{player[1].country_name}的贸易路线关闭，商队悉数遭到没收。"
 TRADE_ROUTES_BROKEN_BY_WAR		"报告一个坏消息，{player[0].sir}。由于我国与{player[1].country_name}发生零星冲突，通往{player[1].civ_name_singular}的贸易路线关闭，商队悉数遭没收。"
 SENDER_KILLED_TRADE_ROUTE               "{player[0].leader_name}取消了从{city[0].name}到{city[1].name}的{good[0].name}贸易路线。"

--- a/ctp2_data/default/gamedata/script.slc
+++ b/ctp2_data/default/gamedata/script.slc
@@ -1740,6 +1740,11 @@ messagebox '040GrossPolluter' {
 	EyePoint(city[0], city[0].owner, 'OpenProductionCallback');//Added by MG
 }
 
+messagebox '044TradePirateGold' {
+	Text(ID_TRADE_PIRATE_GOLD);
+	MessageType("TRADE");
+}
+
 messagebox '045TradePirated' {
 	Text(ID_TRADE_PIRATED) ;
 	MessageType("PIRATE");

--- a/ctp2_data/english/gamedata/info_str.txt
+++ b/ctp2_data/english/gamedata/info_str.txt
@@ -151,7 +151,8 @@ WAR_OVER				"The {player[0].civ_name_plural} are no longer at war with the {play
 
 
 ## Trade Messages ##
-TRADE_PIRATED				"{player[0].sir_cap}, our trade route from {city[0].name} to {city[1].name} has been pirated by the {player[1].civ_name_plural]."
+TRADE_PIRATED				"{player[0].sir_cap}, our trade route from {city[0].name} to {city[1].name} has been pirated by the {player[1].civ_name_plural}."
+TRADE_PIRATE_GOLD			"{gold[0].value} gold was pirated on the trade route from {city[0].name} to {city[1].name} owned by {player[0].civ_name_plural}."
 TRADE_ROUTES_BROKEN_BY_EMBARGO		"{player[0].sir_cap}, the {player[1].civ_name_plural} have placed an embargo on all of our trade into their nations. All existing trade routes to {player[1].country_name} have been broken! We have lost all of the caravans on those routes as well."
 TRADE_ROUTES_BROKEN_BY_WAR		"Troubling news, {player[0].sir}. Due to the sparking of conflict between us and {player[1].country_name}, all of our trade routes to {player[1].civ_name_singular} cities have been broken. All caravans assigned to those routes have been lost as well."
 SENDER_KILLED_TRADE_ROUTE		"{player[0].leader_name} has cancelled the trade route carrying {good[0].name} from {city[0].name} to {city[1].name}."

--- a/ctp2_data/german/gamedata/info_str.txt
+++ b/ctp2_data/german/gamedata/info_str.txt
@@ -152,6 +152,7 @@ WAR_OVER				"Die {player[0].civ_name_plural} führen keinen Krieg mehr gegen die 
 
 ## Trade Messages ##
 TRADE_PIRATED				"{player[0].leader_name#SIR_CAP}, unser Handelsweg von {city[0].name} nach {city[1].name} wurde von den {player[1].civ_name_plural#DAT} überfallen."
+TRADE_PIRATE_GOLD			"Wir erbeuteten {gold[0].value} Gold als wir den Handelsweg von {city[0].name} nach {city[1].name} von {player[0].civ_name_plural#DAT} überfiehlen."
 TRADE_ROUTES_BROKEN_BY_EMBARGO		"{player[0].leader_name#SIR_CAP}, die {player[1].civ_name_plural} haben ein Handelsembargo gegen uns verhengt. Der Handel auf allen Handelswege {player[1].country_name#TOWARDS} wurde eingestellt! Außerdem haben wir alle Karawanen auf diesen Routen verloren."
 TRADE_ROUTES_BROKEN_BY_WAR		"Es gibt beunruhigende Neuigkeiten, {player[0].leader_name#SIR_CAP}. Wegen des zwischen uns und {player[1].country_name#DAT} entbrannten Konflikts wurde der Handel auf unseren Handelswegen, die in {player[1].civ_name_singular#UNDEF_PLURAL_ACC} Städte führen, eingestellt. Außerdem haben wir alle Karawanen, die dort unterwegs waren, verloren."
 SENDER_KILLED_TRADE_ROUTE		"{player[0].leader_name} hat den Handelsweg für den Handel mit {good[0].name#PLURAL} von {city[0].name} nach {city[1].name} eingestellt."

--- a/ctp2_data/italian/gamedata/info_str.txt
+++ b/ctp2_data/italian/gamedata/info_str.txt
@@ -152,6 +152,7 @@ WAR_OVER				"{player[0].civ_name_plural#ARTICLE_CAP} non sono più in guerra con 
 
 ## Trade Messages ##
 TRADE_PIRATED				"{player[0].sir_cap}, la nostra rotta commerciale da {city[0].name} verso {city[1].name} è stata colpita dagli atti di pirateria {player[1].civ_name_plural#PREPOSITION}."
+TRADE_PIRATE_GOLD			"{gold[0].value} gold was pirated on the trade route from {city[0].name} to {city[1].name} owned by {player[0].civ_name_plural}."
 TRADE_ROUTES_BROKEN_BY_EMBARGO		"{player[0].sir_cap}, {player[1].civ_name_plural#ARTICLE} hanno deciso l'embargo contro di noi in ogni loro nazione. Tutte le rotte esistenti verso {player[1].country_name#ARTICLE} sono state eliminate! Inoltra, abbiamo perso tutte le carovane che si trovavano su quelle vie."
 TRADE_ROUTES_BROKEN_BY_WAR		"Brutte notizie, {player[0].sir}. A causa del conflitto scoppiato fra noi e {player[1].civ_name_plural#ARTICLE}, tutte le nostre rotte commerciali verso le città {player[1].country_name#ARTICLED_PREPOSITION} sono state bloccate. Tutte le carovane presenti su quelle rotte sono andate perse."
 SENDER_KILLED_TRADE_ROUTE		"{player[0].leader_name} ha chiuso la rotta commerciale che trasportava {good[0].name} da {city[0].name} a {city[1].name}."

--- a/ctp2_data/spanish/gamedata/info_str.txt
+++ b/ctp2_data/spanish/gamedata/info_str.txt
@@ -152,6 +152,7 @@ WAR_OVER				"Los {player[0].civ_name_plural} ya no están en guerra con los {play
 
 ## Trade Messages ##
 TRADE_PIRATED				"{player[0].sir_cap}, nuestra ruta comercial de {city[0].name} a {city[1].name} ha sido pirateada por los {player[1].civ_name_plural]."
+TRADE_PIRATE_GOLD			"{gold[0].value} gold was pirated on the trade route from {city[0].name} to {city[1].name} owned by {player[0].civ_name_plural}."
 TRADE_ROUTES_BROKEN_BY_EMBARGO		"{player[0].sir_cap}, los {player[1].civ_name_plural} han impuesto un embargo sobre todas nuestras relaciones comerciales en todas sus naciones. ¡Han cortado todas nuestras rutas comerciales con {player[1].country_name}. Además hemos perdido todas las caravanas que estaban en esas rutas."
 TRADE_ROUTES_BROKEN_BY_WAR		"Malas noticias, {player[0].sir}. Debido al conflicto que ha brotado entre nosotros y {player[1].country_name}, se han cortado todas las rutas comerciales con las ciudades de {player[1].civ_name_singular}. Y además hemos perdido las caravanas que estaban en esas rutas."
 SENDER_KILLED_TRADE_ROUTE		"{player[0].leader_name} ha cancelado la ruta comercial por la que se lleva {good[0].name} de {city[0].name} a {city[1].name}."


### PR DESCRIPTION
This PR introduces a game message to tell the pirating civilization what amount of gold was pirated from with trade route. This is in relation to #49.
Pirating with ctp2 style works in the way that a unit is placed on a trade route, ordered to pirate __and then left there for the following turns__. Gold will only be assigned at the __beginning of each new turn__ if the unit __stays there__.