### PR TITLE
Allow optimizations for GCC builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The build itself is pretty classing and straight forward:
 
 ```
 ./autogen.sh
-CFLAGS="$CFLAGS -w -fuse-ld=gold" CXXFLAGS="$CXXFLAGS -fpermissive -w -fuse-ld=gold" ./configure --enable-silent-rules
+CFLAGS="$CFLAGS -w -O3 -fuse-ld=gold" CXXFLAGS="$CXXFLAGS -fpermissive -w -O3 -fuse-ld=gold" ./configure --enable-silent-rules
 make
 ```
 
@@ -40,9 +40,11 @@ If you want to build a debug version it is:
 
 ```
 ./autogen.sh
-CFLAGS="$CFLAGS -w -fno-omit-frame-pointer -fuse-ld=gold" CXXFLAGS="$CXXFLAGS -fpermissive -w -fno-omit-frame-pointer -fuse-ld=gold" ./configure --enable-silent-rules --enable-debug
+CFLAGS="$CFLAGS -w -Og -fno-omit-frame-pointer -fuse-ld=gold" CXXFLAGS="$CXXFLAGS -fpermissive -w -Og -fno-omit-frame-pointer -fuse-ld=gold" ./configure --enable-silent-rules --enable-debug
 make
 ```
+
+The option -Og optimizes bulds for debugging, this speeds up the debug function and should in general not change anything of the behavior of the executable, however it still could do so. In that case remove the -Og option.
 
 You can look at `./configure` for options, but there aren't many.
 

--- a/ctp2_code/gs/gameobj/Order.h
+++ b/ctp2_code/gs/gameobj/Order.h
@@ -64,7 +64,17 @@ public:
 		m_gameEventArgs = NULL;
 	}
 
+#if defined(__GNUC__)
+	// GCC optimizes away the NULLing in the destructor
+	// Since the Order objects comes from a pool it is
+	// effectively deleted, twice. That is the design,
+	// whether that is good or bad is another question.
+	__attribute__((optimize("-O0"))) ~Order();
+#elif defined(WIN32)
 	~Order();
+#else
+	~Order();
+#endif
 
 	void *operator new(size_t size);
 	void operator delete (void *ptr);


### PR DESCRIPTION
Right now the project readme explains how to build CTP2 under Linux without optimizations. This way, we have a bigger executable and it runs more slowly than it could. However using optimization flags for GCC makes the game crash, when save games are reloaded, that means you load a savegame when already another game has been loaded. This can actually be the same savegame. The first commit fixes this:

If CTP2 is compiled by GCC and optimization flags are used such as -Os or -Og, GCC removes the NULL assignments from the destructors. Since the memory for the Order objects comes from a pool, these parts of memory can be reused and the destructor for that is called again. That is the design, whether it is good or bad is another question. However, pointers in this design must be NULLed for proper code function. So for the Order destructor optimizations are disabled.
..\ctp2_code\gs\gameobj\Order.h

In a second commit, I would like to update the readme, to include the optimize options in the build instructions. I just don't know whether it should go into CFLAGS or CXXFLAGS or both.