### PR TITLE
Debug piracy issue

### DIFF
--- a/ctp2_code/gs/gameobj/Army.cpp
+++ b/ctp2_code/gs/gameobj/Army.cpp
@@ -56,7 +56,7 @@ void Army::KillArmy()
 
 	CAUSE_REMOVE_ARMY cause = GetRemoveCause();
 
-	AccessData()->StopPirating();
+	AccessData()->StopPirating(); // do not execute pirating if army gets killed
 
 	Army tmp(*this);
 	tmp.SetRemoveCause(cause);

--- a/ctp2_code/gs/gameobj/ArmyData.cpp
+++ b/ctp2_code/gs/gameobj/ArmyData.cpp
@@ -6201,7 +6201,9 @@ void ArmyData::AddOrders(UNIT_ORDER_TYPE order, Path *path, const MapPoint &poin
 		}
 	}
 
-	StopPirating(); // why?
+	if(point != m_pos || order != UNIT_ORDER_INTERCEPT_TRADE){
+	    StopPirating(); // to ensure trade route is not regarded as pirated when moving off (which is not possible any more on the new position, see https://github.com/civctp2/civctp2/issues/75
+	    }
 
 	Order *o = m_orders->GetTail();
 	if(g_network.IsHost()) {

--- a/ctp2_code/gs/gameobj/ArmyData.cpp
+++ b/ctp2_code/gs/gameobj/ArmyData.cpp
@@ -6054,7 +6054,10 @@ void ArmyData::AutoAddOrders(UNIT_ORDER_TYPE order, Path *path,
 	}
 
 	m_orders->AddTail(new Order(order, path, point, argument));
-	StopPirating(); // why?
+
+	if(point != m_pos || order != UNIT_ORDER_INTERCEPT_TRADE){
+	    StopPirating(); // to ensure trade route is not regarded as pirated when moving off (which is not possible any more on the new position, see https://github.com/civctp2/civctp2/issues/75
+	    }
 
 	if(m_owner >= 0 && m_owner < k_MAX_PLAYERS && g_player[m_owner])
 	{
@@ -6092,7 +6095,10 @@ void ArmyData::AutoAddOrdersWrongTurn(UNIT_ORDER_TYPE order, Path *path,
 	ClearOrders();
 
 	m_orders->AddTail(new Order(order, path, point, argument));
-	StopPirating(); // why?
+
+	if(point != m_pos || order != UNIT_ORDER_INTERCEPT_TRADE){
+	    StopPirating(); // to ensure trade route is not regarded as pirated when moving off (which is not possible any more on the new position, see https://github.com/civctp2/civctp2/issues/75
+	    }
 
 	if(m_owner >= 0 && m_owner < k_MAX_PLAYERS && g_player[m_owner]) {
 		ExecuteOrders(false);

--- a/ctp2_code/gs/gameobj/ArmyData.cpp
+++ b/ctp2_code/gs/gameobj/ArmyData.cpp
@@ -1701,7 +1701,7 @@ void ArmyData::BeginTurn()
                 }
             }
             if(piratedByMe < 1) {
-                StopPirating();
+                StopPirating(); // if no route was successfully pirated by me, which happens if routes got removed; moving the army/unit along a route also calls StopPirating probably from AddOrders or AutoAddOrders
             }
         }
     }
@@ -6054,7 +6054,7 @@ void ArmyData::AutoAddOrders(UNIT_ORDER_TYPE order, Path *path,
 	}
 
 	m_orders->AddTail(new Order(order, path, point, argument));
-	StopPirating();
+	StopPirating(); // why?
 
 	if(m_owner >= 0 && m_owner < k_MAX_PLAYERS && g_player[m_owner])
 	{
@@ -6092,7 +6092,7 @@ void ArmyData::AutoAddOrdersWrongTurn(UNIT_ORDER_TYPE order, Path *path,
 	ClearOrders();
 
 	m_orders->AddTail(new Order(order, path, point, argument));
-	StopPirating();
+	StopPirating(); // why?
 
 	if(m_owner >= 0 && m_owner < k_MAX_PLAYERS && g_player[m_owner]) {
 		ExecuteOrders(false);
@@ -6201,7 +6201,7 @@ void ArmyData::AddOrders(UNIT_ORDER_TYPE order, Path *path, const MapPoint &poin
 		}
 	}
 
-	StopPirating();
+	StopPirating(); // why?
 
 	Order *o = m_orders->GetTail();
 	if(g_network.IsHost()) {


### PR DESCRIPTION
This PR solves the issue of #75, i.e. that the player does not get a colored square in the piracy column of the trade manager, nor the diplomatic option to ask for stopping piracy (#116) and is the base for PRs like #125 and #126.