### PR TITLE
using `-O3` for compiling ctp2 in GL-CI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -67,8 +67,8 @@ RUN cd /ctp2 \
     && CPPFLAGS="-I/usr/local/include/SDL/" \
     CC=/usr/bin/gcc-5 \
     CXX=/usr/bin/g++-5 \
-    CFLAGS="$CFLAGS -w -fuse-ld=gold" \
-    CXXFLAGS="$CXXFLAGS -fpermissive -w -fuse-ld=gold" \
+    CFLAGS="$CFLAGS -w -O3 -fuse-ld=gold" \
+    CXXFLAGS="$CXXFLAGS -fpermissive -w -O3 -fuse-ld=gold" \
     LDFLAGS="$LDFLAGS -L/usr/local/lib" \
     ./configure --prefix=/opt/ctp2 --bindir=/opt/ctp2/ctp2_program/ctp --enable-silent-rules \
     && make -j"$(nproc)" \


### PR DESCRIPTION
In regard to https://github.com/civctp2/civctp2/pull/95#issuecomment-467116205, this PR offers compilation with `-O3` for GL-CI. While the compilation takes a bit longer, the test seem to run a bit quicker, however the overall time consumtion is quite similar.
This PR is more interesting for testing if the game actually still functions when compiled with `-O3`, i.e. to catch cases like #95.