### PR TITLE
WIP: message for the pirate victim

### DIFF
--- a/ctp2_code/gs/gameobj/ArmyData.cpp
+++ b/ctp2_code/gs/gameobj/ArmyData.cpp
@@ -1683,21 +1683,13 @@ void ArmyData::BeginTurn()
 		    fromCity = route.GetSource();
 		    toCity = route.GetDestination();
 
-		    SlicObject * so1 = new SlicObject("044TradePirateGold");
-		    so1->AddRecipient(GetOwner());
-		    so1->AddGold(pgold) ;
-		    so1->AddCity(fromCity);
-		    so1->AddCity(toCity);
-		    so1->AddCivilisation(fromCity.GetOwner());
-		    g_slicEngine->Execute(so1);
-
-		    SlicObject * so2 = new SlicObject("045TradePirated");
-		    so2->AddRecipient(fromCity.GetOwner());
-		    so2->AddGold(route->GetValue()) ;
-		    so2->AddCity(fromCity);
-		    so2->AddCity(toCity);
-		    so2->AddCivilisation(GetOwner());
-		    g_slicEngine->Execute(so2);
+		    SlicObject * so = new SlicObject("044TradePirateGold");
+		    so->AddRecipient(GetOwner());
+		    so->AddGold(pgold) ;
+		    so->AddCity(fromCity);
+		    so->AddCity(toCity);
+		    so->AddCivilisation(fromCity.GetOwner());
+		    g_slicEngine->Execute(so);
                 }
             }
             if(piratedByMe < 1) {

--- a/ctp2_code/gs/gameobj/CityData.cpp
+++ b/ctp2_code/gs/gameobj/CityData.cpp
@@ -3605,7 +3605,7 @@ void CityData::CalculateCoeffProd()
 //----------------------------------------------------------------------------
 void CityData::CalculateBonusGold()
 {
-	m_bonusGold  = static_cast<double>(CalculateGoldFromResources());
+	m_bonusGold  = static_cast<double>(CalculateGoldFromResources(true));
 
 	//EMOD Civilization and Citystyle bonuses
 	m_bonusGold += g_player[m_owner]->CivCommerceBonus();
@@ -4430,7 +4430,7 @@ void CityData::CalculateTradeRoutes(bool projectedOnly)
 	}
 }
 
-sint32 CityData::CalculateGoldFromResources()
+sint32 CityData::CalculateGoldFromResources(bool issueMessage)
 {
 	m_goldFromTradeRoutes = 0;
 	m_goldLostToPiracy    = 0;
@@ -4445,17 +4445,19 @@ sint32 CityData::CalculateGoldFromResources()
 		{
 			m_goldLostToPiracy += m_tradeSourceList[i]->GetValue();
 
-			TradeRoute route = m_tradeSourceList[i];
-			// Unit fromCity = route.GetSource();
-			Unit toCity = route.GetDestination();
-
-			SlicObject * so = new SlicObject("045TradePirated");
-			so->AddRecipient(GetOwner());
-			so->AddGold(route->GetValue()) ;
-			so->AddCity(m_home_city); // m_home_city should equal fromCity
-			so->AddCity(toCity);
-			so->AddCivilisation(route->GetPiratingArmy().GetOwner());
-			g_slicEngine->Execute(so);
+			if(issueMessage){ // supress message e.g. for CauseAndEffectTab call
+			    TradeRoute route = m_tradeSourceList[i];
+			    // Unit fromCity = route.GetSource();
+			    Unit toCity = route.GetDestination();
+			    
+			    SlicObject * so = new SlicObject("045TradePirated");
+			    so->AddRecipient(GetOwner());
+			    so->AddGold(route->GetValue()) ;
+			    so->AddCity(m_home_city); // m_home_city should equal fromCity
+			    so->AddCity(toCity);
+			    so->AddCivilisation(route->GetPiratingArmy().GetOwner());
+			    g_slicEngine->Execute(so);
+			    }
 		}
 	}
 

--- a/ctp2_code/gs/gameobj/CityData.cpp
+++ b/ctp2_code/gs/gameobj/CityData.cpp
@@ -4444,6 +4444,18 @@ sint32 CityData::CalculateGoldFromResources()
 		else
 		{
 			m_goldLostToPiracy += m_tradeSourceList[i]->GetValue();
+
+			TradeRoute route = m_tradeSourceList[i];
+			// Unit fromCity = route.GetSource();
+			Unit toCity = route.GetDestination();
+
+			SlicObject * so = new SlicObject("045TradePirated");
+			so->AddRecipient(GetOwner());
+			so->AddGold(route->GetValue()) ;
+			so->AddCity(m_home_city); // m_home_city should equal fromCity
+			so->AddCity(toCity);
+			so->AddCivilisation(route->GetPiratingArmy().GetOwner());
+			g_slicEngine->Execute(so);
 		}
 	}
 

--- a/ctp2_code/gs/gameobj/citydata.h
+++ b/ctp2_code/gs/gameobj/citydata.h
@@ -454,7 +454,7 @@ public:
 	void DelTradeRoute(TradeRoute route);
 	sint32 IsUsedInTradeRoute(const MapPoint &qpos);
 	void CalculateTradeRoutes(bool projectedOnly);
-	sint32 CalculateGoldFromResources();
+	sint32 CalculateGoldFromResources(bool issueMessage= false);
 	void AddTradeResource(ROUTE_TYPE type, sint32 resource);
 #ifdef CTP1_TRADE
 	sint32 GetResourceCount(sint32 resource);

--- a/ctp2_code/ui/interface/CauseAndEffectTab.cpp
+++ b/ctp2_code/ui/interface/CauseAndEffectTab.cpp
@@ -887,7 +887,7 @@ void CauseAndEffectTab::UpdateCommerceValues()
 
 		// Savings from trade routes.
 		cityData->CalculateTradeRoutes(true); // Update trade routes
-		sint32 goldTradeRoutes = cityData->CalculateGoldFromResources();
+		sint32 goldTradeRoutes = cityData->CalculateGoldFromResources(false);
 
 		// Government modifiers to science and savings.
 		sint32 totalScieWithoutGov = scienceFromCommerce + scienceBuildingsBonus +


### PR DESCRIPTION
Follow up on #76 based on @MartinGuehmann comment https://github.com/civctp2/civctp2/pull/76#issuecomment-482749127, the message for the victim of piracy should not be based on the success of the attacker but instead on the fact that the trade gold is not added in case of piracy (especially by multiple civs on the same route).