### PR TITLE
Allow unloading 12 units from stacked transporters at once

### DIFF
--- a/ctp2_code/gfx/tilesys/TileHighlight.cpp
+++ b/ctp2_code/gfx/tilesys/TileHighlight.cpp
@@ -112,14 +112,14 @@ double GetEntryCost
 					  : g_theWorld->GetMoveCost(a_Place);
 
 	if ((a_Army.IsAtLeastOneMoveShallowWater() ||
-		 a_Army.IsAtLeastOneMoveWater()
-		) &&
-		(!a_Army.IsAtLeastOneMoveLand())
+	     a_Army.IsAtLeastOneMoveWater()
+	    ) &&
+	    (!a_Army.IsAtLeastOneMoveLand())
 	   )
 	{
 		// Army without land units: do not use roads/tunnels etc.
 		TerrainRecord::Modifiers const * bareTerrainProperties  =
-		    (g_theWorld->HasCity(a_Place))
+		    (g_theWorld->HasCity(a_Place)/* && g_theWorld->GetTerrain(a_Place)->HasEnvCity()*/)
 		    ? g_theWorld->GetTerrain(a_Place)->GetEnvCityPtr()
 		    : g_theWorld->GetTerrain(a_Place)->GetEnvBase();
 
@@ -191,25 +191,31 @@ bool IsKnownEntryCost
 // Remark(s)  :
 //
 //----------------------------------------------------------------------------
-bool TiledMap::CanDrawSpecialMove(SELECT_TYPE sType, Army &sel_army, const MapPoint &old_pos, const MapPoint &dest_pos)
+bool TiledMap::CanDrawSpecialMove(SELECT_TYPE sType, Army &sel_army, const MapPoint &dest_pos)
 {
-	switch (sType) {
+	switch (sType)
+	{
 	case SELECT_TYPE_LOCAL_ARMY:
-		if (g_theWorld->HasCity(dest_pos)) {
-			if(g_controlPanel->GetTargetingMode() == CP_TARGETING_MODE_ORDER_PENDING) {
+		if (g_theWorld->HasCity(dest_pos))
+		{
+			if(g_controlPanel->GetTargetingMode() == CP_TARGETING_MODE_ORDER_PENDING)
+			{
 				const OrderRecord *rec = g_controlPanel->GetCurrentOrder();
-				if(rec->GetTargetPretestEnemyCity()) {
+				if(rec->GetTargetPretestEnemyCity())
+				{
 					if(g_theWorld->GetCell(dest_pos)->GetCity().GetOwner() != g_selected_item->GetVisiblePlayer()) {
 						return true;
 					}
 				}
 			}
 			return false;
-		} else {
-			return sel_army.CanAtLeastOneCargoUnloadAt(old_pos, dest_pos, TRUE);
+		}
+		else
+		{
+			return sel_army.CanAtLeastOneCargoUnloadAt(dest_pos, true);
 		}
 	case SELECT_TYPE_LOCAL_ARMY_UNLOADING:
-		return sel_army.CanAtLeastOneCargoUnloadAt(old_pos, dest_pos, TRUE);
+		return sel_army.CanAtLeastOneCargoUnloadAt(dest_pos, true);
 	default:
 		return false;
 	}
@@ -472,7 +478,7 @@ void TiledMap::DrawLegalMove
 				((sType == SELECT_TYPE_LOCAL_ARMY_UNLOADING) && (line_segment_count == 0))
 			   )
 			{
-				if (draw_one_special && CanDrawSpecialMove(sType, sel_army, prevPos, currPos))
+				if (draw_one_special && CanDrawSpecialMove(sType, sel_army, currPos))
 				{
 					draw_one_special		= false;
 					lineColor				= k_TURN_COLOR_SPECIAL;
@@ -550,7 +556,7 @@ void TiledMap::DrawLegalMove
 			if (((sType == SELECT_TYPE_LOCAL_ARMY) ||
 				 ((sType == SELECT_TYPE_LOCAL_ARMY_UNLOADING) && (line_segment_count == 0))
 				) &&
-				(draw_one_special && CanDrawSpecialMove(sType, sel_army, prevPos, currPos))
+				(draw_one_special && CanDrawSpecialMove(sType, sel_army, currPos))
 			   )
 			{
 				draw_one_special		= false;
@@ -619,7 +625,7 @@ void TiledMap::DrawLegalMove
 				if (((sType == SELECT_TYPE_LOCAL_ARMY) ||
 					 ((sType == SELECT_TYPE_LOCAL_ARMY_UNLOADING) && (line_segment_count == 1))
 					) &&
-					(draw_one_special && CanDrawSpecialMove(sType, sel_army, prevPos, currPos))
+					(draw_one_special && CanDrawSpecialMove(sType, sel_army, currPos))
 				   )
 				{
 					draw_one_special		= FALSE;

--- a/ctp2_code/gfx/tilesys/TileHighlight.cpp
+++ b/ctp2_code/gfx/tilesys/TileHighlight.cpp
@@ -119,7 +119,7 @@ double GetEntryCost
 	{
 		// Army without land units: do not use roads/tunnels etc.
 		TerrainRecord::Modifiers const * bareTerrainProperties  =
-		    (g_theWorld->HasCity(a_Place)/* && g_theWorld->GetTerrain(a_Place)->HasEnvCity()*/)
+		    (g_theWorld->HasCity(a_Place) && g_theWorld->GetTerrain(a_Place)->HasEnvCity())
 		    ? g_theWorld->GetTerrain(a_Place)->GetEnvCityPtr()
 		    : g_theWorld->GetTerrain(a_Place)->GetEnvBase();
 
@@ -129,8 +129,10 @@ double GetEntryCost
 			cost = icost;
 		}
 	}
+
 	sint32 highestbonus;
-	if (a_Army.GetMoveBonusUnits(highestbonus)) {
+	if (a_Army.GetMoveBonusUnits(highestbonus))
+	{
 		cost = highestbonus;
 	}
 

--- a/ctp2_code/gfx/tilesys/tiledmap.h
+++ b/ctp2_code/gfx/tilesys/tiledmap.h
@@ -409,7 +409,7 @@ public:
 
 	void		DrawWater(void);
 
-	bool        CanDrawSpecialMove(SELECT_TYPE sType, Army &sel_army, const MapPoint &old_pos, const MapPoint &cur_pos);
+	bool        CanDrawSpecialMove(SELECT_TYPE sType, Army &sel_army, const MapPoint &dest_pos);
 	void		DrawLegalMove(aui_Surface *pSurface);
 	void		DrawUnfinishedMove(aui_Surface *pSurface);
 

--- a/ctp2_code/gs/gameobj/Army.cpp
+++ b/ctp2_code/gs/gameobj/Army.cpp
@@ -895,13 +895,12 @@ bool Army::IsWounded(void) const
 
 bool Army::CanAtLeastOneCargoUnloadAt
 (
-    MapPoint const &    old_pos,
-    MapPoint const &    dest_pos,
+    MapPoint const &    unload_pos,
     bool                use_vision,
     const bool          check_move_points
 ) const
 {
-	return GetData()->CanAtLeastOneCargoUnloadAt(old_pos, dest_pos, use_vision, check_move_points);
+	return GetData()->CanAtLeastOneCargoUnloadAt(unload_pos, use_vision, check_move_points);
 }
 
 bool Army::ExecutedThisTurn() const

--- a/ctp2_code/gs/gameobj/Army.h
+++ b/ctp2_code/gs/gameobj/Army.h
@@ -294,8 +294,7 @@ public:
 
 	bool CanAtLeastOneCargoUnloadAt
 	(
-	    MapPoint const &    old_pos,
-	    MapPoint const &    dest_pos,
+	    MapPoint const &    unload_pos,
 	    bool                use_vision,
 	    const bool          check_move_points = true
 	) const;

--- a/ctp2_code/gs/gameobj/ArmyData.cpp
+++ b/ctp2_code/gs/gameobj/ArmyData.cpp
@@ -2690,7 +2690,6 @@ ORDER_RESULT ArmyData::CauseUnhappiness(const MapPoint &point,
 bool ArmyData::CanPlantNuke(double &chance, double &escape_chance,
 							sint32 &uindex) const
 {
-
 	if ( !g_player[m_owner]->m_advances->HasAdvance(advanceutil_GetNukeAdvance()))
 		return false;
 
@@ -2727,7 +2726,6 @@ bool ArmyData::CanPlantNuke(double &chance, double &escape_chance,
 //----------------------------------------------------------------------------
 bool ArmyData::CanPlantNuke(double &chance, double &escape_chance) const
 {
-
 	if ( !g_player[m_owner]->m_advances->HasAdvance(advanceutil_GetNukeAdvance()))
 		return false;
 
@@ -5317,7 +5315,7 @@ bool ArmyData::CanBombard(const MapPoint &point) const
 	}
 
 #if 0
-	// This prevents the AI from figuring out wheather a uit can be bombarded
+	// This prevents the AI from figuring out wheather a unit can be bombarded
 	// Fix this first, before you enable it again.
 	// In case of doubt check the method's callers
 
@@ -6049,7 +6047,8 @@ void ArmyData::AutoAddOrders(UNIT_ORDER_TYPE order, Path *path,
 	m_orders->AddTail(new Order(order, path, point, argument));
 	StopPirating();
 
-	if(m_owner >= 0 && m_owner < k_MAX_PLAYERS && g_player[m_owner]) {
+	if(m_owner >= 0 && m_owner < k_MAX_PLAYERS && g_player[m_owner])
+	{
 		ExecuteOrders(false);
 	}
 }
@@ -6621,9 +6620,9 @@ bool ArmyData::ExecuteMoveOrder(Order *order)
 	    (order->m_order == UNIT_ORDER_MOVE_THEN_UNLOAD)
 	   )
 	{
-		if (order->m_path->IsEndDir() ||
-			(order->m_order == UNIT_ORDER_MOVE_THEN_UNLOAD && order->m_point.IsNextTo(m_pos))
-		   )
+		if( order->m_path->IsEndDir() ||
+		   (order->m_order == UNIT_ORDER_MOVE_THEN_UNLOAD && order->m_point.IsNextTo(m_pos))
+		  )
 		{
 			if (order->m_order == UNIT_ORDER_MOVE_THEN_UNLOAD && order->m_point.IsNextTo(m_pos))
 			{
@@ -6722,13 +6721,18 @@ void ArmyData::CheckLoadSleepingCargoFromCity(Order *order)
 	if(cell->UnitArmy()->Num() < 1)
 		return;
 
-	for(sint32 i = 0; i < m_nElements; i++) {
-		if(m_array[i].GetCargoCapacity() > 0) {
-			for (int j = cell->UnitArmy()->Num() - 1; j >= 0; j--) {
+	for(sint32 i = 0; i < m_nElements; i++)
+	{
+		if(m_array[i].GetCargoCapacity() > 0)
+		{
+			for (int j = cell->UnitArmy()->Num() - 1; j >= 0; j--)
+			{
 				Unit u = cell->UnitArmy()->Access(j);
 				if(!u.IsAsleep())
 					continue;
-				if(m_array[i].CanCarry(u)) {
+
+				if(m_array[i].CanCarry(u))
+				{
 					bool out_of_fuel;
 					u.SetIsInTransport(m_array[i]);
 					u.DeductMoveCost(k_MOVE_ENTER_TRANSPORT_COST, out_of_fuel);
@@ -6736,9 +6740,8 @@ void ArmyData::CheckLoadSleepingCargoFromCity(Order *order)
 					u.UndoVision();
 					u.RemoveUnitVision();
 					m_array[i].InsertCargo(u);
-					g_player[m_owner]->RegisterInsertCargo
-					    (m_array[i].GetArmy(), u.GetType(), (sint32)u.GetHP());
 				}
+
 				if(m_array[i].GetCargoCapacity() < 1)
 					break;
 			}
@@ -7629,7 +7632,7 @@ bool ArmyData::MoveIntoCell(const MapPoint &pos, UNIT_ORDER_TYPE order, WORLD_DI
 
 		if(g_player[m_owner]->IsRobot())
 		{
-			if(CanAtLeastOneCargoUnloadAt(RetPos(), pos, false))
+			if(CanAtLeastOneCargoUnloadAt(pos, false))
 			{
 				g_gevManager->AddEvent
 				                      (
@@ -8247,15 +8250,13 @@ void ArmyData::DoBoardTransport(Order *order)
 // Remark(s)  : -
 //
 //----------------------------------------------------------------------------
-bool ArmyData::CanAtLeastOneCargoUnloadAt(const MapPoint & old_pos,
-                                          const MapPoint & dest_pos,
+bool ArmyData::CanAtLeastOneCargoUnloadAt(const MapPoint & unload_pos,
                                           const bool & used_vision,
                                           const bool check_move_points) const
 {
 	for(sint32 i = 0; i < m_nElements; i++)
 	{
-		if(m_array[i].CanAtLeastOneCargoUnloadAt(old_pos,
-		                                         dest_pos,
+		if(m_array[i].CanAtLeastOneCargoUnloadAt(unload_pos,
 		                                         used_vision,
 		                                         check_move_points)
 		){
@@ -8375,7 +8376,8 @@ void ArmyData::FinishUnloadOrder(Army &debark, MapPoint &to_pt)
 	{
 		sint32 visiblePlayer = g_selected_item->GetVisiblePlayer();
 		if ((visiblePlayer == m_array[0].GetOwner()) ||
-			(m_array[0].GetVisibility() & (1 << visiblePlayer))) {
+			(m_array[0].GetVisibility() & (1 << visiblePlayer)))
+		{
 			g_soundManager->AddSound(SOUNDTYPE_SFX, (uint32)0,
 								m_array[0].GetCantMoveSoundID(),
 								to_pt.x,
@@ -8383,24 +8385,28 @@ void ArmyData::FinishUnloadOrder(Army &debark, MapPoint &to_pt)
 		}
 
 		debark.Kill();
-	} else {
-
+	}
+	else
+	{
 		sint32 i;
 //		sint32 n = debark.Num();
 
-		if(IsOccupiedByForeigner(to_pt)) {
-			for(i = 0; i < debark.Num(); i++) {
-				if((!debark[i]->Flag(k_UDF_BEACH_ASSAULT_LEGAL))) {
+		if(IsOccupiedByForeigner(to_pt))
+		{
+			for(i = 0; i < debark.Num(); i++)
+			{
+				if((!debark[i]->Flag(k_UDF_BEACH_ASSAULT_LEGAL)))
+				{
 					CheckWasEnemyVisible(to_pt);
 
 					bool inserted = false;
-					for(sint32 j = 0; j < m_nElements && !inserted; j++) {
+					for(sint32 j = 0; j < m_nElements && !inserted; j++)
+					{
 						inserted = m_array[j].InsertCargo(debark[i]);
-						if(inserted) {
+						if(inserted)
+						{
 							Unit u = debark[i];
 							u.GetInserted(m_array[j]);
-							g_player[m_owner]->RegisterInsertCargo
-							    (m_id, u.GetType(), (sint32)u.GetHP());
 							break;
 						}
 					}
@@ -8411,17 +8417,20 @@ void ArmyData::FinishUnloadOrder(Army &debark, MapPoint &to_pt)
 					i--;
 				}
 			}
-		} else if(g_theWorld->GetCity(to_pt).m_id != 0 &&
-			      g_theWorld->GetCity(to_pt).GetOwner() != m_owner) {
-			if(!g_theArmyPool->AccessArmy(debark)->CanAtLeastOneCaptureCity()) {
+		}
+		else if(g_theWorld->GetCity(to_pt).m_id != 0 &&
+		        g_theWorld->GetCity(to_pt).GetOwner() != m_owner)
+		{
+			if(!g_theArmyPool->AccessArmy(debark)->CanAtLeastOneCaptureCity())
+			{
 				for(i = debark.Num() - 1; i >= 0; i--) {
 					bool inserted = false;
-					for(sint32 j = 0; j < m_nElements && !inserted; j++) {
+					for(sint32 j = 0; j < m_nElements && !inserted; j++)
+					{
 						inserted = m_array[j].InsertCargo(debark[i]);
-						if(inserted) {
+						if(inserted)
+						{
 							debark[i].GetInserted(m_array[j]);
-							g_player[m_owner]->RegisterInsertCargo
-							    (m_id, debark[i].GetType(),(sint32)debark[i].GetHP());
 							break;
 						}
 					}
@@ -8433,24 +8442,24 @@ void ArmyData::FinishUnloadOrder(Army &debark, MapPoint &to_pt)
 			}
 		}
 
-		if(0 < debark.Num()) {
-			if (g_soundManager) {
+		if(debark.Num() > 0)
+		{
+			if (g_soundManager)
+			{
 				sint32 visiblePlayer = g_selected_item->GetVisiblePlayer();
 				if ((visiblePlayer == debark[0].GetOwner()) ||
-				    (debark[0].GetVisibility() & (1 << visiblePlayer))) {
+				    (debark[0].GetVisibility() & (1 << visiblePlayer)))
+				{
 					g_soundManager->AddSound(SOUNDTYPE_SFX, (uint32)0,
 									    m_array[0].GetUnloadSoundID(),
 									    to_pt.x,
 									    to_pt.y);
 				}
 			}
-		}
-		if (0 < debark.Num())
-		{
+
 			if (debark.IsValid())
 			{
-				sint32 i;
-				for(i = 0; i < debark.Num(); i++)
+				for(sint32 i = 0; i < debark.Num(); i++)
 				{
 					if(!debark[i]->Flag(k_UDF_BEACH_ASSAULT_LEGAL) &&
 					   !debark[i].GetMovementTypeAir())
@@ -8462,24 +8471,27 @@ void ArmyData::FinishUnloadOrder(Army &debark, MapPoint &to_pt)
 				}
 			}
 
-			if(m_pos != to_pt) {
-				sint32 i;
-				for(i = 0; i < debark.Num(); i++) {
-					if (debark[i].GetActor()) {
+			if(m_pos != to_pt)
+			{
+				for(sint32 i = 0; i < debark.Num(); i++)
+				{
+					if (debark[i].GetActor())
+					{
 						debark[i].GetActor()->Hide();
 						debark[i].GetActor()->PositionActor(m_pos);
 						g_director->AddShow(debark[i]);
 					}
 				}
 				debark.AutoAddOrders(UNIT_ORDER_MOVE_TO, NULL, to_pt, 0);
-			} else {
-				sint32 i;
-				for(i = 0; i < debark.Num(); i++) {
+			}
+			else
+			{
+				for(sint32 i = 0; i < debark.Num(); i++)
+				{
 					g_director->AddShow(debark[i]);
 				}
 				debark.AutoAddOrders(UNIT_ORDER_TELEPORT_TO, NULL, m_pos, 0);
 			}
-
 		}
 	}
 }
@@ -8862,8 +8874,6 @@ bool ArmyData::ExecuteTeleportOrder(Order *order)
 
 	CheckTerrainEvents();
 
-    MapPoint norm_pos;
-    norm_pos.Iso2Norm(order->m_point);
 
 	return true;
 }

--- a/ctp2_code/gs/gameobj/ArmyData.cpp
+++ b/ctp2_code/gs/gameobj/ArmyData.cpp
@@ -6376,7 +6376,6 @@ bool ArmyData::ExecuteOrders(bool propagate)
 				completedOrder = true;
 				break;
 			case UNIT_ORDER_UNLOAD:
-			case UNIT_ORDER_UNLOAD_ONE_UNIT:
 			case UNIT_ORDER_UNLOAD_SELECTED_STACK:
 				completedOrder = ExecuteUnloadOrder(order);
 				if(!completedOrder)
@@ -8323,20 +8322,17 @@ bool ArmyData::ExecuteUnloadOrder(Order *order)
 	Army debark;
 
 	bool unitUnloadDone = false;
+	sint32 count = 0; // Count the units to debark between the transporters so that we do not try to debark more units than fit at the unload position.
 	for(sint32 i = 0; i < m_nElements; i++)
 	{
-		if(order->m_order == UNIT_ORDER_UNLOAD_ONE_UNIT)
+		if(order->m_order == UNIT_ORDER_UNLOAD
+		|| order->m_order == UNIT_ORDER_MOVE_THEN_UNLOAD)
 		{
-			unitUnloadDone |= m_array[i].UnloadCargo(to_pt, debark, true, Unit(order->m_argument));
-		}
-		else if(order->m_order == UNIT_ORDER_UNLOAD
-		     || order->m_order == UNIT_ORDER_MOVE_THEN_UNLOAD)
-		{
-			unitUnloadDone |= m_array[i].UnloadCargo(to_pt, debark, false, Unit());
+			unitUnloadDone |= m_array[i].UnloadCargo(to_pt, debark, count);
 		}
 		else if(order->m_order == UNIT_ORDER_UNLOAD_SELECTED_STACK)
 		{
-			unitUnloadDone |= m_array[i].UnloadSelectedCargo(to_pt, debark);
+			unitUnloadDone |= m_array[i].UnloadCargo(to_pt, debark, count, true);
 		}
 		else
 		{

--- a/ctp2_code/gs/gameobj/ArmyData.h
+++ b/ctp2_code/gs/gameobj/ArmyData.h
@@ -426,7 +426,7 @@ public:
     void SetTurnOver();
     bool TurnOver();
 
-    bool CanAtLeastOneCargoUnloadAt(const MapPoint &old_pos, const MapPoint &dest_pos, const bool & used_vision, const bool check_move_points = true) const;
+    bool CanAtLeastOneCargoUnloadAt(const MapPoint &unload_pos, const bool & used_vision, const bool check_move_points = true) const;
 
     static bool GetInciteRevolutionCost( const MapPoint &point, sint32 &attackCost );
     static bool GetInciteUprisingCost( const MapPoint &point, sint32 &attackCost );

--- a/ctp2_code/gs/gameobj/Order.cpp
+++ b/ctp2_code/gs/gameobj/Order.cpp
@@ -92,7 +92,7 @@ OrderInfo g_orderInfo[] = {
 	{UNIT_ORDER_GROUP_UNIT,                 "ORDER_GROUP_UNIT",                 0, 0, 0, 0, NULL}, // 44
 	{UNIT_ORDER_DISBAND,                    "ORDER_DISBAND_ARMY",               0, 0, 0, 0, NULL}, // 45
 	{UNIT_ORDER_FINISH_ATTACK,              "ORDER_FINISH_ATTACK",              0, 0, 0, 0, NULL}, // 46
-	{UNIT_ORDER_UNLOAD_ONE_UNIT,            "ORDER_UNLOAD_ONE_UNIT",            0, 0, 0, 0, NULL}, // 47
+	{UNIT_ORDER_UNUSED,                     "ORDER_UNUSED",                     0, 0, 0, 0, NULL}, // 47
 	{UNIT_ORDER_BOARD_TRANSPORT,            "ORDER_BOARD_TRANSPORT",            0, 0, 0, 0, NULL}, // 48
 	{UNIT_ORDER_WAKE_UP,                    "ORDER_WAKE_UP",                    0, 0, 0, 0, NULL}, // 49
 	{UNIT_ORDER_PILLAGE_UNCONDITIONALLY,    "ORDER_PILLAGE_UNCONDITIONALLY",    0, 0, 0, 0, NULL}, // 50

--- a/ctp2_code/gs/gameobj/Player.cpp
+++ b/ctp2_code/gs/gameobj/Player.cpp
@@ -1325,16 +1325,6 @@ void Player::RegisterLostUnits(sint32 nUnits, const MapPoint &pos,
 	}
 }
 
-void Player::RegisterInsertCargo(ID id, const sint32 unit_type, sint32 hp)
-{
-	// Edit this so that the cargo is registered
-}
-
-void Player::RegisterUnloadCargo(ID id, const sint32 unit_type, sint32 hp)
-{
-	// Edit this so that the cargo is registered
-}
-
 sint32 Player::GetWeakestEnemy() const
 {
 	return Diplomat::GetDiplomat(m_owner).GetWeakestEnemy();
@@ -6660,19 +6650,6 @@ void Player::UngroupArmy(Army &army)
 	}
 }
 #endif
-
-void Player::RegisterYourArmyWasMoved(const Army &i_moved, const MapPoint &new_pos)
-{
-
-	for(sint32 i = 0; i < m_all_armies->Num(); i++) {
-        if(m_all_armies->Access(i).m_id == i_moved.m_id) {
-
-            return;
-        }
-	}
-
-    return;
-}
 
 void Player::AssasinateRuler()
 {

--- a/ctp2_code/gs/gameobj/Unit.cpp
+++ b/ctp2_code/gs/gameobj/Unit.cpp
@@ -740,27 +740,14 @@ bool Unit::IsBeingTransported() const
 	return GetData()->IsBeingTransported();
 }
 
-#if 0
-void Unit::Transform()
-{
-	AccessData()->Transform();
-}
-#endif
-
 bool Unit::CanAtLeastOneCargoUnloadAt(const MapPoint & unload_pos, const bool & use_vision, bool check_move_points) const
 {
 	return GetData()->CanAtLeastOneCargoUnloadAt(unload_pos, use_vision, check_move_points);
 }
 
-bool Unit::UnloadCargo(const MapPoint &unload_pos, Army &debark,
-                       bool justOneUnit, const Unit &theUnit)
+bool Unit::UnloadCargo(const MapPoint &unload_pos, Army &debark, sint32 &count, bool unloadSelected)
 {
-	return AccessData()->UnloadCargo(unload_pos, debark, justOneUnit, theUnit);
-}
-
-bool Unit::UnloadSelectedCargo(const MapPoint &unload_pos, Army &debark)
-{
-	return AccessData()->UnloadSelectedCargo(unload_pos, debark);
+	return AccessData()->UnloadCargo(unload_pos, debark, count, unloadSelected);
 }
 
 bool Unit::IsMovePointsEnough(const MapPoint &pos) const

--- a/ctp2_code/gs/gameobj/Unit.cpp
+++ b/ctp2_code/gs/gameobj/Unit.cpp
@@ -747,20 +747,20 @@ void Unit::Transform()
 }
 #endif
 
-bool Unit::CanAtLeastOneCargoUnloadAt(const MapPoint & old_pos, const MapPoint & dest_pos, const bool & use_vision, bool check_move_points) const
+bool Unit::CanAtLeastOneCargoUnloadAt(const MapPoint & unload_pos, const bool & use_vision, bool check_move_points) const
 {
-	return GetData()->CanAtLeastOneCargoUnloadAt(old_pos, dest_pos, use_vision, check_move_points);
+	return GetData()->CanAtLeastOneCargoUnloadAt(unload_pos, use_vision, check_move_points);
 }
 
-bool Unit::UnloadCargo(const MapPoint &new_pos, Army &debark,
-					   bool justOneUnit, const Unit &theUnit)
+bool Unit::UnloadCargo(const MapPoint &unload_pos, Army &debark,
+                       bool justOneUnit, const Unit &theUnit)
 {
-	return AccessData()->UnloadCargo(new_pos, debark, justOneUnit, theUnit);
+	return AccessData()->UnloadCargo(unload_pos, debark, justOneUnit, theUnit);
 }
 
-bool Unit::UnloadSelectedCargo(const MapPoint &new_pos, Army &debark)
+bool Unit::UnloadSelectedCargo(const MapPoint &unload_pos, Army &debark)
 {
-	return AccessData()->UnloadSelectedCargo(new_pos, debark);
+	return AccessData()->UnloadSelectedCargo(unload_pos, debark);
 }
 
 bool Unit::IsMovePointsEnough(const MapPoint &pos) const

--- a/ctp2_code/gs/gameobj/Unit.h
+++ b/ctp2_code/gs/gameobj/Unit.h
@@ -180,11 +180,11 @@ public:
 	void SetIsInTransport(const Unit &transport);
 	bool IsBeingTransported() const;
 
-	bool CanAtLeastOneCargoUnloadAt(const MapPoint & old_pos, const MapPoint & dest_pos, const bool & used_vision, bool check_move_points = true) const;
+	bool CanAtLeastOneCargoUnloadAt(const MapPoint & unload_pos, const bool & used_vision, bool check_move_points = true) const;
 
-	bool UnloadCargo(const MapPoint &new_pos, Army &debark,
+	bool UnloadCargo(const MapPoint &unload_pos, Army &debark,
 			 bool justOneUnit, const Unit &theUnit);
-	bool UnloadSelectedCargo(const MapPoint &new_pos, Army &debark);
+	bool UnloadSelectedCargo(const MapPoint &unload_pos, Army &debark);
 
 	bool IsMovePointsEnough(const MapPoint &pos) const;
 

--- a/ctp2_code/gs/gameobj/Unit.h
+++ b/ctp2_code/gs/gameobj/Unit.h
@@ -182,9 +182,7 @@ public:
 
 	bool CanAtLeastOneCargoUnloadAt(const MapPoint & unload_pos, const bool & used_vision, bool check_move_points = true) const;
 
-	bool UnloadCargo(const MapPoint &unload_pos, Army &debark,
-			 bool justOneUnit, const Unit &theUnit);
-	bool UnloadSelectedCargo(const MapPoint &unload_pos, Army &debark);
+	bool UnloadCargo(const MapPoint &unload_pos, Army &debark, sint32 &count, bool unloadSelected = false);
 
 	bool IsMovePointsEnough(const MapPoint &pos) const;
 

--- a/ctp2_code/gs/gameobj/UnitData.cpp
+++ b/ctp2_code/gs/gameobj/UnitData.cpp
@@ -1050,15 +1050,12 @@ bool UnitData::UnloadCargo(const MapPoint &unload_pos, Army &debark, sint32 &cou
 	sint32 max_debark;
 	if(cell->UnitArmy() && cell->UnitArmy()->GetOwner() != m_owner)
 	{
-	//compute the max number of units we can unload
-		max_debark = k_MAX_ARMY_SIZE - g_theWorld->GetCell(m_pos)->GetNumUnits();
+		// Get the max number of units we can unload
+		max_debark = k_MAX_ARMY_SIZE;
 	}
 	else
 	{
-		max_debark = std::min
-		    (k_MAX_ARMY_SIZE - cell->GetNumUnits(),
-		     k_MAX_ARMY_SIZE - g_theWorld->GetCell(m_pos)->GetNumUnits()
-		    );
+		max_debark = k_MAX_ARMY_SIZE - cell->GetNumUnits();
 	}
 
 	sint32 const        n       = GetNumCarried();
@@ -1087,7 +1084,12 @@ bool UnitData::UnloadCargo(const MapPoint &unload_pos, Army &debark, sint32 &cou
 			passenger .UnsetIsInTransport();
 
 			UnitDynamicArray revealedUnits;
-			g_theWorld->InsertUnit(m_pos, passenger, revealedUnits);
+
+			if(m_pos == unload_pos)
+			{
+				g_theWorld->InsertUnit(m_pos, passenger, revealedUnits);
+			}
+		//	else will be handled when the unit moves
 
 			passenger.AddUnitVision();
 

--- a/ctp2_code/gs/gameobj/UnitData.h
+++ b/ctp2_code/gs/gameobj/UnitData.h
@@ -269,8 +269,7 @@ public:
 
 	bool CanAtLeastOneCargoUnloadAt
 	(
-	    MapPoint const &    old_pos,
-	    MapPoint const &    dest_pos,
+	    MapPoint const &    unload_pos,
 	    bool                use_vision,
 	    bool                check_move_points = true
 	) const;
@@ -278,15 +277,14 @@ public:
 	bool CanThisCargoUnloadAt
 	(
 	    Unit                the_cargo,
-	    MapPoint const &    old_pos,
-	    MapPoint const &    new_pos,
+	    MapPoint const &    unload_pos,
 	    bool                use_vision,
 	    bool                check_move_points = true
 	) const;
 
-	bool UnloadCargo(const MapPoint &new_pos, Army &debark,
+	bool UnloadCargo(const MapPoint &unload_pos, Army &debark,
 	                 bool justOneUnit, const Unit &theUnit);
-	bool UnloadSelectedCargo(const MapPoint &new_pos, Army &debark);
+	bool UnloadSelectedCargo(const MapPoint &unload_pos, Army &debark);
 
 	bool IsBeingTransported() const { return Flag(k_UDF_IS_IN_TRANSPORT); };
 	void SetIsInTransport(const Unit &transport);

--- a/ctp2_code/gs/gameobj/UnitData.h
+++ b/ctp2_code/gs/gameobj/UnitData.h
@@ -282,9 +282,7 @@ public:
 	    bool                check_move_points = true
 	) const;
 
-	bool UnloadCargo(const MapPoint &unload_pos, Army &debark,
-	                 bool justOneUnit, const Unit &theUnit);
-	bool UnloadSelectedCargo(const MapPoint &unload_pos, Army &debark);
+	bool UnloadCargo(const MapPoint &unload_pos, Army &debark, sint32 &count, bool unloadSelected = false);
 
 	bool IsBeingTransported() const { return Flag(k_UDF_IS_IN_TRANSPORT); };
 	void SetIsInTransport(const Unit &transport);

--- a/ctp2_code/gs/gameobj/UnitTypes.h
+++ b/ctp2_code/gs/gameobj/UnitTypes.h
@@ -171,7 +171,7 @@ enum UNIT_ORDER_TYPE
 	UNIT_ORDER_GROUP_UNIT,                   // 44
 	UNIT_ORDER_DISBAND,                      // 45
 	UNIT_ORDER_FINISH_ATTACK,                // 46
-	UNIT_ORDER_UNLOAD_ONE_UNIT,              // 47
+	UNIT_ORDER_UNUSED,                       // 47
 	UNIT_ORDER_BOARD_TRANSPORT,              // 48
 	UNIT_ORDER_WAKE_UP,                      // 49
 

--- a/ctp2_code/gs/gameobj/player.h
+++ b/ctp2_code/gs/gameobj/player.h
@@ -432,15 +432,10 @@ public:
 	void RegisterLostUnits(sint32 nUnits, const MapPoint &pos,
 	                       const DEATH_EFFECT_MORALE mtype);
 
-	void RegisterInsertCargo(ID id, const sint32 unit_type, sint32 hp);
-	void RegisterUnloadCargo(ID id, const sint32 unit_type, sint32 hp);
 	void GroupArmy(Army &army);
 	void UngroupArmy(Army &army);
 
-	void RegisterYourArmyWasMoved(const Army &i_moved, const MapPoint &new_pos);
-
 	void GetArmyPos(sint32 index, MapPoint &army_pos);
-	void UnloadAllTransports ();
 
 	bool Settle      (Army &settle_army);
 	bool SettleInCity(Army &settle_army);

--- a/ctp2_code/gs/gameobj/unitutil.cpp
+++ b/ctp2_code/gs/gameobj/unitutil.cpp
@@ -336,20 +336,20 @@ bool unitutil_GetCityInfo(MapPoint &pos, char * city_name, sint32 & image_index)
 
 void unitutil_ExecuteMadLaunch(Unit & unit)
 {
-
 	if( unit.GetDBRec()->HasNuclearAttack() &&
 		unit->GetTargetCity().IsValid() &&
-		!unit.Flag(k_UDF_MAD_LAUNCHED)) {
-
-
-
-
+		!unit.Flag(k_UDF_MAD_LAUNCHED))
+	{
 		if (unit.IsBeingTransported())
 		{
+			sint32 count = 0;
+			unit.SetFlag(k_UDF_TEMP_TRANSPORT_SELECT);
 			Unit transport = unit.GetTransport();
 			Army debark = g_player[unit.GetOwner()]->GetNewArmy(CAUSE_NEW_ARMY_TRANSPORTED);
-			transport.UnloadCargo(transport.RetPos(), debark, TRUE, unit);
-		} else {
+			transport.UnloadCargo(transport.RetPos(), debark, count, true);
+		}
+		else
+		{
 			unit->CreateOwnArmy();
 		}
 

--- a/ctp2_code/gs/world/Cell.cpp
+++ b/ctp2_code/gs/world/Cell.cpp
@@ -267,11 +267,6 @@ bool Cell::RemoveUnitReference(const Unit &u)
 	}
 	else
 	{
-		if(!u.IsValid() || !u.IsBeingTransported())
-		{
-			Assert(false);
-		}
-
 		return false;
 	}
 }

--- a/ctp2_code/robot/pathing/robotastar2.cpp
+++ b/ctp2_code/robot/pathing/robotastar2.cpp
@@ -76,7 +76,7 @@ bool RobotAstar2::TransportPathCallback (const bool & can_enter,
 		bool is_land    = ( g_theWorld->IsLand(pos) || g_theWorld->IsMountain(pos) );
 		bool wrong_cont = ( cont != m_transDestCont ) && (!g_theWorld->IsCity(pos));
 
-		bool occupied = (m_army->HasCargo() && (!m_army.CanAtLeastOneCargoUnloadAt(prev, pos, false, !m_is_robot)));
+		bool occupied = (m_army->HasCargo() && (!m_army.CanAtLeastOneCargoUnloadAt(pos, false, !m_is_robot)));
 
 		if(occupied || wrong_cont)
 		{
@@ -169,11 +169,11 @@ bool RobotAstar2::AirliftPathCallback (const bool & can_enter,
 		   )
 		  )
 		{
-			bool occupied = (m_army->HasCargo() && !m_army.CanAtLeastOneCargoUnloadAt(prev, pos, false, !m_is_robot));
+			bool occupied = (m_army->HasCargo() && !m_army.CanAtLeastOneCargoUnloadAt(pos, false, !m_is_robot));
 
 			if(occupied)
 			{
-				if(!m_army.CanAtLeastOneCargoUnloadAt(prev, prev, false, !m_is_robot))
+				if(!m_army.CanAtLeastOneCargoUnloadAt(prev, false, !m_is_robot))
 				{
 					cost = k_ASTAR_BIG;
 					entry = ASTAR_RETRY_DIRECTION;


### PR DESCRIPTION
For instance the coracle can only transport one unit, if you want to bring 12 land units to a target tile you would use 12 coracles and group. However, in that scenario you could not even unload one unit, because first the units are unloaded at the position of the coracles and added to the unit list of that tile, which can only hold 12 units. Which means no additional can be added.

From a player's perspective, I consider it as a bug, but it is the design. A quite stupid design and gives the AI trouble to unload units. For instance if the transporter is in a city with 11 other units on the target continent.

Basically, this changes it so that the units are not inserted into the unit list of the transporter position, but only their position is set to the transporter position and then they are moved to their final destination. However, nothing has changed for helicopters if they unload their cargo at their position.