### PR TITLE
Fix memory leaks

### DIFF
--- a/ctp2_code/gs/gameobj/CityData.cpp
+++ b/ctp2_code/gs/gameobj/CityData.cpp
@@ -1316,6 +1316,7 @@ CityData::CityData(CivArchive &archive)
 }
 
 CityData::CityData(CityData *copy)
+: m_name(NULL)
 {
 	m_distanceToGood = new sint32[g_theResourceDB->NumRecords()];
 	m_happy = new Happy;
@@ -1485,9 +1486,7 @@ void CityData::Copy(CityData *copy)
 
 	m_happy->Copy(copy->m_happy);
 
-	size_t len = (strlen(copy->m_name) + 1) * sizeof(MBCHAR);
-	m_name = new MBCHAR[len];
-	memcpy(m_name, copy->m_name, len);
+	SetNameLocal(copy->m_name);
 	memcpy(m_distanceToGood, copy->m_distanceToGood, sizeof(sint32) * g_theResourceDB->NumRecords());
 	m_defensiveBonus = copy->m_defensiveBonus;
 

--- a/ctp2_code/ui/aui_ctp2/radarmap.cpp
+++ b/ctp2_code/ui/aui_ctp2/radarmap.cpp
@@ -137,6 +137,7 @@ RadarMap::RadarMap(AUI_ERRCODE *retval,
 //---------------------------------------------------------------------------
 RadarMap::~RadarMap()
 {
+	delete[] m_mapOverlay;
 	delete m_mapSurface;
 	delete m_tempSurface;
 	if (m_tempBuffer)


### PR DESCRIPTION
I found some leaks, the one in CityData was introduced by redesigning the CityData class. And the one of RadarMap only showed up after opening the Gaia Controller screen.
..\ctp2_code\gs\gameobj\CityData.cpp
..\ctp2_code\ui\aui_ctp2\radarmap.cpp