### PR TITLE
Make the AI not trying to sell buildings while bankrupting if it does not help

### DIFF
--- a/ctp2_code/gs/gameobj/CityData.cpp
+++ b/ctp2_code/gs/gameobj/CityData.cpp
@@ -4492,20 +4492,23 @@ sint32 CityData::SupportBuildings(bool projectedOnly)
 			sint32 const    wonderLevel =
 			    wonderutil_GetDecreaseMaintenance(g_player[m_owner]->m_builtWonders);
 
-			while (IsBankrupting() && (m_built_improvements != 0))
+			if(buildingUpkeep > 0)
 			{
-				sint32 const    cheapBuilding =
-				    buildingutil_GetCheapestBuilding(m_built_improvements, wonderLevel, m_owner);
-				Assert(cheapBuilding >= 0);
-				if (cheapBuilding < 0)
-					break;
+				while(IsBankrupting() && (m_built_improvements != 0))
+				{
+					sint32 const    cheapBuilding =
+						buildingutil_GetCheapestBuilding(m_built_improvements, wonderLevel, m_owner);
+					Assert(cheapBuilding >= 0);
+					if(cheapBuilding < 0)
+						break;
 
-				SellBuilding(cheapBuilding, false);
-				SlicObject * so = new SlicObject("029NoMaint");
-				so->AddRecipient(GetOwner());
-				so->AddCity(m_home_city);
-				so->AddBuilding(cheapBuilding);
-				g_slicEngine->Execute(so);
+					SellBuilding(cheapBuilding, false);
+					SlicObject * so = new SlicObject("029NoMaint");
+					so->AddRecipient(GetOwner());
+					so->AddCity(m_home_city);
+					so->AddBuilding(cheapBuilding);
+					g_slicEngine->Execute(so);
+				}
 			}
 
 			if(IsBankrupting())


### PR DESCRIPTION
If a city bankrupts it does not try to sell building if the maintenance of the remaining buildings is zero, such as the capitol. This actually just fixes an assert in the debug version, and give a little speed, but probably not noticeable.
..\ctp2_code\gs\gameobj\CityData.cpp