### PR TITLE
Message for gold from trade through city

### DIFF
--- a/ctp2_code/gs/gameobj/CityData.cpp
+++ b/ctp2_code/gs/gameobj/CityData.cpp
@@ -11281,10 +11281,15 @@ void CityData::GiveTradeRouteGold()
 					Unit fromCity = route.GetSource();
 					Unit toCity = route.GetDestination();
 
+					ROUTE_TYPE type;
+					sint32 good;
+					route.GetSourceResource(type, good);
+					
 					SlicObject * so = new SlicObject("359TradePassing");
 					so->AddRecipient(GetOwner());
 					so->AddGold(tgold) ;
 					so->AddCity(m_home_city); // m_home_city should equal fromCity
+					so->AddGood(good);
 					so->AddCity(fromCity);
 					so->AddCity(toCity);
 					so->AddCivilisation(fromCity.GetOwner());

--- a/ctp2_code/gs/gameobj/CityData.cpp
+++ b/ctp2_code/gs/gameobj/CityData.cpp
@@ -11285,6 +11285,7 @@ void CityData::GiveTradeRouteGold()
 				    route.GetSourceResource(type, good);
 					
 				    if(!route->IsBeingPirated()){
+					/*
 					g_player[m_owner]->AddGold(tgold);
 					
 					SlicObject * so = new SlicObject("359TradePassing");
@@ -11296,6 +11297,7 @@ void CityData::GiveTradeRouteGold()
 					so->AddCity(toCity);
 					so->AddCivilisation(fromCity.GetOwner());
 					g_slicEngine->Execute(so);
+					*/
 					}
 				    else { // message that tgold is not earned from transit due to pirating
 					SlicObject * so = new SlicObject("358TradePassingPirated");

--- a/ctp2_code/gs/gameobj/CityData.cpp
+++ b/ctp2_code/gs/gameobj/CityData.cpp
@@ -11275,7 +11275,8 @@ void CityData::GiveTradeRouteGold()
 				if((route.GetSource().GetOwner() != m_owner)
 				&&(route.GetDestination().GetOwner() != m_owner)
 				){
-					sint32 tgold = static_cast<sint32>(route->GetValue() * g_theConstDB->Get(0)->GetCityOnTradeRouteCoeff());
+				    sint32 tgold = static_cast<sint32>(route->GetValue() * g_theConstDB->Get(0)->GetCityOnTradeRouteCoeff());
+				    if(!route->IsBeingPirated()){
 					g_player[m_owner]->AddGold(tgold);
 
 					Unit fromCity = route.GetSource();
@@ -11294,6 +11295,10 @@ void CityData::GiveTradeRouteGold()
 					so->AddCity(toCity);
 					so->AddCivilisation(fromCity.GetOwner());
 					g_slicEngine->Execute(so);
+					}
+				    // else {
+				    // 	// message that tgold is not earned from transit due to pirating
+				    // 	}
 				}
 			}
 		}

--- a/ctp2_code/gs/gameobj/CityData.cpp
+++ b/ctp2_code/gs/gameobj/CityData.cpp
@@ -11275,7 +11275,20 @@ void CityData::GiveTradeRouteGold()
 				if((route.GetSource().GetOwner() != m_owner)
 				&&(route.GetDestination().GetOwner() != m_owner)
 				){
-					g_player[m_owner]->AddGold(static_cast<sint32>(route->GetValue() * g_theConstDB->Get(0)->GetCityOnTradeRouteCoeff()));
+					sint32 tgold = static_cast<sint32>(route->GetValue() * g_theConstDB->Get(0)->GetCityOnTradeRouteCoeff());
+					g_player[m_owner]->AddGold(tgold);
+
+					Unit fromCity = route.GetSource();
+					Unit toCity = route.GetDestination();
+
+					SlicObject * so = new SlicObject("359TradePassing");
+					so->AddRecipient(GetOwner());
+					so->AddGold(tgold) ;
+					so->AddCity(m_home_city); // m_home_city should equal fromCity
+					so->AddCity(fromCity);
+					so->AddCity(toCity);
+					so->AddCivilisation(fromCity.GetOwner());
+					g_slicEngine->Execute(so);
 				}
 			}
 		}

--- a/ctp2_code/gs/gameobj/CityData.cpp
+++ b/ctp2_code/gs/gameobj/CityData.cpp
@@ -11306,6 +11306,7 @@ void CityData::GiveTradeRouteGold()
 					so->AddCity(fromCity);
 					so->AddCity(toCity);
 					so->AddCivilisation(fromCity.GetOwner());
+					so->AddCivilisation(route->GetPiratingArmy().GetOwner());
 					g_slicEngine->Execute(so);
 				    	}
 				}

--- a/ctp2_code/gs/gameobj/CityData.cpp
+++ b/ctp2_code/gs/gameobj/CityData.cpp
@@ -11276,15 +11276,16 @@ void CityData::GiveTradeRouteGold()
 				&&(route.GetDestination().GetOwner() != m_owner)
 				){
 				    sint32 tgold = static_cast<sint32>(route->GetValue() * g_theConstDB->Get(0)->GetCityOnTradeRouteCoeff());
+
+				    Unit fromCity = route.GetSource();
+				    Unit toCity = route.GetDestination();
+				    
+				    ROUTE_TYPE type;
+				    sint32 good;
+				    route.GetSourceResource(type, good);
+					
 				    if(!route->IsBeingPirated()){
 					g_player[m_owner]->AddGold(tgold);
-
-					Unit fromCity = route.GetSource();
-					Unit toCity = route.GetDestination();
-
-					ROUTE_TYPE type;
-					sint32 good;
-					route.GetSourceResource(type, good);
 					
 					SlicObject * so = new SlicObject("359TradePassing");
 					so->AddRecipient(GetOwner());
@@ -11296,9 +11297,17 @@ void CityData::GiveTradeRouteGold()
 					so->AddCivilisation(fromCity.GetOwner());
 					g_slicEngine->Execute(so);
 					}
-				    // else {
-				    // 	// message that tgold is not earned from transit due to pirating
-				    // 	}
+				    else { // message that tgold is not earned from transit due to pirating
+					SlicObject * so = new SlicObject("358TradePassingPirated");
+					so->AddRecipient(GetOwner());
+					so->AddGold(tgold) ;
+					so->AddCity(m_home_city); // m_home_city should equal fromCity
+					so->AddGood(good);
+					so->AddCity(fromCity);
+					so->AddCity(toCity);
+					so->AddCivilisation(fromCity.GetOwner());
+					g_slicEngine->Execute(so);
+				    	}
 				}
 			}
 		}

