### PR TITLE
Make Lawyers and Corporate Branches expellable

### DIFF
--- a/ctp2_data/default/gamedata/Units.txt
+++ b/ctp2_data/default/gamedata/Units.txt
@@ -970,6 +970,7 @@ UNIT_CORPORATE_BRANCH {
    IgnoreZOC
    NoZoc
    CanBeSued
+   CanBeExpelled
    CantCaptureCity
    DeathEffectsHappy
    Advertise
@@ -2342,6 +2343,7 @@ UNIT_LAWYER {
    NoZoc
    CanSue
    CanBeSued
+   CanBeExpelled
    CantCaptureCity
    DeathEffectsHappy
    IsSpecialForces


### PR DESCRIPTION
Lawyers and Corporate Branches are special units and civilians and should be expellable as every other civilian and special unit. I just do not know whether it is intended that those cannot be expelled. For sure these units can be sued.
..\ctp2_data\default\gamedata\Units.txt