### PR TITLE
expecting leader names < 100 chars during GL-CI tests

### DIFF
--- a/tests/name-game.sikuli/name-game.py
+++ b/tests/name-game.sikuli/name-game.py
@@ -20,7 +20,7 @@ def main():
     hover(getLastMatch().getTarget().offset(0, 100)) # move mouse out of the text field for later matching
     Settings.TypeDelay = 0.1; # ctp2-SDL needs some more time
     count= 0
-    while not exists(Pattern("ctp2empty-leader-name-field.png").similar(0.95), 0.01) and count < 1024: # high similarity to ensure empty text field
+    while not exists(Pattern("ctp2empty-leader-name-field.png").similar(0.95), 0.01) and count < 100: # high similarity to ensure empty text field
         type(Key.BACKSPACE) # hit backspace until name-field is empty
         count= count + 1
     type(leaderName)


### PR DESCRIPTION
to speed up test in case of missed sikuli events. 
This reduces the time of the name-game test by a factor of 10 in case a sikuli event gets lost.