### PR TITLE
WIP: updating to SDL_ffmpeg that works with modern ffmpeg

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -71,7 +71,7 @@ COPY ctp2_data/  /ctp2/ctp2_data/
 
 RUN cd /ctp2 \
     && ./autogen.sh \
-    && CPPFLAGS="-I/usr/local/include/SDL/" \
+    && CPPFLAGS="-I/usr/include/SDL/ -I/usr/local/include/SDL/" \
     CC=/usr/bin/gcc-5 \
     CXX=/usr/bin/g++-5 \
     CFLAGS="$CFLAGS -w -fuse-ld=gold" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,8 @@ RUN git clone --depth 1 -b v0.6.1 http://github.com/FFmpeg/FFmpeg/ && \
     cd FFmpeg && \
     ./configure \
     	--prefix=/usr/local/ \
+	--enable-shared \
+	--disable-static \
 	--disable-doc \
 	--disable-avdevice \
 	--disable-ffprobe \
@@ -50,8 +52,9 @@ RUN git clone -b v1.3.2 http://github.com/lynxabraxas/SDL_ffmpeg && \
     mkdir SDL_ffmpeg_build && \
     cd SDL_ffmpeg_build && \
     cmake \
-    	  -DCMAKE_INSTALL_PREFIX=/usr/ \
+    	  -DCMAKE_INSTALL_PREFIX=/usr/local/ \
 	  -DCMAKE_BUILD_TYPE=Release \
+	  -DCMAKE_VERBOSE_MAKEFILEL=ON \
 	  ../SDL_ffmpeg && \
     make && \
     make install

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN useradd -m $USERNAME && \
 FROM system as builder
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    yasm libsdl1.2-dev libsdl-mixer1.2-dev libsdl-image1.2-dev byacc libgtk2.0-dev gcc-5 g++-5 \
+    libsdl1.2-dev libsdl-mixer1.2-dev libsdl-image1.2-dev libavformat-dev libswscale-dev byacc libgtk2.0-dev gcc-5 g++-5 \
     automake libtool unzip flex git ca-certificates cmake
 
 ### set default compilers
@@ -28,24 +28,6 @@ RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-5 100 && \
     cc --version && \
     c++ --version && \
     cpp --version
-
-### build ffmpeg
-RUN git clone --depth 1 -b n3.3.6 http://github.com/FFmpeg/FFmpeg/ && \
-    cd FFmpeg && \
-    ./configure \
-    	--prefix=/usr/local/ \
-	--enable-shared \
-	--disable-static \
-	--disable-doc \
-	--disable-avdevice \
-	--disable-ffprobe \
-	--disable-ffmpeg \
-	--disable-ffplay \
-	--disable-ffserver && \
-    make -j"$(nproc)" && \
-    make install
-
-### ffmpeg built
 
 ### build SDL_ffmpeg
 RUN git clone -b FFmpeg-2018 http://github.com/lynxabraxas/SDL_ffmpeg && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN useradd -m $USERNAME && \
 FROM system as builder
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    libsdl1.2-dev libsdl-mixer1.2-dev libsdl-image1.2-dev byacc libgtk2.0-dev gcc-5 g++-5 \
+    yasm libsdl1.2-dev libsdl-mixer1.2-dev libsdl-image1.2-dev byacc libgtk2.0-dev gcc-5 g++-5 \
     automake libtool unzip flex git ca-certificates cmake
 
 ### set default compilers
@@ -30,7 +30,7 @@ RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-5 100 && \
     cpp --version
 
 ### build ffmpeg
-RUN git clone --depth 1 -b v0.6.1 http://github.com/FFmpeg/FFmpeg/ && \
+RUN git clone --depth 1 -b n3.3.6 http://github.com/FFmpeg/FFmpeg/ && \
     cd FFmpeg && \
     ./configure \
     	--prefix=/usr/local/ \
@@ -48,7 +48,7 @@ RUN git clone --depth 1 -b v0.6.1 http://github.com/FFmpeg/FFmpeg/ && \
 ### ffmpeg built
 
 ### build SDL_ffmpeg
-RUN git clone -b v1.3.2 http://github.com/lynxabraxas/SDL_ffmpeg && \
+RUN git clone -b FFmpeg-2018 http://github.com/lynxabraxas/SDL_ffmpeg && \
     mkdir SDL_ffmpeg_build && \
     cd SDL_ffmpeg_build && \
     cmake \

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ FROM system as builder
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     libsdl1.2-dev libsdl-mixer1.2-dev libsdl-image1.2-dev byacc libgtk2.0-dev gcc-5 g++-5 \
-    automake libtool unzip flex git ca-certificates
+    automake libtool unzip flex git ca-certificates cmake
 
 ### set default compilers
 RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-5 100 && \
@@ -30,10 +30,13 @@ RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-5 100 && \
     cpp --version
 
 ### build ffmpeg
-RUN git clone --depth 1 -b v0.5.2 http://github.com/FFmpeg/FFmpeg/ && \
+RUN git clone --depth 1 -b v0.6.1 http://github.com/FFmpeg/FFmpeg/ && \
     cd FFmpeg && \
     ./configure \
     	--prefix=/usr/local/ \
+	--disable-doc \
+	--disable-avdevice \
+	--disable-ffprobe \
 	--disable-ffmpeg \
 	--disable-ffplay \
 	--disable-ffserver && \
@@ -43,12 +46,13 @@ RUN git clone --depth 1 -b v0.5.2 http://github.com/FFmpeg/FFmpeg/ && \
 ### ffmpeg built
 
 ### build SDL_ffmpeg
-RUN git clone -b v0.9.0 http://github.com/lynxabraxas/SDL_ffmpeg && \
-    cd /SDL_ffmpeg/trunk/ && \
-    sed -i 's/CFLAGS=-I$INCDIR/CFLAGS="$CFLAGS -I$INCDIR"/' configure  && \
-    sed -i 's/LDFLAGS=-L$LIBDIR/LDFLAGS="$LDFLAGS -L$LIBDIR"/' configure  && \
-    LDFLAGS="-lm" \
-    ./configure --prefix=/usr/local/ --static=yes && \
+RUN git clone -b v1.3.2 http://github.com/lynxabraxas/SDL_ffmpeg && \
+    mkdir SDL_ffmpeg_build && \
+    cd SDL_ffmpeg_build && \
+    cmake \
+    	  -DCMAKE_INSTALL_PREFIX=/usr/ \
+	  -DCMAKE_BUILD_TYPE=Release \
+	  ../SDL_ffmpeg && \
     make && \
     make install
 


### PR DESCRIPTION
Regarding #88 this PR concerns updating to SDL_ffmpeg that works with modern ffmpeg. So far it contains the changes to GL-CI for testing this, however building https://github.com/civctp2/civctp2/commit/4d2aee2ad647af5f316d862b1bbdd35333b8a381 fails because [SDL_ffmpeg@FFmpeg-2018](https://github.com/LynxAbraxas/SDL_ffmpeg/tree/FFmpeg-2018) demands corrections to its use in the code of ctp2 in 
https://github.com/civctp2/civctp2/blob/132f78b67c1997c64e034c888d02f62457ca2ce5/ctp2_code/ui/aui_common/aui_movie.cpp#L233
and elsewhere.