### PR TITLE
sprite building not part of GL-CI config for civctp2

### DIFF
--- a/GL-CI.md
+++ b/GL-CI.md
@@ -28,7 +28,3 @@ Sprite loading:
 Sprite animation looping:
 
 ![image only visible on GitLab](/../-/jobs/artifacts/master/raw/loop-sprite.png?job=loop-sprite)
-
-Automated creation of animated sprites:
-
-![image only visible on GitLab](/../-/jobs/artifacts/master/raw/create-sprite.png?job=buildSprites)


### PR DESCRIPTION
Minor change that was missed in #84, sprite building offered in #108.