### PR TITLE
Remove unused load/save (serialize) methods from Scheduler

### DIFF
--- a/ctp2_code/ai/strategy/scheduler/Scheduler.h
+++ b/ctp2_code/ai/strategy/scheduler/Scheduler.h
@@ -115,11 +115,6 @@ public:
 
 	static void ResizeAll(const PLAYER_INDEX & newMaxPlayerId);
 
-#if 0
-	static void LoadAll(CivArchive & archive);
-	static void SaveAll(CivArchive & archive);
-#endif
-
 	static Scheduler & GetScheduler(const sint32 & playerId);
 
 	static void CleanupAll(void);

--- a/ctp2_code/ai/strategy/scheduler/scheduler.cpp
+++ b/ctp2_code/ai/strategy/scheduler/scheduler.cpp
@@ -135,27 +135,6 @@ void Scheduler::ResizeAll(const PLAYER_INDEX & newMaxPlayerId)
 	}
 }
 
-/*
-// no longer used "Reason: should be able to regenerate state from game objects."
-void Scheduler::LoadAll(CivArchive & archive)
-{
-	AI_DPRINTF(k_DBG_AI, m_playerId, -1, -1, ("\n\ncalling Scheduler::LoadAll\n\n"));
-	for(size_t i = 0; i < s_theSchedulers.size(); i++)
-	{
-		s_theSchedulers[i].Load(archive);
-	}
-}
-
-// no longer used "Reason: should be able to regenerate state from game objects."
-void Scheduler::SaveAll(CivArchive & archive)
-{
-	for(size_t i = 0; i < s_theSchedulers.size(); i++)
-	{
-		s_theSchedulers[i].Save(archive);
-	}
-}
-*/
-
 //////////////////////////////
 //
 // used mainly in ctpai to get the player's scheduler


### PR DESCRIPTION
This is leftover code from CTP1 and was used to save the state of the scheduler. However, the schdeuler is now regenerated from the game state and is therefore not be needed to be saved. Additionally, saving it would require more additions, because the code is already outcommented and incomplete, so that it would not compile anyway. Additionally, to use it again would require to change the savegame format, which should however stay as it is for backward compatibility. To sum it up it this code will never used again and therefore can go.

Additionally, it clutters the files for two files it is not a problem, but so far the code produces save games that can be loaded on Windows versions produced by Visual Studio and Linux versions produced by gcc. Both operating systems are little endian systems. On big endian systems the save game format is not compatible. It can only be made compatible by modifying the serialize methods of a round 160 classes, which would be identified by file search. And here it would help if two files less showed up in the results.
..\ctp2_code\ai\strategy\scheduler\Scheduler.h
..\ctp2_code\ai\strategy\scheduler\scheduler.cpp