--- a/ctp2_data/chinese/gamedata/info_str.txt
+++ b/ctp2_data/chinese/gamedata/info_str.txt
@@ -156,7 +156,7 @@ TRADE_PIRATE_GOLD			"{gold[0].value} gold was pirated on the trade route carryin
 TRADE_ROUTES_BROKEN_BY_EMBARGO		"{player[0].sir_cap}，{player[1].civ_name_plural}对我采取贸易禁运，通往{player[1].country_name}的贸易路线关闭，商队悉数遭到没收。"
 TRADE_ROUTES_BROKEN_BY_WAR		"报告一个坏消息，{player[0].sir}。由于我国与{player[1].country_name}发生零星冲突，通往{player[1].civ_name_singular}的贸易路线关闭，商队悉数遭没收。"
 TRADE_PASS				"The trade route passing through our city of {city[0].name} carrying {good[0].name} from {city[1].name} to {city[2].name} owned by the {player[0].civ_name_plural} brought us {gold[0].value} gold."
-TRADE_PASS_PIRATED			"The trade route passing through our city of {city[0].name} carrying {good[0].name} from {city[1].name} to {city[2].name} owned by the {player[0].civ_name_plural} was pirated and {gold[0].value} gold from transit was not earned."
+TRADE_PASS_PIRATED			"The trade route passing through our city of {city[0].name} carrying {good[0].name} from {city[1].name} to {city[2].name} owned by the {player[0].civ_name_plural} was pirated by the {player[1].civ_name_plural} and {gold[0].value} gold from transit was not earned."
 SENDER_KILLED_TRADE_ROUTE               "{player[0].leader_name}取消了从{city[0].name}到{city[1].name}的{good[0].name}贸易路线。"
 
 ## Trade Advisor Stuff ##

--- a/ctp2_data/chinese/gamedata/info_str.txt
+++ b/ctp2_data/chinese/gamedata/info_str.txt
@@ -155,7 +155,7 @@ TRADE_PIRATED 				"，我{city[0].name}至{city[1].name}的贸易路线遭到{player[0].ci
 TRADE_PIRATE_GOLD			"{gold[0].value} gold was pirated on the trade route carrying {good[0].name} from {city[0].name} to {city[1].name} owned by {player[0].civ_name_plural}."
 TRADE_ROUTES_BROKEN_BY_EMBARGO		"{player[0].sir_cap}，{player[1].civ_name_plural}对我采取贸易禁运，通往{player[1].country_name}的贸易路线关闭，商队悉数遭到没收。"
 TRADE_ROUTES_BROKEN_BY_WAR		"报告一个坏消息，{player[0].sir}。由于我国与{player[1].country_name}发生零星冲突，通往{player[1].civ_name_singular}的贸易路线关闭，商队悉数遭没收。"
-TRADE_PASS				"The trade route passing through our city of {city[0].name} carrying goods from {city[1].name} to {city[2].name} owned by the {player[0].civ_name_plural} brought us {gold[0].value} gold."
+TRADE_PASS				"The trade route passing through our city of {city[0].name} carrying {good[0].name} from {city[1].name} to {city[2].name} owned by the {player[0].civ_name_plural} brought us {gold[0].value} gold."
 SENDER_KILLED_TRADE_ROUTE               "{player[0].leader_name}取消了从{city[0].name}到{city[1].name}的{good[0].name}贸易路线。"
 
 ## Trade Advisor Stuff ##

--- a/ctp2_data/chinese/gamedata/info_str.txt
+++ b/ctp2_data/chinese/gamedata/info_str.txt
@@ -156,6 +156,7 @@ TRADE_PIRATE_GOLD			"{gold[0].value} gold was pirated on the trade route carryin
 TRADE_ROUTES_BROKEN_BY_EMBARGO		"{player[0].sir_cap}，{player[1].civ_name_plural}对我采取贸易禁运，通往{player[1].country_name}的贸易路线关闭，商队悉数遭到没收。"
 TRADE_ROUTES_BROKEN_BY_WAR		"报告一个坏消息，{player[0].sir}。由于我国与{player[1].country_name}发生零星冲突，通往{player[1].civ_name_singular}的贸易路线关闭，商队悉数遭没收。"
 TRADE_PASS				"The trade route passing through our city of {city[0].name} carrying {good[0].name} from {city[1].name} to {city[2].name} owned by the {player[0].civ_name_plural} brought us {gold[0].value} gold."
+TRADE_PASS_PIRATED			"The trade route passing through our city of {city[0].name} carrying {good[0].name} from {city[1].name} to {city[2].name} owned by the {player[0].civ_name_plural} was pirated and {gold[0].value} gold from transit was not earned."
 SENDER_KILLED_TRADE_ROUTE               "{player[0].leader_name}取消了从{city[0].name}到{city[1].name}的{good[0].name}贸易路线。"
 
 ## Trade Advisor Stuff ##

