### PR TITLE
output error/debug messages to stderr, which is unbuffered (in contrast to stdout)

### DIFF
--- a/ctp2_code/ctp/civ3_main.cpp
+++ b/ctp2_code/ctp/civ3_main.cpp
@@ -1696,7 +1696,7 @@ int WINAPI CivMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PSTR szCmdLine,
 	for (gDone = FALSE; !gDone; )
 	{
 		g_civApp->Process();
-                //printf("%s L%d: g_civApp->Process() done!\n", __FILE__, __LINE__);
+                //fprintf(stderr, "%s L%d: g_civApp->Process() done!\n", __FILE__, __LINE__);
 
 #ifdef __AUI_USE_SDL__
 		SDL_Event event;
@@ -1706,7 +1706,7 @@ int WINAPI CivMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PSTR szCmdLine,
                             ~(SDL_EVENTMASK(SDL_MOUSEMOTION) | SDL_EVENTMASK(SDL_MOUSEBUTTONDOWN) | SDL_EVENTMASK(SDL_MOUSEBUTTONUP)));
 			if (0 > n) {
                             //fprintf(stderr, "[CivMain] PeepEvents failed: %s\n", SDL_GetError());
-                            printf("%s L%d: SDL_PeepEvents: Still events stored! Error?: %s\n", __FILE__, __LINE__, SDL_GetError());
+                            fprintf(stderr, "%s L%d: SDL_PeepEvents: Still events stored! Error?: %s\n", __FILE__, __LINE__, SDL_GetError());
 
 				break;
 			}

--- a/ctp2_code/gfx/spritesys/spritefile.cpp
+++ b/ctp2_code/gfx/spritesys/spritefile.cpp
@@ -1355,7 +1355,7 @@ SPRITEFILEERR SpriteFile::Open(SPRITEFILETYPE *type)
 	{
 		// c3errors_ErrorDialog(m_filename, "SpriteFile: BAD FILE.  Looking for valid SPR.");
 		// return SPRITEFILEERR_BADTAG;
-		printf("%s L%d: %s SpriteFile: k_SPRITEFILE_TAG wrong!\n", __FILE__, __LINE__, m_filename);
+		fprintf(stderr, "%s L%d: %s SpriteFile: k_SPRITEFILE_TAG wrong!\n", __FILE__, __LINE__, m_filename);
 	}
 
 	err = ReadData((void *)&data, sizeof(data));

