### PR TITLE
get '/' (for e.g. /reloadslic) with Shift+7

### DIFF
--- a/ctp2_code/ctp/civ3_main.cpp
+++ b/ctp2_code/ctp/civ3_main.cpp
@@ -1911,7 +1911,7 @@ int SDLMessageHandler(const SDL_Event &event)
 			SDLKCONVSHIFT(SDLK_4, '4', '$');
 			SDLKCONVSHIFT(SDLK_5, '5', '%');
 			SDLKCONVSHIFT(SDLK_6, '6', '^');
-			SDLKCONVSHIFT(SDLK_7, '7', '&');
+			SDLKCONVSHIFT(SDLK_7, '7', '/');
 			SDLKCONVSHIFT(SDLK_8, '8', '*');
 			SDLKCONVSHIFT(SDLK_9, '9', '(');
 			SDLKCONVSHIFT(SDLK_0, '0', ')');


### PR DESCRIPTION
essential for testing if there is no number-pad emulation on your laptop and you don't have a spare keyboard around...