--- a/ctp2_data/chinese/gamedata/info_str.txt
+++ b/ctp2_data/chinese/gamedata/info_str.txt
@@ -155,6 +155,7 @@ TRADE_PIRATED 				"，我{city[0].name}至{city[1].name}的贸易路线遭到{player[0].ci
 TRADE_PIRATE_GOLD			"{gold[0].value} gold was pirated on the trade route carrying {good[0].name} from {city[0].name} to {city[1].name} owned by {player[0].civ_name_plural}."
 TRADE_ROUTES_BROKEN_BY_EMBARGO		"{player[0].sir_cap}，{player[1].civ_name_plural}对我采取贸易禁运，通往{player[1].country_name}的贸易路线关闭，商队悉数遭到没收。"
 TRADE_ROUTES_BROKEN_BY_WAR		"报告一个坏消息，{player[0].sir}。由于我国与{player[1].country_name}发生零星冲突，通往{player[1].civ_name_singular}的贸易路线关闭，商队悉数遭没收。"
+TRADE_PASS				"The trade route passing through our city of {city[0].name} carrying goods from {city[1].name} to {city[2].name} owned by the {player[0].civ_name_plural} brought us {gold[0].value} gold."
 SENDER_KILLED_TRADE_ROUTE               "{player[0].leader_name}取消了从{city[0].name}到{city[1].name}的{good[0].name}贸易路线。"
 
 ## Trade Advisor Stuff ##

--- a/ctp2_data/default/gamedata/Const.txt
+++ b/ctp2_data/default/gamedata/Const.txt
@@ -390,4 +390,4 @@ CAPTURED_CITY_KILL_POP   1  # when a city is captured this number of the populat
 # Like veteran by zeroed out, possible for mods
 COMBAT_ELITE_CHANCE 0.00 
 COMBAT_LEADER_CHANCE 0.00 
-CITY_ON_TRADE_ROUTE_BONUS  0.0   # if a trade route passes through a city and the desination and source is not the same as the city owner then you get this percentage of the trade route value
+CITY_ON_TRADE_ROUTE_BONUS  0.3   # if a trade route passes through a city and the desination and source is not the same as the city owner then you get this percentage of the trade route value

--- a/ctp2_data/default/gamedata/script.slc
+++ b/ctp2_data/default/gamedata/script.slc
@@ -2356,6 +2356,11 @@ alertbox '355SessionLost' {
 	}
 }
 
+messagebox '358TradePassingPirated' {
+	Text(ID_TRADE_PASS_PIRATED) ;
+	MessageType("PIRATE");
+}
+
 messagebox '359TradePassing' {
 	Text(ID_TRADE_PASS) ;
 	MessageType("TRADE");

--- a/ctp2_data/default/gamedata/script.slc
+++ b/ctp2_data/default/gamedata/script.slc
@@ -2356,6 +2356,11 @@ alertbox '355SessionLost' {
 	}
 }
 