--- a/ctp2_code/gfx/spritesys/spriteutils.cpp
+++ b/ctp2_code/gfx/spritesys/spriteutils.cpp
@@ -269,7 +269,7 @@ char spriteutils_EncodeScanline(Pixel32 *scanline, sint32 width, Pixel16 **outBu
 			{
 
 				printf("\nError in bitmap data.  Pixel with no associated alpha.\n");
-			        printf("%s L%d: pix32: %08X pix16: %04X alpha: %02X \n", __FILE__, __LINE__, pix32, pix16, alpha);
+			        fprintf(stderr, "%s L%d: pix32: %08X pix16: %04X alpha: %02X \n", __FILE__, __LINE__, pix32, pix16, alpha);
 				printf("\nMake sure to assign black to fully transparent pixels!\n");
 				printf("\nUse e.g. ImageMagick: mogrify -background black -alpha Background -type TrueColorMatte *.TIF\n");
 
@@ -331,7 +331,7 @@ char spriteutils_EncodeScanlineWshadow(Pixel32 *scanline, sint32 width, Pixel16 
 				spriteutils_EncodeCopyRun(&scanPtr, &pos, width, outBufPtr);
 			else {
 				printf("\nError in bitmap data.  Pixel with no associated alpha.\n");
-			        printf("%s L%d: pix32: %08X pix16: %04X alpha: %02X \n", __FILE__, __LINE__, pix32, pix16, alpha);
+			        fprintf(stderr, "%s L%d: pix32: %08X pix16: %04X alpha: %02X \n", __FILE__, __LINE__, pix32, pix16, alpha);
 				printf("\nMake sure to assign black to fully transparent pixels!\n");
 				printf("\nUse e.g. ImageMagick: mogrify -background black -alpha Background -type TrueColorMatte *.TIF\n");
 				exit(-1);

--- a/ctp2_code/os/nowin32/nowin32.cpp
+++ b/ctp2_code/os/nowin32/nowin32.cpp
@@ -110,7 +110,7 @@ void _splitpath( const char *path,
     else
       strcpy(ext, dot + 1); // expecting pre-allocted array by caller
 }
-  // printf("%s L%d: %s %s %s %s!\n", __FILE__, __LINE__, drive, dir, fname, ext);
+  // fprintf(stderr, "%s L%d: %s %s %s %s!\n", __FILE__, __LINE__, drive, dir, fname, ext);
 }
 
 uint32 GetTickCount()

--- a/ctp2_code/ui/aui_common/aui_image.cpp
+++ b/ctp2_code/ui/aui_common/aui_image.cpp
@@ -310,19 +310,19 @@ AUI_ERRCODE aui_BmpImageFormat::Load(MBCHAR const * filename, aui_Image *image )
 
 	return retcode;
 #elif defined(__AUI_USE_SDL__)
-        printf("%s L%d: image %s!\n", __FILE__, __LINE__, filename); //is this ever called?
+        fprintf(stderr, "%s L%d: image %s!\n", __FILE__, __LINE__, filename); //is this ever called?
 	assert(0);
 	SDL_Surface *bmp = SDL_LoadBMP(filename);
 	SDL_Surface *surf = NULL;
 	SDL_PixelFormat fmt = { 0 };
 
-        printf("%s L%d: image %s!\n", __FILE__, __LINE__, filename);
+        fprintf(stderr, "%s L%d: image %s!\n", __FILE__, __LINE__, filename);
         if (g_ui->Primary()->BitsPerPixel() != 16)
-            printf("%s L%d: bpp %d", __FILE__, __LINE__,  g_ui->Primary()->BitsPerPixel());
+            fprintf(stderr, "%s L%d: bpp %d", __FILE__, __LINE__,  g_ui->Primary()->BitsPerPixel());
         if (bmp->format->Gmask >> bmp->format->Gshift == 0x3F)
-            printf("%s L%d: 565 image!\n", __FILE__, __LINE__);
+            fprintf(stderr, "%s L%d: 565 image!\n", __FILE__, __LINE__);
         if (bmp->format->Gmask >> bmp->format->Gshift == 0x1F)
-            printf("%s L%d: 555 image!\n", __FILE__, __LINE__);
+            fprintf(stderr, "%s L%d: 555 image!\n", __FILE__, __LINE__);
 	if (NULL == surf) {
 		surf = SDL_DisplayFormat(bmp);
 	}

--- a/ctp2_code/ui/aui_common/aui_movie.cpp
+++ b/ctp2_code/ui/aui_common/aui_movie.cpp
@@ -246,14 +246,14 @@ void reload_audio(int channel)
 
 			m_moviechannel= Mix_PlayChannel(channel, &achunk , 0);
 			if(m_moviechannel < 0)
-				printf("%s L%d: Error initializing SDL_mixer: %s\n", __FILE__, __LINE__, Mix_GetError());
+				fprintf(stderr, "%s L%d: Error initializing SDL_mixer: %s\n", __FILE__, __LINE__, Mix_GetError());
 			//else
 			//    Mix_ChannelFinished(reload_audio);
 			SDL_ffmpegReleaseAudio(film, aframe, achunk.alen);
 		}
 	}
 	else
-		printf("%s L%d: Not a movie audio channel!\n", __FILE__, __LINE__);
+		fprintf(stderr, "%s L%d: Not a movie audio channel!\n", __FILE__, __LINE__);
 
 	return;
 }
