### PR TITLE
Televangelist "faith heal" message expects spec. of civ

### DIFF
--- a/ctp2_code/gs/gameobj/ArmyData.cpp
+++ b/ctp2_code/gs/gameobj/ArmyData.cpp
@@ -4417,6 +4417,7 @@ ORDER_RESULT ArmyData::IndulgenceSale(const MapPoint &point)
 
 		SlicObject * so  = new SlicObject("911FaithHealAttacker");
 		so->AddRecipient(u.GetOwner());
+		so->AddCivilisation(c.GetOwner()); // Televangelist message differs that of clerics and in addition needs the civ
 		so->AddCity(c);
 		g_slicEngine->Execute(so);
 	} else {


### PR DESCRIPTION
Televangelist message is sightly different to that of clerics. Either the messages need to be adjusted or the civ specified for the message to avoid in-game errors/warinings. 
This PR goes for the latter.