### PR TITLE
Update the save game converter for pull request #89

### DIFF
--- a/ctp2_code/gs/slic/SlicArray.cpp
+++ b/ctp2_code/gs/slic/SlicArray.cpp
@@ -126,9 +126,15 @@ void SlicArray::Serialize(CivArchive &archive)
 			archive.PutUINT8(static_cast<uint8>(m_structTemplate->GetType()));
 		}
 
-		if(m_type == SS_TYPE_INT) {
-			archive.Store((uint8*)m_array, m_arraySize * sizeof(SlicStackValue::m_int));
-		} else {
+		if(m_type == SS_TYPE_INT)
+		{
+			for(i = 0; i < m_arraySize; i++)
+			{
+				archive.PutSINT32(m_array[i].m_int);
+			}
+		}
+		else
+		{
 			Assert(m_type == SS_TYPE_SYM);
 			for(i = 0; i < m_arraySize; i++) {
 				haveSym = m_array[i].m_sym != NULL;

--- a/ctp2_code/gs/slic/SlicArray.cpp
+++ b/ctp2_code/gs/slic/SlicArray.cpp
@@ -127,7 +127,7 @@ void SlicArray::Serialize(CivArchive &archive)
 		}
 
 		if(m_type == SS_TYPE_INT) {
-			archive.Store((uint8*)m_array, m_arraySize * sizeof(SlicStackValue));
+			archive.Store((uint8*)m_array, m_arraySize * sizeof(SlicStackValue::m_int));
 		} else {
 			Assert(m_type == SS_TYPE_SYM);
 			for(i = 0; i < m_arraySize; i++) {
@@ -171,7 +171,6 @@ void SlicArray::Serialize(CivArchive &archive)
 
 BOOL SlicArray::Lookup(sint32 index, SS_TYPE &type, SlicStackValue &value)
 {
-
 	type = m_type;
 
 	if(index < 0 || index >= m_arraySize) {
@@ -210,7 +209,6 @@ BOOL SlicArray::Insert(sint32 untestedIndex, SS_TYPE type, SlicStackValue value)
 	switch(m_type) {
 		case SS_TYPE_VAR:
 		{
-
 			Assert(type == SS_TYPE_VAR || type == SS_TYPE_SYM);
 			if(type != SS_TYPE_VAR && type != SS_TYPE_SYM) {
 				return FALSE;


### PR DESCRIPTION
Another incompatibility was found for Windows savegames loaded on 64bit versions of CTP2, which includes the current Linux version but no Windows version, because so far all Windows versions are 32 bit. It is a problem that only occurs if the player has messages stores, and it only occurs with a subset of messages. Therefore, save games could be converted by saving them without any stored messages. But of course for more convenience here is an update for the save game converter. It loads save games in the old 64 bit format and saves them in the format generated by 32 bits.
..\ctp2_code\gs\slic\SlicArray.cpp