@@ -437,7 +437,7 @@ AUI_ERRCODE aui_Movie::Open(
 			int w, h;
 			// we get the size from our active video stream
 			if(SDL_ffmpegGetVideoSize(film, &w, &h))
-				printf("%s L%d: Could not determin movie size!\n", __FILE__, __LINE__);
+				fprintf(stderr, "%s L%d: Could not determin movie size!\n", __FILE__, __LINE__);
 			else
 			{
 				m_rect.right = m_rect.left + w;
@@ -446,7 +446,7 @@ AUI_ERRCODE aui_Movie::Open(
 		}
 		else
 		{
-			printf("%s L%d: Could not open %s!\n", __FILE__, __LINE__, m_filename);
+			fprintf(stderr, "%s L%d: Could not open %s!\n", __FILE__, __LINE__, m_filename);
 		}
 #endif
 		m_isOpen = TRUE; //even if open failed, loops otherwise
@@ -524,8 +524,8 @@ AUI_ERRCODE aui_Movie::Play( void )
 		snprintf(cmd, sizeof(cmd), "mplayer -vo xv -wid 0x%lx /media/cdrom/Setup/data/Max/ctp2_data/default/videos/%s", info.info.x11.window, m_filename);
 		else
 		snprintf(cmd, sizeof(cmd), "mplayer -vo sdl /media/cdrom/Setup/data/Max/ctp2_data/default/videos/%s", m_filename);
-		printf("%s L%d: Trying to execute: %s!\n", __FILE__, __LINE__, cmd);
-		printf("%s L%d: The path to the movies is hard coded! Solve it! ;)\n", __FILE__, __LINE__);
+		fprintf(stderr, "%s L%d: Trying to execute: %s!\n", __FILE__, __LINE__, cmd);
+		fprintf(stderr, "%s L%d: The path to the movies is hard coded! Solve it! ;)\n", __FILE__, __LINE__);
 		g_soundManager->ReleaseSoundDriver();
 		system(cmd);
 		g_soundManager->ReacquireSoundDriver();//no function with SDL, see soundmanager.cpp
@@ -538,7 +538,7 @@ AUI_ERRCODE aui_Movie::Play( void )
 			Mix_HookMusic(audioCallback, film);
 
 		//	if(Mix_OpenAudio(48000, AUDIO_S16SYS, 2, 512)==-1)
-		//		printf("%s L%d: Mix_OpenAudio: %s\n", __FILE__, __LINE__, Mix_GetError());
+		//		fprintf(stderr, "%s L%d: Mix_OpenAudio: %s\n", __FILE__, __LINE__, Mix_GetError());
 
 			SDL_ffmpegStartDecoding(film); //returns always 0!
 			//SDL_ffmpegPause(film, 0);//unpause film sdl_ffmpeg <= 0.7.1
@@ -561,7 +561,7 @@ AUI_ERRCODE aui_Movie::Play( void )
 			Mix_VolumeChunk(&achunk, MIX_MAX_VOLUME);
 			m_moviechannel= Mix_PlayChannel(-1, &achunk , 0);
 			if(m_moviechannel < 0)
-				printf("%s L%d: Error initializing SDL_mixer: %s\n", __FILE__, __LINE__, Mix_GetError());
+				fprintf(stderr, "%s L%d: Error initializing SDL_mixer: %s\n", __FILE__, __LINE__, Mix_GetError());
 			else
 				Mix_ChannelFinished(reload_audio);
 			SDL_ffmpegReleaseAudio(film, aframe, achunk.alen);
@@ -637,7 +637,7 @@ AUI_ERRCODE aui_Movie::PlayOnScreenMovie( void )
 	SetWindowLong( g_ui->TheHWND(), GWL_WNDPROC, (LONG)m_windowProc );
 	m_windowProc = NULL;
 #else
-	printf("%s L%d: SDL mouse code is missing here!\n", __FILE__, __LINE__);
+	fprintf(stderr, "%s L%d: SDL mouse code is missing here!\n", __FILE__, __LINE__);
 	//m_onScreenMovie = this;
 
 	while(!m_isFinished && m_isPlaying)
@@ -664,7 +664,7 @@ AUI_ERRCODE aui_Movie::Stop( void )
 		Assert(err == 0);
 		if(err) return AUI_ERRCODE_HACK;
 #elif defined(USE_SDL_FFMPEG)
-		printf("%s L%d: Stopping movie!\n", __FILE__, __LINE__);
+		fprintf(stderr, "%s L%d: Stopping movie!\n", __FILE__, __LINE__);
 		if(film)
 		{
 			//SDL_ffmpegPause(film, 1);//pause film film sdl_ffmpeg <= 0.7.1
@@ -838,7 +838,7 @@ AUI_ERRCODE aui_Movie::Process( void )
 
 				if(frame)
 				{
-					//printf("%s L%d: Got frame!\n", __FILE__, __LINE__);
+					//fprintf(stderr, "%s L%d: Got frame!\n", __FILE__, __LINE__);
 
 					// we got a frame, so we better show this one
 					SDL_BlitSurface(frame->buffer, 0, sdl_surf->DDS(), &sdl_rect);
@@ -857,7 +857,7 @@ AUI_ERRCODE aui_Movie::Process( void )
 
 			if(m_isFinished)
 			{
-				//printf("%s L%d: Done displaying movie!\n", __FILE__, __LINE__);
+				//fprintf(stderr, "%s L%d: Done displaying movie!\n", __FILE__, __LINE__);
 				m_isPlaying = FALSE;
 			}
 	}

--- a/ctp2_code/ui/aui_common/aui_textfield.cpp
+++ b/ctp2_code/ui/aui_common/aui_textfield.cpp
@@ -369,7 +369,7 @@ sint32 aui_TextField::SetMaxFieldLen( sint32 maxFieldLen )
 	delete[] m_Text;
 	m_Text = newText;
 #else
-	printf("%s L%d: SetMaxFieldLen doing nothing here!\n", __FILE__, __LINE__);
+	fprintf(stderr, "%s L%d: SetMaxFieldLen doing nothing here!\n", __FILE__, __LINE__);
 #endif
 #endif
 
@@ -716,7 +716,7 @@ bool aui_TextField::HandleKey(uint32 wParam)
 				break;
 			// No tags allowed, they are for "tabbing focus" between controls.
 			case VK_TAB:
-				printf("%s L%d: Tab ignored in TextField!\n", __FILE__, __LINE__);
+				fprintf(stderr, "%s L%d: Tab ignored in TextField!\n", __FILE__, __LINE__);
 				return false;
 			case VK_BACK:
 			{
@@ -727,7 +727,7 @@ bool aui_TextField::HandleKey(uint32 wParam)
 					break;
 			}
 			case ' ':
-			// printf("%s L%d: space!\n", __FILE__, __LINE__);
+			// fprintf(stderr, "%s L%d: space!\n", __FILE__, __LINE__);
 			default:
 			{ // append char to char array, apparently easiest with std::string
 

--- a/ctp2_code/ui/aui_ctp2/c3blitter.cpp
+++ b/ctp2_code/ui/aui_ctp2/c3blitter.cpp
@@ -375,7 +375,7 @@ AUI_ERRCODE C3Blitter::Blt16To16FastMMX(
 					}
 #else // _MSCVER
 //					assert(0);
-                    //printf("%s L%d: Using Blt16To16FastMMX!\n", __FILE__, __LINE__);
+                    //fprintf(stderr, "%s L%d: Using Blt16To16FastMMX!\n", __FILE__, __LINE__);
                     __asm__ (
                         //"movl $scanWidth, %eax       \n\t"
                         //"movl $srcBuf, %esi          \n\t"
@@ -659,7 +659,7 @@ bool C3Blitter::CheckMMXTechnology(void)
             );
         }
     catch(...) {
-        printf("%s L%d: MMX-Test FAILED!\n", __FILE__, __LINE__);
+        fprintf(stderr, "%s L%d: MMX-Test FAILED!\n", __FILE__, __LINE__);
         retval = false;
         }
 
@@ -670,12 +670,12 @@ bool C3Blitter::CheckMMXTechnology(void)
     {
     try { __asm__ (" emms            \n\t"); }
     catch(...) {
-        printf("%s L%d: MMX-Test FAILED!\n", __FILE__, __LINE__);
+        fprintf(stderr, "%s L%d: MMX-Test FAILED!\n", __FILE__, __LINE__);
         retval = false;
         }
     }
 
-    printf("%s L%d: MMX-Test succeded!\n", __FILE__, __LINE__);
+    fprintf(stderr, "%s L%d: MMX-Test succeded!\n", __FILE__, __LINE__);
 #endif // _MSC_VER
 
     return retval;

--- a/ctp2_code/ui/aui_sdl/aui_sdlblitter.cpp
+++ b/ctp2_code/ui/aui_sdl/aui_sdlblitter.cpp
@@ -49,8 +49,8 @@ AUI_ERRCODE aui_SDLBlitter::Blt16To16(
             //ChromaKey and SDL_SRCCOLORKEY  should be set with aui_SDLSurface::SetChromaKey on
             //the SDL-surface already but if SDL_SRCCOLORKEY is missing we set it here:
             if (SDL_SetColorKey(sdlSrc->DDS(), SDL_SRCCOLORKEY, sdlSrc->GetChromaKey())) //sdlSrc->DDS()->format->colorkey))
-                printf("%s L%d: SDL_SRCCOLORKEY setting failed! key %#X\n", __FILE__, __LINE__, sdlSrc->DDS()->format->colorkey);
-            //else printf("%s L%d: SDL_SRCCOLORKEY setting succeded!\n", __FILE__, __LINE__);
+                fprintf(stderr, "%s L%d: SDL_SRCCOLORKEY setting failed! key %#X\n", __FILE__, __LINE__, sdlSrc->DDS()->format->colorkey);
+            //else fprintf(stderr, "%s L%d: SDL_SRCCOLORKEY setting succeded!\n", __FILE__, __LINE__);
             }
 */  //there seems no need for all this
         if (SDL_BlitSurface(sdlSrc->DDS(), &ssrc, sdlDest->DDS(), &sdst) < 0) {
@@ -277,23 +277,23 @@ AUI_ERRCODE aui_SDLBlitter::StretchBlt16To16(
 
         if (ssrc.w == sdst.w) {
             if (ssrc.h == sdst.h) {
-                //printf("%s L%d: Using normal blit!\n", __FILE__, __LINE__);
+                //fprintf(stderr, "%s L%d: Using normal blit!\n", __FILE__, __LINE__);
                 if (SDL_BlitSurface(sdlSrc->DDS(), &ssrc, sdlDest->DDS(), &sdst) < 0) {
                     fprintf(stderr, "StrechBlt failed: %s\n", SDL_GetError());
                     retcode = AUI_ERRCODE_BLTFAILED;
                     }
                 }
             else {
-                //printf("%s L%d: Using V blit!\n", __FILE__, __LINE__);
+                //fprintf(stderr, "%s L%d: Using V blit!\n", __FILE__, __LINE__);
                 retcode = SimpleVStretch(sdlSrc->DDS(), &ssrc, sdlDest->DDS(), &sdst);
                 }
             }
         else if (ssrc.h == sdst.h) {
-            //printf("%s L%d: Using H blit!\n", __FILE__, __LINE__);
+            //fprintf(stderr, "%s L%d: Using H blit!\n", __FILE__, __LINE__);
             retcode = SimpleHStretch(sdlSrc->DDS(), &ssrc, sdlDest->DDS(), &sdst);
             }
         else {
-            //printf("%s L%d: Using HV blit!\n", __FILE__, __LINE__);
+            //fprintf(stderr, "%s L%d: Using HV blit!\n", __FILE__, __LINE__);
             retcode = SimpleHVStretch(sdlSrc->DDS(), &ssrc, sdlDest->DDS(), &sdst);
             }
 

--- a/ctp2_code/ui/aui_sdl/aui_sdlmouse.cpp
+++ b/ctp2_code/ui/aui_sdl/aui_sdlmouse.cpp
@@ -50,7 +50,7 @@ void HandleMouseWheel(sint16 delta)
 		}
 	}
 	else
-		printf("%s L%d: Mouse wheel for SDL not handled!\n", __FILE__, __LINE__);
+		fprintf(stderr, "%s L%d: Mouse wheel for SDL not handled!\n", __FILE__, __LINE__);
 }
 
 AUI_ERRCODE

--- a/ctp2_code/ui/aui_sdl/aui_sdlsurface.cpp
+++ b/ctp2_code/ui/aui_sdl/aui_sdlsurface.cpp
@@ -61,11 +61,11 @@ aui_SDLSurface::aui_SDLSurface(
         //but save is save...
 	if ((fmt->Rmask >> fmt->Rshift == 0x1F) && (fmt->Gmask >> fmt->Gshift == 0x3F) && (fmt->Bmask >> fmt->Bshift == 0x1F)) {
             m_pixelFormat = AUI_SURFACE_PIXELFORMAT_565;
-            //printf("%s L%d: AUI_SURFACE_PIXELFORMAT_565\n", __FILE__, __LINE__);
+            //fprintf(stderr, "%s L%d: AUI_SURFACE_PIXELFORMAT_565\n", __FILE__, __LINE__);
             }
         if ((fmt->Rmask >> fmt->Rshift == 0x1F) && (fmt->Gmask >> fmt->Gshift == 0x1F) && (fmt->Bmask >> fmt->Bshift == 0x1F)) {
             m_pixelFormat = AUI_SURFACE_PIXELFORMAT_555;
-            //printf("%s L%d: AUI_SURFACE_PIXELFORMAT_555\n", __FILE__, __LINE__);
+            //fprintf(stderr, "%s L%d: AUI_SURFACE_PIXELFORMAT_555\n", __FILE__, __LINE__);
             }
 
 	m_pitch = m_lpdds->pitch;
@@ -98,13 +98,13 @@ aui_SDLSurface::~aui_SDLSurface()
 uint32 aui_SDLSurface::SetChromaKey( uint32 color ) {
     int hr = SDL_SetColorKey(m_lpdds, SDL_SRCCOLORKEY, /*SDL_MapRGB(m_lpdds->format, color>>16, (color>>8)&0xff, color&0xff)*/color); //|SDL_RLEACCEL ?
     //hr == 0 if succeded!
-    //printf("%s L%d: SDL_SRCCOLORKEY set to %#X\n", __FILE__, __LINE__, color);
+    //fprintf(stderr, "%s L%d: SDL_SRCCOLORKEY set to %#X\n", __FILE__, __LINE__, color);
 
     if ( hr == 0 )
         return aui_Surface::SetChromaKey( color ); //sets aui_Surface.m_chromaKey and returns last value!
 
     //return AUI_ERRCODE_OK;  //this is not sensible, should retrun last color key!?!
-    //printf("%s L%d: SDL_SRCCOLORKEY setting failed!\n", __FILE__, __LINE__);
+    //fprintf(stderr, "%s L%d: SDL_SRCCOLORKEY setting failed!\n", __FILE__, __LINE__);
     return (uint32)-1; //better?
     }
 
@@ -123,9 +123,9 @@ AUI_ERRCODE aui_SDLSurface::Lock( RECT *rect, LPVOID *buffer, DWORD flags ){
 
     // must lock the mutex first!
     SDL_LockMutex(m_bltMutex);
-    //printf("%s L%d: Locking mutex!\n", __FILE__, __LINE__);
+    //fprintf(stderr, "%s L%d: Locking mutex!\n", __FILE__, __LINE__);
     if (SDL_MUSTLOCK(m_lpdds)) {
-//        printf("%s L%d: Locking surface! Check this!\n", __FILE__, __LINE__);
+//        fprintf(stderr, "%s L%d: Locking surface! Check this!\n", __FILE__, __LINE__);
         if (SDL_LockSurface(m_lpdds) < 0) {
             fprintf(stderr, "Cannot lock surface: %s\n", SDL_GetError());
             return AUI_ERRCODE_SURFACELOCKFAILED;

--- a/ctp2_code/ui/interface/spriteeditor.cpp
+++ b/ctp2_code/ui/interface/spriteeditor.cpp
@@ -523,7 +523,7 @@ void SpriteEditWindow::LoadSprite(char *name)
 	if(strstr(tbuffer, ".SPR")) // Obviously, this is crap on Windows, but for now it compiles, and is not a feature of the release version.
 #endif
 	{
-		printf("%s L%d: name= %s!\n", __FILE__, __LINE__, tbuffer);
+		fprintf(stderr, "%s L%d: name= %s!\n", __FILE__, __LINE__, tbuffer);
 		if (!FileExists(tbuffer))
 			return;
 
@@ -538,15 +538,15 @@ void SpriteEditWindow::LoadSprite(char *name)
 		if (!FileExists(tbuffer))
 			return;
 
-		printf("%s L%d: name= %s!\n", __FILE__, __LINE__, strupr(tbuffer));
+		fprintf(stderr, "%s L%d: name= %s!\n", __FILE__, __LINE__, strupr(tbuffer));
 		sint16 id = -1;
 		sscanf(strupr(tbuffer), "GG%d.TXT", &id);
-		printf("%s L%d: id= %d!\n", __FILE__, __LINE__, id);
+		fprintf(stderr, "%s L%d: id= %d!\n", __FILE__, __LINE__, id);
 		m_currentSprite->Parse(id, GROUPTYPE_GROUP); // GROUPTYPE is not used
 	}
 	else
 	{
-		printf("%s L%d: name= %s!\n", __FILE__, __LINE__, tbuffer);
+		fprintf(stderr, "%s L%d: name= %s!\n", __FILE__, __LINE__, tbuffer);
 		return;
 	}
 
@@ -622,7 +622,7 @@ void SpriteEditWindow::SaveSprite(char *name)
 	if(strstr(tbuffer, ".SPR"))
 #endif
 	{
-		printf("%s L%d: name= %s!\n", __FILE__, __LINE__, tbuffer); // Actually debug printing, should be go through the system
+		fprintf(stderr, "%s L%d: name= %s!\n", __FILE__, __LINE__, tbuffer); // Actually debug printing, should be go through the system
 		m_currentSprite->Save(name,k_SPRITEFILE_VERSION2,SPRDATA_LZW1);
 	}
 #if defined(LINUX)
@@ -631,7 +631,7 @@ void SpriteEditWindow::SaveSprite(char *name)
 	else if(strstr(tbuffer, ".TXT"))
 #endif
 	{
-		printf("%s L%d: name= %s!\n", __FILE__, __LINE__, tbuffer); // Actually debug printing, should be go through the system
+		fprintf(stderr, "%s L%d: name= %s!\n", __FILE__, __LINE__, tbuffer); // Actually debug printing, should be go through the system
 		m_currentSprite->ExportScript(name);
 	}
 }


### PR DESCRIPTION
The (false) assumption in #79 that language specifics are the problem that the `play-game_build-city` test failed was due to debug messages were sent to stdout, which is buffered. This PR changes these stdout to stderr (which is not buffered) to avoid such confusion in future.