### PR TITLE
music only needs either CD or OGGs (with SDL)

### DIFF
--- a/ctp2_code/sound/soundmanager.cpp
+++ b/ctp2_code/sound/soundmanager.cpp
@@ -900,7 +900,8 @@ void SoundManager::StartMusic(const sint32 &InTrackNum)
 #if !defined(USE_SDL)
 	if (!g_theProfileDB->IsUseRedbookAudio() || !c3files_HasCD()) return;
 #else
-	if (!g_theProfileDB->IsUseRedbookAudio() || !c3files_HasCD() || !m_useOggTracks) return;
+	if (!g_theProfileDB->IsUseRedbookAudio()) return;
+	if (!(c3files_HasCD() || m_useOggTracks)) return;
 #endif
 
 	if (m_noSound) return;


### PR DESCRIPTION
There is a bug in the logic for playing music, which aborts if there is no CD or no OGGs, https://github.com/civctp2/civctp2/blob/a21b96cf46d7eb1b89b2c21519f21e5a5db436dc/ctp2_code/sound/soundmanager.cpp#L903. This used to work because before https://github.com/civctp2/civctp2/commit/9446560cae32b09f31831728300334c1675c3403#diff-0039129f4311ecee53c3184b02d234d5L522 CD status was always true. However, with SDL we can have music with either CD or with OGGs (even if there is no CD), which this PR takes into account.