+messagebox '359TradePassing' {
+	Text(ID_TRADE_PASS) ;
+	MessageType("TRADE");
+}
+
 messagebox '360SenderKilledTradeRoute' {
 	Text(ID_SENDER_KILLED_TRADE_ROUTE);
 	MessageType("TRADE");

--- a/ctp2_data/english/gamedata/info_str.txt
+++ b/ctp2_data/english/gamedata/info_str.txt
@@ -155,7 +155,7 @@ TRADE_PIRATED				"Our trade route carrying {good[0].name} from {city[0].name} to
 TRADE_PIRATE_GOLD			"{gold[0].value} gold was pirated on the trade route carrying {good[0].name} from {city[0].name} to {city[1].name} owned by {player[0].civ_name_plural}."
 TRADE_ROUTES_BROKEN_BY_EMBARGO		"{player[0].sir_cap}, the {player[1].civ_name_plural} have placed an embargo on all of our trade into their nations. All existing trade routes to {player[1].country_name} have been broken! We have lost all of the caravans on those routes as well."
 TRADE_ROUTES_BROKEN_BY_WAR		"Troubling news, {player[0].sir}. Due to the sparking of conflict between us and {player[1].country_name}, all of our trade routes to {player[1].civ_name_singular} cities have been broken. All caravans assigned to those routes have been lost as well."
-TRADE_PASS				"The trade route passing through our city of {city[0].name} carrying goods from {city[1].name} to {city[2].name} owned by the {player[0].civ_name_plural} brought us {gold[0].value} gold."
+TRADE_PASS				"The trade route passing through our city of {city[0].name} carrying {good[0].name} from {city[1].name} to {city[2].name} owned by the {player[0].civ_name_plural} brought us {gold[0].value} gold."
 SENDER_KILLED_TRADE_ROUTE		"{player[0].leader_name} has cancelled the trade route carrying {good[0].name} from {city[0].name} to {city[1].name}."
 
 ## Trade Advisor Stuff ##

--- a/ctp2_data/english/gamedata/info_str.txt
+++ b/ctp2_data/english/gamedata/info_str.txt
@@ -156,6 +156,7 @@ TRADE_PIRATE_GOLD			"{gold[0].value} gold was pirated on the trade route carryin
 TRADE_ROUTES_BROKEN_BY_EMBARGO		"{player[0].sir_cap}, the {player[1].civ_name_plural} have placed an embargo on all of our trade into their nations. All existing trade routes to {player[1].country_name} have been broken! We have lost all of the caravans on those routes as well."
 TRADE_ROUTES_BROKEN_BY_WAR		"Troubling news, {player[0].sir}. Due to the sparking of conflict between us and {player[1].country_name}, all of our trade routes to {player[1].civ_name_singular} cities have been broken. All caravans assigned to those routes have been lost as well."
 TRADE_PASS				"The trade route passing through our city of {city[0].name} carrying {good[0].name} from {city[1].name} to {city[2].name} owned by the {player[0].civ_name_plural} brought us {gold[0].value} gold."
+TRADE_PASS_PIRATED			"The trade route passing through our city of {city[0].name} carrying {good[0].name} from {city[1].name} to {city[2].name} owned by the {player[0].civ_name_plural} was pirated and {gold[0].value} gold from transit was not earned."
 SENDER_KILLED_TRADE_ROUTE		"{player[0].leader_name} has cancelled the trade route carrying {good[0].name} from {city[0].name} to {city[1].name}."
 
 ## Trade Advisor Stuff ##

--- a/ctp2_data/english/gamedata/info_str.txt
+++ b/ctp2_data/english/gamedata/info_str.txt
@@ -155,6 +155,7 @@ TRADE_PIRATED				"Our trade route carrying {good[0].name} from {city[0].name} to
 TRADE_PIRATE_GOLD			"{gold[0].value} gold was pirated on the trade route carrying {good[0].name} from {city[0].name} to {city[1].name} owned by {player[0].civ_name_plural}."
 TRADE_ROUTES_BROKEN_BY_EMBARGO		"{player[0].sir_cap}, the {player[1].civ_name_plural} have placed an embargo on all of our trade into their nations. All existing trade routes to {player[1].country_name} have been broken! We have lost all of the caravans on those routes as well."
 TRADE_ROUTES_BROKEN_BY_WAR		"Troubling news, {player[0].sir}. Due to the sparking of conflict between us and {player[1].country_name}, all of our trade routes to {player[1].civ_name_singular} cities have been broken. All caravans assigned to those routes have been lost as well."
+TRADE_PASS				"The trade route passing through our city of {city[0].name} carrying goods from {city[1].name} to {city[2].name} owned by the {player[0].civ_name_plural} brought us {gold[0].value} gold."
 SENDER_KILLED_TRADE_ROUTE		"{player[0].leader_name} has cancelled the trade route carrying {good[0].name} from {city[0].name} to {city[1].name}."
 
 ## Trade Advisor Stuff ##

--- a/ctp2_data/english/gamedata/info_str.txt
+++ b/ctp2_data/english/gamedata/info_str.txt
@@ -156,7 +156,7 @@ TRADE_PIRATE_GOLD			"{gold[0].value} gold was pirated on the trade route carryin
 TRADE_ROUTES_BROKEN_BY_EMBARGO		"{player[0].sir_cap}, the {player[1].civ_name_plural} have placed an embargo on all of our trade into their nations. All existing trade routes to {player[1].country_name} have been broken! We have lost all of the caravans on those routes as well."
 TRADE_ROUTES_BROKEN_BY_WAR		"Troubling news, {player[0].sir}. Due to the sparking of conflict between us and {player[1].country_name}, all of our trade routes to {player[1].civ_name_singular} cities have been broken. All caravans assigned to those routes have been lost as well."
 TRADE_PASS				"The trade route passing through our city of {city[0].name} carrying {good[0].name} from {city[1].name} to {city[2].name} owned by the {player[0].civ_name_plural} brought us {gold[0].value} gold."
-TRADE_PASS_PIRATED			"The trade route passing through our city of {city[0].name} carrying {good[0].name} from {city[1].name} to {city[2].name} owned by the {player[0].civ_name_plural} was pirated and {gold[0].value} gold from transit was not earned."
+TRADE_PASS_PIRATED			"The trade route passing through our city of {city[0].name} carrying {good[0].name} from {city[1].name} to {city[2].name} owned by the {player[0].civ_name_plural} was pirated by the {player[1].civ_name_plural} and {gold[0].value} gold from transit was not earned."
 SENDER_KILLED_TRADE_ROUTE		"{player[0].leader_name} has cancelled the trade route carrying {good[0].name} from {city[0].name} to {city[1].name}."
 
 ## Trade Advisor Stuff ##

--- a/ctp2_data/german/gamedata/info_str.txt
+++ b/ctp2_data/german/gamedata/info_str.txt
@@ -155,7 +155,7 @@ TRADE_PIRATED				"Unser Handelsweg, der {good[0].name} von {city[0].name} nach {
 TRADE_PIRATE_GOLD			"Wir erbeuteten {gold[0].value} Gold als wir den Handelsweg von {player[0].civ_name_plural#DAT} überfiehlen, der {good[0].name} von {city[0].name} nach {city[1].name} bringt."
 TRADE_ROUTES_BROKEN_BY_EMBARGO		"{player[0].leader_name#SIR_CAP}, die {player[1].civ_name_plural} haben ein Handelsembargo gegen uns verhengt. Der Handel auf allen Handelswege {player[1].country_name#TOWARDS} wurde eingestellt! Außerdem haben wir alle Karawanen auf diesen Routen verloren."
 TRADE_ROUTES_BROKEN_BY_WAR		"Es gibt beunruhigende Neuigkeiten, {player[0].leader_name#SIR_CAP}. Wegen des zwischen uns und {player[1].country_name#DAT} entbrannten Konflikts wurde der Handel auf unseren Handelswegen, die in {player[1].civ_name_singular#UNDEF_PLURAL_ACC} Städte führen, eingestellt. Außerdem haben wir alle Karawanen, die dort unterwegs waren, verloren."
-TRADE_PASS				"Der Handelsweg von den {player[0].civ_name_plural} durch unsere Stadt {city[0].name}, welcher Güter von {city[1].name} nach {city[2].name} bringt, brachte uns {gold[0].value} Gold."
+TRADE_PASS				"Der Handelsweg von den {player[0].civ_name_plural} durch unsere Stadt {city[0].name}, welcher {good[0].name#PLURAL} von {city[1].name} nach {city[2].name} bringt, brachte uns {gold[0].value} Gold."
 SENDER_KILLED_TRADE_ROUTE		"{player[0].leader_name} hat den Handelsweg für den Handel mit {good[0].name#PLURAL} von {city[0].name} nach {city[1].name} eingestellt."
 
 ## Trade Advisor Stuff ##

--- a/ctp2_data/german/gamedata/info_str.txt
+++ b/ctp2_data/german/gamedata/info_str.txt
@@ -155,6 +155,7 @@ TRADE_PIRATED				"Unser Handelsweg, der {good[0].name} von {city[0].name} nach {
 TRADE_PIRATE_GOLD			"Wir erbeuteten {gold[0].value} Gold als wir den Handelsweg von {player[0].civ_name_plural#DAT} überfiehlen, der {good[0].name} von {city[0].name} nach {city[1].name} bringt."
 TRADE_ROUTES_BROKEN_BY_EMBARGO		"{player[0].leader_name#SIR_CAP}, die {player[1].civ_name_plural} haben ein Handelsembargo gegen uns verhengt. Der Handel auf allen Handelswege {player[1].country_name#TOWARDS} wurde eingestellt! Außerdem haben wir alle Karawanen auf diesen Routen verloren."
 TRADE_ROUTES_BROKEN_BY_WAR		"Es gibt beunruhigende Neuigkeiten, {player[0].leader_name#SIR_CAP}. Wegen des zwischen uns und {player[1].country_name#DAT} entbrannten Konflikts wurde der Handel auf unseren Handelswegen, die in {player[1].civ_name_singular#UNDEF_PLURAL_ACC} Städte führen, eingestellt. Außerdem haben wir alle Karawanen, die dort unterwegs waren, verloren."
+TRADE_PASS				"Der Handelsweg von den {player[0].civ_name_plural} durch unsere Stadt {city[0].name}, welcher Güter von {city[1].name} nach {city[2].name} bringt, brachte uns {gold[0].value} Gold."
 SENDER_KILLED_TRADE_ROUTE		"{player[0].leader_name} hat den Handelsweg für den Handel mit {good[0].name#PLURAL} von {city[0].name} nach {city[1].name} eingestellt."
 
 ## Trade Advisor Stuff ##

--- a/ctp2_data/german/gamedata/info_str.txt
+++ b/ctp2_data/german/gamedata/info_str.txt
@@ -156,6 +156,7 @@ TRADE_PIRATE_GOLD			"Wir erbeuteten {gold[0].value} Gold als wir den Handelsweg 
 TRADE_ROUTES_BROKEN_BY_EMBARGO		"{player[0].leader_name#SIR_CAP}, die {player[1].civ_name_plural} haben ein Handelsembargo gegen uns verhengt. Der Handel auf allen Handelswege {player[1].country_name#TOWARDS} wurde eingestellt! Außerdem haben wir alle Karawanen auf diesen Routen verloren."
 TRADE_ROUTES_BROKEN_BY_WAR		"Es gibt beunruhigende Neuigkeiten, {player[0].leader_name#SIR_CAP}. Wegen des zwischen uns und {player[1].country_name#DAT} entbrannten Konflikts wurde der Handel auf unseren Handelswegen, die in {player[1].civ_name_singular#UNDEF_PLURAL_ACC} Städte führen, eingestellt. Außerdem haben wir alle Karawanen, die dort unterwegs waren, verloren."
 TRADE_PASS				"Der Handelsweg von den {player[0].civ_name_plural} durch unsere Stadt {city[0].name}, welcher {good[0].name#PLURAL} von {city[1].name} nach {city[2].name} bringt, brachte uns {gold[0].value} Gold."
+TRADE_PASS_PIRATED			"Der Handelsweg von den {player[0].civ_name_plural} durch unsere Stadt {city[0].name}, welcher {good[0].name#PLURAL} von {city[1].name} nach {city[2].name} bringt, wurde überfallen und {gold[0].value} Gold durch den Transit wurden nicht erwirtschafted."
 SENDER_KILLED_TRADE_ROUTE		"{player[0].leader_name} hat den Handelsweg für den Handel mit {good[0].name#PLURAL} von {city[0].name} nach {city[1].name} eingestellt."
 
 ## Trade Advisor Stuff ##

--- a/ctp2_data/german/gamedata/info_str.txt
+++ b/ctp2_data/german/gamedata/info_str.txt
@@ -156,7 +156,7 @@ TRADE_PIRATE_GOLD			"Wir erbeuteten {gold[0].value} Gold als wir den Handelsweg 
 TRADE_ROUTES_BROKEN_BY_EMBARGO		"{player[0].leader_name#SIR_CAP}, die {player[1].civ_name_plural} haben ein Handelsembargo gegen uns verhengt. Der Handel auf allen Handelswege {player[1].country_name#TOWARDS} wurde eingestellt! Außerdem haben wir alle Karawanen auf diesen Routen verloren."
 TRADE_ROUTES_BROKEN_BY_WAR		"Es gibt beunruhigende Neuigkeiten, {player[0].leader_name#SIR_CAP}. Wegen des zwischen uns und {player[1].country_name#DAT} entbrannten Konflikts wurde der Handel auf unseren Handelswegen, die in {player[1].civ_name_singular#UNDEF_PLURAL_ACC} Städte führen, eingestellt. Außerdem haben wir alle Karawanen, die dort unterwegs waren, verloren."
 TRADE_PASS				"Der Handelsweg von den {player[0].civ_name_plural} durch unsere Stadt {city[0].name}, welcher {good[0].name#PLURAL} von {city[1].name} nach {city[2].name} bringt, brachte uns {gold[0].value} Gold."
-TRADE_PASS_PIRATED			"Der Handelsweg von den {player[0].civ_name_plural} durch unsere Stadt {city[0].name}, welcher {good[0].name#PLURAL} von {city[1].name} nach {city[2].name} bringt, wurde überfallen und {gold[0].value} Gold durch den Transit wurden nicht erwirtschafted."
+TRADE_PASS_PIRATED			"Der Handelsweg von den {player[0].civ_name_plural} durch unsere Stadt {city[0].name}, welcher {good[0].name#PLURAL} von {city[1].name} nach {city[2].name} bringt, wurde von den {player[1].civ_name_plural} überfallen und {gold[0].value} Gold durch den Transit wurden nicht erwirtschafted."
 SENDER_KILLED_TRADE_ROUTE		"{player[0].leader_name} hat den Handelsweg für den Handel mit {good[0].name#PLURAL} von {city[0].name} nach {city[1].name} eingestellt."
 
 ## Trade Advisor Stuff ##

--- a/ctp2_data/italian/gamedata/info_str.txt
+++ b/ctp2_data/italian/gamedata/info_str.txt
@@ -155,7 +155,7 @@ TRADE_PIRATED				"La nostra rotta commerciale da  {good[0].name} {city[0].name} 
 TRADE_PIRATE_GOLD			"{gold[0].value} gold was pirated on the trade route carrying {good[0].name} from {city[0].name} to {city[1].name} owned by {player[0].civ_name_plural}."
 TRADE_ROUTES_BROKEN_BY_EMBARGO		"{player[0].sir_cap}, {player[1].civ_name_plural#ARTICLE} hanno deciso l'embargo contro di noi in ogni loro nazione. Tutte le rotte esistenti verso {player[1].country_name#ARTICLE} sono state eliminate! Inoltra, abbiamo perso tutte le carovane che si trovavano su quelle vie."
 TRADE_ROUTES_BROKEN_BY_WAR		"Brutte notizie, {player[0].sir}. A causa del conflitto scoppiato fra noi e {player[1].civ_name_plural#ARTICLE}, tutte le nostre rotte commerciali verso le città {player[1].country_name#ARTICLED_PREPOSITION} sono state bloccate. Tutte le carovane presenti su quelle rotte sono andate perse."
-TRADE_PASS				"The trade route passing through our city of {city[0].name} carrying goods from {city[1].name} to {city[2].name} owned by the {player[0].civ_name_plural} brought us {gold[0].value} gold."
+TRADE_PASS				"The trade route passing through our city of {city[0].name} carrying {good[0].name} from {city[1].name} to {city[2].name} owned by the {player[0].civ_name_plural} brought us {gold[0].value} gold."
 SENDER_KILLED_TRADE_ROUTE		"{player[0].leader_name} ha chiuso la rotta commerciale che trasportava {good[0].name} da {city[0].name} a {city[1].name}."
 
 ## Trade Advisor Stuff ##

--- a/ctp2_data/italian/gamedata/info_str.txt
+++ b/ctp2_data/italian/gamedata/info_str.txt
@@ -156,6 +156,7 @@ TRADE_PIRATE_GOLD			"{gold[0].value} gold was pirated on the trade route carryin
 TRADE_ROUTES_BROKEN_BY_EMBARGO		"{player[0].sir_cap}, {player[1].civ_name_plural#ARTICLE} hanno deciso l'embargo contro di noi in ogni loro nazione. Tutte le rotte esistenti verso {player[1].country_name#ARTICLE} sono state eliminate! Inoltra, abbiamo perso tutte le carovane che si trovavano su quelle vie."
 TRADE_ROUTES_BROKEN_BY_WAR		"Brutte notizie, {player[0].sir}. A causa del conflitto scoppiato fra noi e {player[1].civ_name_plural#ARTICLE}, tutte le nostre rotte commerciali verso le città {player[1].country_name#ARTICLED_PREPOSITION} sono state bloccate. Tutte le carovane presenti su quelle rotte sono andate perse."
 TRADE_PASS				"The trade route passing through our city of {city[0].name} carrying {good[0].name} from {city[1].name} to {city[2].name} owned by the {player[0].civ_name_plural} brought us {gold[0].value} gold."
+TRADE_PASS_PIRATED			"The trade route passing through our city of {city[0].name} carrying {good[0].name} from {city[1].name} to {city[2].name} owned by the {player[0].civ_name_plural} was pirated and {gold[0].value} gold from transit was not earned."
 SENDER_KILLED_TRADE_ROUTE		"{player[0].leader_name} ha chiuso la rotta commerciale che trasportava {good[0].name} da {city[0].name} a {city[1].name}."
 
 ## Trade Advisor Stuff ##

--- a/ctp2_data/italian/gamedata/info_str.txt
+++ b/ctp2_data/italian/gamedata/info_str.txt
@@ -155,6 +155,7 @@ TRADE_PIRATED				"La nostra rotta commerciale da  {good[0].name} {city[0].name} 
 TRADE_PIRATE_GOLD			"{gold[0].value} gold was pirated on the trade route carrying {good[0].name} from {city[0].name} to {city[1].name} owned by {player[0].civ_name_plural}."
 TRADE_ROUTES_BROKEN_BY_EMBARGO		"{player[0].sir_cap}, {player[1].civ_name_plural#ARTICLE} hanno deciso l'embargo contro di noi in ogni loro nazione. Tutte le rotte esistenti verso {player[1].country_name#ARTICLE} sono state eliminate! Inoltra, abbiamo perso tutte le carovane che si trovavano su quelle vie."
 TRADE_ROUTES_BROKEN_BY_WAR		"Brutte notizie, {player[0].sir}. A causa del conflitto scoppiato fra noi e {player[1].civ_name_plural#ARTICLE}, tutte le nostre rotte commerciali verso le città {player[1].country_name#ARTICLED_PREPOSITION} sono state bloccate. Tutte le carovane presenti su quelle rotte sono andate perse."
+TRADE_PASS				"The trade route passing through our city of {city[0].name} carrying goods from {city[1].name} to {city[2].name} owned by the {player[0].civ_name_plural} brought us {gold[0].value} gold."
 SENDER_KILLED_TRADE_ROUTE		"{player[0].leader_name} ha chiuso la rotta commerciale che trasportava {good[0].name} da {city[0].name} a {city[1].name}."
 
 ## Trade Advisor Stuff ##

--- a/ctp2_data/italian/gamedata/info_str.txt
+++ b/ctp2_data/italian/gamedata/info_str.txt
@@ -156,7 +156,7 @@ TRADE_PIRATE_GOLD			"{gold[0].value} gold was pirated on the trade route carryin
 TRADE_ROUTES_BROKEN_BY_EMBARGO		"{player[0].sir_cap}, {player[1].civ_name_plural#ARTICLE} hanno deciso l'embargo contro di noi in ogni loro nazione. Tutte le rotte esistenti verso {player[1].country_name#ARTICLE} sono state eliminate! Inoltra, abbiamo perso tutte le carovane che si trovavano su quelle vie."
 TRADE_ROUTES_BROKEN_BY_WAR		"Brutte notizie, {player[0].sir}. A causa del conflitto scoppiato fra noi e {player[1].civ_name_plural#ARTICLE}, tutte le nostre rotte commerciali verso le città {player[1].country_name#ARTICLED_PREPOSITION} sono state bloccate. Tutte le carovane presenti su quelle rotte sono andate perse."
 TRADE_PASS				"The trade route passing through our city of {city[0].name} carrying {good[0].name} from {city[1].name} to {city[2].name} owned by the {player[0].civ_name_plural} brought us {gold[0].value} gold."
-TRADE_PASS_PIRATED			"The trade route passing through our city of {city[0].name} carrying {good[0].name} from {city[1].name} to {city[2].name} owned by the {player[0].civ_name_plural} was pirated and {gold[0].value} gold from transit was not earned."
+TRADE_PASS_PIRATED			"The trade route passing through our city of {city[0].name} carrying {good[0].name} from {city[1].name} to {city[2].name} owned by the {player[0].civ_name_plural} was pirated by the {player[1].civ_name_plural} and {gold[0].value} gold from transit was not earned."
 SENDER_KILLED_TRADE_ROUTE		"{player[0].leader_name} ha chiuso la rotta commerciale che trasportava {good[0].name} da {city[0].name} a {city[1].name}."
 
 ## Trade Advisor Stuff ##

--- a/ctp2_data/spanish/gamedata/info_str.txt
+++ b/ctp2_data/spanish/gamedata/info_str.txt
@@ -156,7 +156,7 @@ TRADE_PIRATE_GOLD			"{gold[0].value} gold was pirated on the trade route carryin
 TRADE_ROUTES_BROKEN_BY_EMBARGO		"{player[0].sir_cap}, los {player[1].civ_name_plural} han impuesto un embargo sobre todas nuestras relaciones comerciales en todas sus naciones. ¡Han cortado todas nuestras rutas comerciales con {player[1].country_name}. Además hemos perdido todas las caravanas que estaban en esas rutas."
 TRADE_ROUTES_BROKEN_BY_WAR		"Malas noticias, {player[0].sir}. Debido al conflicto que ha brotado entre nosotros y {player[1].country_name}, se han cortado todas las rutas comerciales con las ciudades de {player[1].civ_name_singular}. Y además hemos perdido las caravanas que estaban en esas rutas."
 TRADE_PASS				"The trade route passing through our city of {city[0].name} carrying {good[0].name} from {city[1].name} to {city[2].name} owned by the {player[0].civ_name_plural} brought us {gold[0].value} gold."
-TRADE_PASS_PIRATED			"The trade route passing through our city of {city[0].name} carrying {good[0].name} from {city[1].name} to {city[2].name} owned by the {player[0].civ_name_plural} was pirated and {gold[0].value} gold from transit was not earned."
+TRADE_PASS_PIRATED			"The trade route passing through our city of {city[0].name} carrying {good[0].name} from {city[1].name} to {city[2].name} owned by the {player[0].civ_name_plural} was pirated by the {player[1].civ_name_plural} and {gold[0].value} gold from transit was not earned."
 SENDER_KILLED_TRADE_ROUTE		"{player[0].leader_name} ha cancelado la ruta comercial por la que se lleva {good[0].name} de {city[0].name} a {city[1].name}."
 
 ## Trade Advisor Stuff ##

--- a/ctp2_data/spanish/gamedata/info_str.txt
+++ b/ctp2_data/spanish/gamedata/info_str.txt
@@ -156,6 +156,7 @@ TRADE_PIRATE_GOLD			"{gold[0].value} gold was pirated on the trade route carryin
 TRADE_ROUTES_BROKEN_BY_EMBARGO		"{player[0].sir_cap}, los {player[1].civ_name_plural} han impuesto un embargo sobre todas nuestras relaciones comerciales en todas sus naciones. ¡Han cortado todas nuestras rutas comerciales con {player[1].country_name}. Además hemos perdido todas las caravanas que estaban en esas rutas."
 TRADE_ROUTES_BROKEN_BY_WAR		"Malas noticias, {player[0].sir}. Debido al conflicto que ha brotado entre nosotros y {player[1].country_name}, se han cortado todas las rutas comerciales con las ciudades de {player[1].civ_name_singular}. Y además hemos perdido las caravanas que estaban en esas rutas."
 TRADE_PASS				"The trade route passing through our city of {city[0].name} carrying {good[0].name} from {city[1].name} to {city[2].name} owned by the {player[0].civ_name_plural} brought us {gold[0].value} gold."
+TRADE_PASS_PIRATED			"The trade route passing through our city of {city[0].name} carrying {good[0].name} from {city[1].name} to {city[2].name} owned by the {player[0].civ_name_plural} was pirated and {gold[0].value} gold from transit was not earned."
 SENDER_KILLED_TRADE_ROUTE		"{player[0].leader_name} ha cancelado la ruta comercial por la que se lleva {good[0].name} de {city[0].name} a {city[1].name}."
 
 ## Trade Advisor Stuff ##

--- a/ctp2_data/spanish/gamedata/info_str.txt
+++ b/ctp2_data/spanish/gamedata/info_str.txt
@@ -155,6 +155,7 @@ TRADE_PIRATED				"Nuestra ruta comercial de  {good[0].name} {city[0].name} a {ci
 TRADE_PIRATE_GOLD			"{gold[0].value} gold was pirated on the trade route carrying {good[0].name} from {city[0].name} to {city[1].name} owned by {player[0].civ_name_plural}."
 TRADE_ROUTES_BROKEN_BY_EMBARGO		"{player[0].sir_cap}, los {player[1].civ_name_plural} han impuesto un embargo sobre todas nuestras relaciones comerciales en todas sus naciones. ¡Han cortado todas nuestras rutas comerciales con {player[1].country_name}. Además hemos perdido todas las caravanas que estaban en esas rutas."
 TRADE_ROUTES_BROKEN_BY_WAR		"Malas noticias, {player[0].sir}. Debido al conflicto que ha brotado entre nosotros y {player[1].country_name}, se han cortado todas las rutas comerciales con las ciudades de {player[1].civ_name_singular}. Y además hemos perdido las caravanas que estaban en esas rutas."
+TRADE_PASS				"The trade route passing through our city of {city[0].name} carrying goods from {city[1].name} to {city[2].name} owned by the {player[0].civ_name_plural} brought us {gold[0].value} gold."
 SENDER_KILLED_TRADE_ROUTE		"{player[0].leader_name} ha cancelado la ruta comercial por la que se lleva {good[0].name} de {city[0].name} a {city[1].name}."
 
 ## Trade Advisor Stuff ##

--- a/ctp2_data/spanish/gamedata/info_str.txt
+++ b/ctp2_data/spanish/gamedata/info_str.txt
@@ -155,7 +155,7 @@ TRADE_PIRATED				"Nuestra ruta comercial de  {good[0].name} {city[0].name} a {ci
 TRADE_PIRATE_GOLD			"{gold[0].value} gold was pirated on the trade route carrying {good[0].name} from {city[0].name} to {city[1].name} owned by {player[0].civ_name_plural}."
 TRADE_ROUTES_BROKEN_BY_EMBARGO		"{player[0].sir_cap}, los {player[1].civ_name_plural} han impuesto un embargo sobre todas nuestras relaciones comerciales en todas sus naciones. ¡Han cortado todas nuestras rutas comerciales con {player[1].country_name}. Además hemos perdido todas las caravanas que estaban en esas rutas."
 TRADE_ROUTES_BROKEN_BY_WAR		"Malas noticias, {player[0].sir}. Debido al conflicto que ha brotado entre nosotros y {player[1].country_name}, se han cortado todas las rutas comerciales con las ciudades de {player[1].civ_name_singular}. Y además hemos perdido las caravanas que estaban en esas rutas."
-TRADE_PASS				"The trade route passing through our city of {city[0].name} carrying goods from {city[1].name} to {city[2].name} owned by the {player[0].civ_name_plural} brought us {gold[0].value} gold."
+TRADE_PASS				"The trade route passing through our city of {city[0].name} carrying {good[0].name} from {city[1].name} to {city[2].name} owned by the {player[0].civ_name_plural} brought us {gold[0].value} gold."
 SENDER_KILLED_TRADE_ROUTE		"{player[0].leader_name} ha cancelado la ruta comercial por la que se lleva {good[0].name} de {city[0].name} a {city[1].name}."
 
 ## Trade Advisor Stuff ##


### PR DESCRIPTION

This PR re-enables the former bonus for trade routes through a city (which was disabled for unobvious reasons in https://github.com/civctp2/civctp2/commit/174224ad9acee585a40fb28d8f9bd46a1f5e4c07) and informs the recipent about this fact. The bonus can be seen like gold from tax on trade transit or from local trade arising from the transit.

The nice thing about this concept is that it can make it more profitable to treat a transit trade route well instead of pirating it because the bonus is added for every transit sity so if more than (currently) 3 transit cities are on a route the overall bonus of the transit is higher than the pirating value.  In the case of the screen shot below, the trade route passes through 4 cities (Comisense, Esfahan, Washington and Chicago):
![ss_2019-04-30_13:08:23](https://user-images.githubusercontent.com/21012234/56957964-217aee80-6b49-11e9-81d1-55f907402c0c.png)
yielding in total `4 * 22 = 88` instead of just `59` in case of successful piracy (which increases the probability that the owner cancels the route):

![ss_2019-04-30_13:21:07](https://user-images.githubusercontent.com/21012234/56970593-bdb3ee00-6b67-11e9-8871-6621a47949b9.png)

With https://github.com/civctp2/civctp2/pull/126/commits/f4e72d2675be3acb9290a7144488081d4c40377a no transit gold will be given if the route is pirated, either by oneself or others, motivating to look for pirates even on other civs routes. Therefore it might be a good to have another message in case of piracy telling who pirates that foreign route, which is currently not possible with the bug behind #75. If that is solved and the message works as epxected the message of https://github.com/civctp2/civctp2/pull/126/commits/a22052722a3eef1925f038b9484bb3ad9cf7b1b9 could actually be removed to reduce the message flood, since a player will get to know about this game concept as soon as he or other pirate such a transit route through one of his cities (thought this would be kind of quite an indirect info).

