### PR TITLE
Save and load piracy history

### DIFF
--- a/ctp2_code/ai/diplomacy/Diplomat.h
+++ b/ctp2_code/ai/diplomacy/Diplomat.h
@@ -75,40 +75,6 @@ class Diplomat;
 class Diplomat
 {
 public:
-	struct PiracyHistory
-	{
-		PiracyHistory()
-		:
-		    m_sourceCity        (),
-		    m_destinationCity   (),
-		    m_piratingPlayer    (PLAYER_UNASSIGNED),
-		    m_accumEvents       (0),
-		    m_lastTurn          (-1)
-		{ };
-
-		bool operator<(const PiracyHistory & rval) const
-			{
-				if (m_sourceCity.m_id < rval.m_sourceCity.m_id &&
-					m_destinationCity.m_id < rval.m_destinationCity.m_id &&
-					m_piratingPlayer < rval.m_piratingPlayer)
-					return true;
-				return false;
-			}
-
-		bool operator==(const PiracyHistory & rval) const
-			{
-				if (m_sourceCity.m_id == rval.m_sourceCity.m_id &&
-					m_destinationCity.m_id == rval.m_destinationCity.m_id &&
-					m_piratingPlayer == rval.m_piratingPlayer )
-					return true;
-				return false;
-			}
-		Unit m_sourceCity;
-		Unit m_destinationCity;
-		PLAYER_INDEX m_piratingPlayer;
-		sint32 m_accumEvents;
-		sint32 m_lastTurn;
-	};
 
 	typedef std::list<Motivation> MotivationList;
 	typedef std::vector<MotivationList::iterator> MotivationVector;
@@ -117,7 +83,6 @@ public:
 	typedef std::list<Threat> ThreatList;
 	typedef std::vector<DiplomacyRecord> DiplomacyRecordVector;
 	typedef std::vector<Diplomat> DiplomatVector;
-	typedef std::list<PiracyHistory> PiracyHistoryList;
 	typedef std::list<AiState> AiStateList;
 	typedef std::list<std::pair<sint32, Unit> > NukeTargetList;
 	typedef std::vector<bool> BoolVector;
@@ -131,18 +96,10 @@ public:
 
 	static sint32 s_proposalTypeToElemIndex[PROPOSAL_MAX];
 
-
-
-
-
-
 	static Diplomat & GetDiplomat(const PLAYER_INDEX & playerId);
 	static bool HasDiplomat(const PLAYER_INDEX & playerId);
 
 	static void ResizeAll(const PLAYER_INDEX & newMaxPlayers);
-
-
-
 
 	static void CleanupAll();
 
@@ -161,10 +118,6 @@ public:
 	sint32 GetNextId();
 
 	void SetNextId(const sint32 & id);
-
-
-
-
 
 	Diplomat();
 	Diplomat(Diplomat const & a_Original);
@@ -204,12 +157,6 @@ public:
 
 	void BeginTurn();
 
-
-
-
-
-
-
 	void LogRegardEvent( const PLAYER_INDEX & foreignerId,
 						 const sint32 & regardDelta,
 						 const REGARD_EVENT_TYPE & type,
@@ -220,7 +167,6 @@ public:
 
 	const ai::Regard GetPublicRegard( const PLAYER_INDEX & foreignerId,
 									  const REGARD_EVENT_TYPE & type = REGARD_EVENT_ALL ) const;
-
 
 	StringId ExplainRegard( const PLAYER_INDEX & foreignerId,
 						  const REGARD_EVENT_TYPE & type = REGARD_EVENT_ALL ) const;
@@ -241,17 +187,9 @@ public:
 
 	void UpdateRegard(const PLAYER_INDEX foreignerId);
 
-
-
-
-
-
-
-
 	sint32 AddAgreement(const PLAYER_INDEX & foreignerId);
 
 	void EnactStopPiracy(const PLAYER_INDEX victimId, const PLAYER_INDEX pirateId);
-
 
 	bool CanAfford( const PLAYER_INDEX senderId,
 					const PLAYER_INDEX receiverId,
@@ -265,30 +203,17 @@ public:
 
 	bool GetEmbargo(const PLAYER_INDEX foreignerId) const;
 
-
-
-
-
-
-
 	void AddRejection(const PLAYER_INDEX & foreignerId);
-
-
-
-
-
 
 	const Threat & GetThreatById(const sint32 & id) const;
 
 	void RemoveThreatById(const sint32 & id);
-
 
 	sint32 AddThreat(const PLAYER_INDEX & foreignerId);
 
 	const ThreatList & GetThreatList() const;
 
 	bool ExecuteThreat(const Threat & threat);
-
 
 	bool HasThreat(const PLAYER_INDEX & foreignerId,
 				   const THREAT_TYPE type,
@@ -297,11 +222,6 @@ public:
 	bool ComputeThreatResponse(const PLAYER_INDEX foreignerId, Response & threat_response) const;
 
 	bool GetAgreementToBreak(const PLAYER_INDEX foreignerId, ai::Agreement & pact) const;
-
-
-
-
-
 
 	void ConsiderResponse( const PLAYER_INDEX & senderId,
 						   const Response & response );
@@ -324,26 +244,11 @@ public:
 	void ExecuteResponse( const PLAYER_INDEX sender,
 						  const PLAYER_INDEX receiver );
 
-
-
-
 	const Response & GetResponsePending(const PLAYER_INDEX foreignerId) const;
 
 	const Response & GetResponse(const PLAYER_INDEX foreignerId) const;
 
 	void ExecuteResponse(const Response & response, bool runAI = true);
-
-
-
-
-
-
-
-
-
-
-
-
 
 	void ConsiderMotivation(const Motivation & motivation);
 
@@ -353,16 +258,7 @@ public:
 
 	const Motivation & GetCurrentMotivation() const;
 
-
 	StringId GetDiplomacyAdvice(SlicContext & sc, const PLAYER_INDEX & foreignerId = -1) const;
-
-
-
-
-
-
-
-
 
 	void ContinueDiplomacy( const PLAYER_INDEX & foreignerId );
 
@@ -415,9 +311,6 @@ public:
 	sint32 GetViolationTrustCost(const PLAYER_INDEX foreignerId,
 					 			 const PROPOSAL_TYPE proposalType ) const;
 
-
-
-
 	const NewProposal & GetNewProposalPending(const PLAYER_INDEX foreignerId) const;
 
 	const NewProposal & GetNewProposalAdvice(const PLAYER_INDEX foreignerId) const;
@@ -433,11 +326,6 @@ public:
 	void ComputeCurrentStrategy();
 
 	const StrategyRecord & GetCurrentStrategy() const;
-
-
-
-
-
 
 	void InitDiplomaticState( const PLAYER_INDEX & foreignerId );
 
@@ -455,11 +343,6 @@ public:
 
 	const DiplomacyRecord & GetCurrentDiplomacy(const PLAYER_INDEX & foreignerId) const;
 
-
-
-
-
-
 	sint32 GetNextAdvance() const;
 
 	sint32 GetDesiredAdvanceFrom( const PLAYER_INDEX & foreignerId, const sint32 min_cost, const sint32 max_cost ) const;
@@ -469,11 +352,6 @@ public:
 	sint32 GetNextKeyAdvance() const;
 
 	StringId GetScienceAdvice(SlicContext & sc, StringId & advance_advice);
-
-
-
-
-
 
 	sint32 GetTradeFrom(const PLAYER_INDEX &foreignId) const;
 
@@ -528,7 +406,6 @@ public:
 	void SetColdwarAttack(const PLAYER_INDEX foreignerId, const sint16 last_cold_war_attack);
 
 	sint32 GetLastColdwarAttack(const PLAYER_INDEX foreignerId) const;
-
 
 	PLAYER_INDEX ComputeNuclearLaunchTarget();
 
@@ -586,8 +463,6 @@ private:
 	static sint32 s_nextId;
 	static Diplomat::DiplomatVector s_theDiplomats;
 
-	void RemoveBestMotivation();
-
 	void UpdateAttributes();
 
 	void MergeStrategy(const sint32 index);
@@ -598,7 +473,6 @@ private:
 						   const DiplomacyArg & argument );
 
 	void ComputeTradeRoutePiracyRisk();
-
 
 	bool LaunchNuclearAttackOnCity(const Unit & city);
 
@@ -612,19 +486,9 @@ private:
 
 	void ExecutePersistantAgreements();
 
-
-
-
-
-
 	PLAYER_INDEX m_playerId;
 	std::string m_personalityName;
 	const PersonalityRecord *m_personality;
-
-
-
-
-
 
 	MotivationList m_motivations;
 
@@ -644,16 +508,10 @@ private:
 
 	ThreatList m_threats;
 
-
-
-
-
 	sint8 m_friendCount;
 	sint8 m_enemyCount;
 	sint32 m_friendPower;
 	sint32 m_enemyThreat;
-
-	PiracyHistoryList m_piracyHistory;
 
 	uint32 m_incursionPermission;
 
@@ -669,13 +527,6 @@ private:
 	bool m_launchedNanoAttack;
 	BoolVector m_desireWarWith;
 
-
-
-
-
-
-
-
 	bool ComputeEffectiveRegard(const PLAYER_INDEX & foreignerId, const ai::Regard & test_regard) const;
 
 	struct cEffectiveRegardEntry
@@ -684,7 +535,6 @@ private:
 		cEffectiveRegardEntry() {m_round=-666;}
 		int m_round;
 		uint32 m_bits;
-
 
 		int RegardToIndex(int regard) {return (regard>>6);}
 	};

--- a/ctp2_code/ai/diplomacy/diplomat.cpp
+++ b/ctp2_code/ai/diplomacy/diplomat.cpp
@@ -154,46 +154,45 @@ sint32 ProposalAutoExpiryTurn
 )
 {
 	switch (prop_type)
-    {
-    // One-time gifts (no use cancelling these)
-    default:
-        return k_EXPIRATION_NEVER;
+	{
+	// One-time gifts (no use cancelling these)
+	default:
+		return k_EXPIRATION_NEVER;
 
-    // Simple agreements
+	// Simple agreements
 	case PROPOSAL_OFFER_WITHDRAW_TROOPS:
-    case PROPOSAL_REQUEST_WITHDRAW_TROOPS:
-    case PROPOSAL_OFFER_STOP_PIRACY:
+	case PROPOSAL_REQUEST_WITHDRAW_TROOPS:
+	case PROPOSAL_OFFER_STOP_PIRACY:
 	case PROPOSAL_REQUEST_STOP_PIRACY:
 	case PROPOSAL_TREATY_CEASEFIRE:
-        return baseExpiryTurn;
+		return baseExpiryTurn;
 
-    // Advanced agreements
+	// Advanced agreements
 	case PROPOSAL_OFFER_STOP_RESEARCH:
 	case PROPOSAL_REQUEST_STOP_RESEARCH:
 	case PROPOSAL_OFFER_REDUCE_NUCLEAR_WEAPONS:
-    case PROPOSAL_REQUEST_REDUCE_NUCLEAR_WEAPONS:
-    case PROPOSAL_OFFER_REDUCE_BIO_WEAPONS:
-    case PROPOSAL_REQUEST_REDUCE_BIO_WEAPONS:
-    case PROPOSAL_OFFER_REDUCE_NANO_WEAPONS:
-    case PROPOSAL_REQUEST_REDUCE_NANO_WEAPONS:
-        return baseExpiryTurn + (baseExpiryTurn / 2);
+	case PROPOSAL_REQUEST_REDUCE_NUCLEAR_WEAPONS:
+	case PROPOSAL_OFFER_REDUCE_BIO_WEAPONS:
+	case PROPOSAL_REQUEST_REDUCE_BIO_WEAPONS:
+	case PROPOSAL_OFFER_REDUCE_NANO_WEAPONS:
+	case PROPOSAL_REQUEST_REDUCE_NANO_WEAPONS:
+		return baseExpiryTurn + (baseExpiryTurn / 2);
 
-    // Treaties (except full alliance)
-    case PROPOSAL_TREATY_PEACE:
-    case PROPOSAL_TREATY_TRADE_PACT:
-    case PROPOSAL_TREATY_RESEARCH_PACT:
-    case PROPOSAL_TREATY_MILITARY_PACT:
-    case PROPOSAL_TREATY_POLLUTION_PACT:
-        return 2 * baseExpiryTurn;
+	// Treaties (except full alliance)
+	case PROPOSAL_TREATY_PEACE:
+	case PROPOSAL_TREATY_TRADE_PACT:
+	case PROPOSAL_TREATY_RESEARCH_PACT:
+	case PROPOSAL_TREATY_MILITARY_PACT:
+	case PROPOSAL_TREATY_POLLUTION_PACT:
+		return 2 * baseExpiryTurn;
 
-    // Full alliance
-    case PROPOSAL_TREATY_ALLIANCE:
-        return k_EXPIRATION_NEVER;
+	// Full alliance
+	case PROPOSAL_TREATY_ALLIANCE:
+		return k_EXPIRATION_NEVER;
 	}
 }
 
 } // namespace
-
 
 AiState Diplomat::s_badAiState;
 Threat Diplomat::s_badThreat;
@@ -205,10 +204,6 @@ ai::Agreement Diplomat::s_badAgreement;
 sint32 Diplomat::s_nextId = 0;
 Diplomat::DiplomatVector Diplomat::s_theDiplomats;
 sint32 Diplomat::s_proposalTypeToElemIndex[PROPOSAL_MAX];
-
-
-
-
 
 #define RELDBG(x) { FILE *f = fopen("reldbg.txt", "a"); fprintf x; fclose(f); }
 Diplomat & Diplomat::GetDiplomat(const PLAYER_INDEX & playerId)
@@ -299,19 +294,19 @@ void Diplomat::SaveAll(CivArchive & archive)
 void Diplomat::DebugStatusAll()
 {
 	for (size_t playerId = 1; playerId < s_theDiplomats.size(); ++playerId)
-    {
+	{
 		if (g_player[playerId] && !g_player[playerId]->IsDead())
 		{
-		    Diplomat & diplomat = GetDiplomat(playerId);
+			Diplomat & diplomat = GetDiplomat(playerId);
 
-		    printf("Player %d: ",diplomat.GetPlayerId());
+			printf("Player %d: ",diplomat.GetPlayerId());
 
-		    if (g_player[diplomat.GetPlayerId()]->IsRobot())
-			    printf("(AI)");
-		    printf("\n");
+			if (g_player[diplomat.GetPlayerId()]->IsRobot())
+				printf("(AI)");
 
-		    diplomat.DebugStatus();
-        }
+			printf("\n");
+			diplomat.DebugStatus();
+		}
 	}
 }
 
@@ -350,11 +345,13 @@ void Diplomat::ExecuteDelayedNegotiations(const sint32 receiverID)
 	}
 }
 
-sint32 Diplomat::GetNextId() {
+sint32 Diplomat::GetNextId()
+{
 	return s_nextId++;
 }
 
-void Diplomat::SetNextId(const sint32 & id) {
+void Diplomat::SetNextId(const sint32 & id)
+{
 	s_nextId = id;
 }
 
@@ -362,14 +359,14 @@ Diplomat::Diplomat()
 :
     m_playerId                      (PLAYER_UNASSIGNED),
     m_personalityName               (),
-	m_personality                   (NULL),
+    m_personality                   (NULL),
     m_motivations                   (),
-	m_lastMotivation                (),
+    m_lastMotivation                (),
     m_diplomaticStates              (),
     m_bestStrategicStates           (),
     m_bestDiplomaticState           (s_badAiState),
     m_strategy                      (),
-	m_diplomacy                     (),
+    m_diplomacy                     (),
     m_foreigners                    (),
     m_threats                       (),
     m_friendCount                   (0),
@@ -380,11 +377,11 @@ Diplomat::Diplomat()
     m_incursionPermission           (1 << PLAYER_INDEX_VANDALS),
     m_outstandingProposals          (0),
     m_diplomcyVictoryCompleteTurn   (-1),
-	m_nuclearAttackTarget           (PLAYER_UNASSIGNED),
-	m_lastParty                     (-1),
-	m_launchedNukes                 (false),
-	m_launchedNanoAttack            (false),
-	m_desireWarWith                 ()
+    m_nuclearAttackTarget           (PLAYER_UNASSIGNED),
+    m_lastParty                     (-1),
+    m_launchedNukes                 (false),
+    m_launchedNanoAttack            (false),
+    m_desireWarWith                 ()
 {
 }
 
@@ -394,12 +391,12 @@ Diplomat::Diplomat(Diplomat const & a_Original)
     m_personalityName               (a_Original.m_personalityName),
     m_personality                   (a_Original.m_personality),
     m_motivations                   (a_Original.m_motivations),
-	m_lastMotivation                (),
+    m_lastMotivation                (),
     m_diplomaticStates              (a_Original.m_diplomaticStates),
     m_bestStrategicStates           (a_Original.m_bestStrategicStates),
     m_bestDiplomaticState           (a_Original.m_bestDiplomaticState),
     m_strategy                      (a_Original.m_strategy),
-	m_diplomacy                     (a_Original.m_diplomacy),
+    m_diplomacy                     (a_Original.m_diplomacy),
     m_foreigners                    (a_Original.m_foreigners),
     m_threats                       (a_Original.m_threats),
     m_friendCount                   (a_Original.m_friendCount),
@@ -414,77 +411,77 @@ Diplomat::Diplomat(Diplomat const & a_Original)
     m_lastParty                     (a_Original.m_lastParty),
     m_launchedNukes                 (a_Original.m_launchedNukes),
     m_launchedNanoAttack            (a_Original.m_launchedNanoAttack),
-	m_desireWarWith                 (a_Original.m_desireWarWith)
+    m_desireWarWith                 (a_Original.m_desireWarWith)
 {
-    // Update the iterators in m_lastMotivation to point to the new list
+	// Update the iterators in m_lastMotivation to point to the new list
 	for
-    (
-        MotivationVector::const_iterator p = a_Original.m_lastMotivation.begin();
-        p != a_Original.m_lastMotivation.end();
-        ++p
-    )
-    {
-        MotivationList::difference_type l_Distance  =
-            std::distance<MotivationList::const_iterator>
-                (a_Original.m_motivations.begin(), *p);
+	(
+	    MotivationVector::const_iterator p = a_Original.m_lastMotivation.begin();
+	    p != a_Original.m_lastMotivation.end();
+	    ++p
+	)
+	{
+		MotivationList::difference_type l_Distance  =
+		    std::distance<MotivationList::const_iterator>
+		        (a_Original.m_motivations.begin(), *p);
 
-        MotivationList::iterator        l_Reference = m_motivations.begin();
-        std::advance(l_Reference, l_Distance);
+		MotivationList::iterator        l_Reference = m_motivations.begin();
+		std::advance(l_Reference, l_Distance);
 
-        m_lastMotivation.push_back(l_Reference);
-    }
+		m_lastMotivation.push_back(l_Reference);
+	}
 }
 
 Diplomat const & Diplomat::operator = (Diplomat const & a_Original)
 {
-    if (this != &a_Original)
-    {
-        m_playerId                      = a_Original.m_playerId;
-        m_personalityName               = a_Original.m_personalityName;
-	    m_personality                   = a_Original.m_personality;
-        m_motivations                   = a_Original.m_motivations;
-        m_diplomaticStates              = a_Original.m_diplomaticStates;
-        m_bestStrategicStates           = a_Original.m_bestStrategicStates;
-        m_bestDiplomaticState           = a_Original.m_bestDiplomaticState;
-        m_strategy                      = a_Original.m_strategy;
-	    m_diplomacy                     = a_Original.m_diplomacy;
-        m_foreigners                    = a_Original.m_foreigners;
-        m_threats                       = a_Original.m_threats;
-        m_friendCount                   = a_Original.m_friendCount;
-        m_enemyCount                    = a_Original.m_enemyCount;
-        m_friendPower                   = a_Original.m_friendPower;
-        m_enemyThreat                   = a_Original.m_enemyThreat;
-        m_piracyHistory                 = a_Original.m_piracyHistory;
-        m_incursionPermission           = a_Original.m_incursionPermission;
-        m_outstandingProposals          = a_Original.m_outstandingProposals;
-        m_diplomcyVictoryCompleteTurn   = a_Original.m_diplomcyVictoryCompleteTurn;
-        m_nuclearAttackTarget           = a_Original.m_nuclearAttackTarget;
-        m_lastParty                     = a_Original.m_lastParty;
-        m_launchedNukes                 = a_Original.m_launchedNukes;
-        m_launchedNanoAttack            = a_Original.m_launchedNanoAttack;
-	    m_desireWarWith                 = a_Original.m_desireWarWith;
+	if (this != &a_Original)
+	{
+		m_playerId                      = a_Original.m_playerId;
+		m_personalityName               = a_Original.m_personalityName;
+		m_personality                   = a_Original.m_personality;
+		m_motivations                   = a_Original.m_motivations;
+		m_diplomaticStates              = a_Original.m_diplomaticStates;
+		m_bestStrategicStates           = a_Original.m_bestStrategicStates;
+		m_bestDiplomaticState           = a_Original.m_bestDiplomaticState;
+		m_strategy                      = a_Original.m_strategy;
+		m_diplomacy                     = a_Original.m_diplomacy;
+		m_foreigners                    = a_Original.m_foreigners;
+		m_threats                       = a_Original.m_threats;
+		m_friendCount                   = a_Original.m_friendCount;
+		m_enemyCount                    = a_Original.m_enemyCount;
+		m_friendPower                   = a_Original.m_friendPower;
+		m_enemyThreat                   = a_Original.m_enemyThreat;
+		m_piracyHistory                 = a_Original.m_piracyHistory;
+		m_incursionPermission           = a_Original.m_incursionPermission;
+		m_outstandingProposals          = a_Original.m_outstandingProposals;
+		m_diplomcyVictoryCompleteTurn   = a_Original.m_diplomcyVictoryCompleteTurn;
+		m_nuclearAttackTarget           = a_Original.m_nuclearAttackTarget;
+		m_lastParty                     = a_Original.m_lastParty;
+		m_launchedNukes                 = a_Original.m_launchedNukes;
+		m_launchedNanoAttack            = a_Original.m_launchedNanoAttack;
+		m_desireWarWith                 = a_Original.m_desireWarWith;
 
-        // Update the iterators in m_lastMotivation to point to the new list
-	    m_lastMotivation.clear();
-	    for
-        (
-            MotivationVector::const_iterator p = a_Original.m_lastMotivation.begin();
-            p != a_Original.m_lastMotivation.end();
-            ++p
-        )
-        {
-            MotivationList::difference_type l_Distance  =
-                std::distance<MotivationList::const_iterator>
-                    (a_Original.m_motivations.begin(), *p);
+		// Update the iterators in m_lastMotivation to point to the new list
+		m_lastMotivation.clear();
+		for
+		(
+		    MotivationVector::const_iterator p = a_Original.m_lastMotivation.begin();
+		    p != a_Original.m_lastMotivation.end();
+		    ++p
+		)
+		{
+			MotivationList::difference_type l_Distance  =
+			    std::distance<MotivationList::const_iterator>
+			        (a_Original.m_motivations.begin(), *p);
 
-            MotivationList::iterator        l_Reference = m_motivations.begin();
-            std::advance(l_Reference, l_Distance);
+			MotivationList::iterator        l_Reference = m_motivations.begin();
+			std::advance(l_Reference, l_Distance);
 
-            m_lastMotivation.push_back(l_Reference);
-        }
-    }
+			m_lastMotivation.push_back(l_Reference);
+		}
+	}
 
-    return *this;
+	return *this;
 }
 
 
@@ -492,13 +489,13 @@ Diplomat::~Diplomat()
 {
 	MotivationList().swap(m_motivations);
 	MotivationVector().swap(m_lastMotivation);
-    AiStateVector().swap(m_diplomaticStates);
+	AiStateVector().swap(m_diplomaticStates);
 	AiStateList().swap(m_bestStrategicStates);
 	DiplomacyRecordVector().swap(m_diplomacy);
 	ForeignerVector().swap(m_foreigners);
 	ThreatList().swap(m_threats);
-    BoolVector().swap(m_desireWarWith);
-    std::string().swap(m_personalityName);
+	BoolVector().swap(m_desireWarWith);
+	std::string().swap(m_personalityName);
 	PiracyHistoryList().swap(m_piracyHistory);
 }
 
@@ -724,33 +721,28 @@ void Diplomat::Initialize()
 void Diplomat::InitForeigner(const PLAYER_INDEX & foreigner)
 {
 	m_lastMotivation[foreigner] = m_motivations.end();
-
-
-
-
 	m_foreigners[foreigner].Initialize();
 	InitDiplomaticState(foreigner);
 }
 
 void Diplomat::DebugStatus(const PLAYER_INDEX & foreignerId) const
 {
-
 	for
-    (
-        size_t tmp_foreignerIndex = 1;
-        tmp_foreignerIndex < m_foreigners.size();
-        ++tmp_foreignerIndex
-    )
-    {
-        PLAYER_INDEX    tmp_foreignerId =
-            static_cast<PLAYER_INDEX>(tmp_foreignerIndex);
+	(
+	    size_t tmp_foreignerIndex = 1;
+	    tmp_foreignerIndex < m_foreigners.size();
+	    ++tmp_foreignerIndex
+	)
+	{
+		PLAYER_INDEX    tmp_foreignerId =
+		    static_cast<PLAYER_INDEX>(tmp_foreignerIndex);
 
 		if (tmp_foreignerId == m_playerId)
 			continue;
 
 		if (    (foreignerId != PLAYER_UNASSIGNED)
-             && (tmp_foreignerId != foreignerId)
-           )
+		     && (tmp_foreignerId != foreignerId)
+		   )
 			continue;
 
 		const Foreigner &foreigner = m_foreigners[tmp_foreignerIndex];
@@ -795,7 +787,6 @@ void Diplomat::DebugStatus(const PLAYER_INDEX & foreignerId) const
 
 void Diplomat::LogDebugStatus(const PLAYER_INDEX & foreignerId) const
 {
-
 	Player *player_ptr = g_player[m_playerId];
 
 	if(!player_ptr)
@@ -854,15 +845,18 @@ void Diplomat::LogDebugStatus(const PLAYER_INDEX & foreignerId) const
 	gslog_dipprint("\n");
 }
 
-void Diplomat::SetPlayerId(const PLAYER_INDEX &playerId) {
+void Diplomat::SetPlayerId(const PLAYER_INDEX &playerId)
+{
 	m_playerId = playerId;
 }
 
-PLAYER_INDEX Diplomat::GetPlayerId() const {
+PLAYER_INDEX Diplomat::GetPlayerId() const
+{
 	return m_playerId;
 }
 
-void Diplomat::SetPersonalityName(const char *personality_name) {
+void Diplomat::SetPersonalityName(const char *personality_name)
+{
 	m_personalityName = std::string(personality_name);
 
 	sint32 index;
@@ -870,7 +864,6 @@ void Diplomat::SetPersonalityName(const char *personality_name) {
 	Assert(found);
 	if (found)
 		m_personality = g_thePersonalityDB->Get(index);
-
 }
 
 std::string Diplomat::GetPersonalityName() const
@@ -888,7 +881,8 @@ bool Diplomat::GetReceiverHasInitiative(const PLAYER_INDEX & foreignerId) const 
 }
 
 void Diplomat::SetReceiverHasInitiative(const PLAYER_INDEX & foreignerId,
-										const bool & hasInitiative) {
+                                        const bool & hasInitiative)
+{
 	m_foreigners[foreignerId].m_hasInitiative = hasInitiative;
 
 	if (hasInitiative) {
@@ -931,9 +925,10 @@ void Diplomat::BeginTurn()
 		iter->SetMyLastNewProposal( Diplomat::s_badNewProposal );
 	}
 
-	g_gevManager->AddEvent(GEV_INSERT_Tail, GEV_ComputeMotivations,
-			  GEA_Player, m_playerId,
-			  GEA_End);
+	g_gevManager->AddEvent(GEV_INSERT_Tail,
+	                       GEV_ComputeMotivations,
+	                       GEA_Player, m_playerId,
+	                       GEA_End);
 
 	NextStrategicState();
 
@@ -999,12 +994,12 @@ void Diplomat::BeginTurn()
 	}
 }
 
-void Diplomat::LogRegardEvent( const PLAYER_INDEX & foreignerId,
-					 const sint32 & regardDelta,
-					 const REGARD_EVENT_TYPE & type,
-					 const StringId & explain,
-					 const sint16 duration) {
-
+void Diplomat::LogRegardEvent(const PLAYER_INDEX & foreignerId,
+                              const sint32 & regardDelta,
+                              const REGARD_EVENT_TYPE & type,
+                              const StringId & explain,
+                              const sint16 duration)
+{
 	RegardEvent regardEvent(static_cast<ai::Regard>(regardDelta),
 							static_cast<sint16>(NewTurnCount::GetCurrentRound()+1), explain, duration);
 	m_foreigners[foreignerId].LogRegardEvent(type, regardEvent);
@@ -1131,7 +1126,6 @@ void Diplomat::LogViolationEvent(const PLAYER_INDEX foreignerId, const PROPOSAL_
 
 	if (AgreementMatrix::s_agreements.HasAgreement(m_playerId, foreignerId, proposal_type))
 	{
-
 		sint32 regard_cost = GetViolationRegardCost(foreignerId, proposal_type);
 
 		sint32 trust_cost = GetViolationTrustCost(foreignerId, proposal_type);
@@ -1172,7 +1166,6 @@ void Diplomat::LogViolationEvent(const PLAYER_INDEX foreignerId, const PROPOSAL_
 
 	if (act_of_war)
 	{
-
 		ai::Agreement war_agreement = AgreementMatrix::s_agreements.GetAgreement(m_playerId, foreignerId, PROPOSAL_TREATY_DECLARE_WAR);
 		if (!war_declared || (turnsatwar == 0 && war_agreement.senderId != m_playerId))
 		{
@@ -1198,13 +1191,13 @@ void Diplomat::LogViolationEvent(const PLAYER_INDEX foreignerId, const PROPOSAL_
 
 	if (act_of_war && !war_declared)
 	{
-
 		DeclareWar(foreignerId);
 	}
 }
 
-const ai::Regard Diplomat::GetPublicRegard( const PLAYER_INDEX & foreignerId,
-								  const REGARD_EVENT_TYPE &type) const {
+const ai::Regard Diplomat::GetPublicRegard(const PLAYER_INDEX & foreignerId,
+                                           const REGARD_EVENT_TYPE &type) const
+{
 	ai::Regard regard = m_foreigners[foreignerId].GetPublicRegard(type);
 
 	if (foreignerId == 0)
@@ -1222,7 +1215,6 @@ const ai::Regard Diplomat::GetPublicRegard( const PLAYER_INDEX & foreignerId,
 	else if ((regard <= HOTWAR_REGARD) &&
 		AgreementMatrix::s_agreements.HasAgreement(m_playerId, foreignerId, PROPOSAL_TREATY_PEACE))
 	{
-
 		regard = HOTWAR_REGARD + 1;
 	}
 
@@ -1231,20 +1223,19 @@ const ai::Regard Diplomat::GetPublicRegard( const PLAYER_INDEX & foreignerId,
 		 AgreementMatrix::s_agreements.HasAgreement(m_playerId, foreignerId, PROPOSAL_TREATY_RESEARCH_PACT) ||
 		 AgreementMatrix::s_agreements.HasAgreement(m_playerId, foreignerId, PROPOSAL_TREATY_MILITARY_PACT)))
 	{
-
 		regard = COLDWAR_REGARD + 1;
 	}
 	return regard;
 }
 
-
-StringId Diplomat::ExplainRegard( const PLAYER_INDEX &foreignerId,
-								  const REGARD_EVENT_TYPE &type) const {
+StringId Diplomat::ExplainRegard(const PLAYER_INDEX &foreignerId,
+                                 const REGARD_EVENT_TYPE &type) const
+{
 	return m_foreigners[foreignerId].GetBestRegardExplain(type);
 }
 
-const ai::Regard Diplomat::GetEffectiveRegard( const PLAYER_INDEX & foreignerId) const {
-
+const ai::Regard Diplomat::GetEffectiveRegard(const PLAYER_INDEX & foreignerId) const
+{
 	if (foreignerId == 0)
 		return MIN_REGARD;
 
@@ -1265,11 +1256,11 @@ void Diplomat::ApplyGlobalTrustChange(const PLAYER_INDEX & foreignerId, const ai
 #endif
 
 	for (size_t i = 1; i < s_theDiplomats.size(); i++)
-    {
+	{
 		if (static_cast<PLAYER_INDEX>(i) != foreignerId)
-        {
+		{
 			s_theDiplomats[i].ApplyTrustChange(foreignerId, trust_delta, NULL);
-        }
+		}
 	}
 }
 
@@ -1284,9 +1275,9 @@ void Diplomat::ApplyTrustChange(const PLAYER_INDEX & foreignerId, const ai::Rega
 #endif
 
 	ai::Regard new_trust =
-        std::min<ai::Regard>(m_foreigners[foreignerId].GetTrust() + trust_delta,
-                             MAX_REGARD
-                            );
+	    std::min<ai::Regard>(m_foreigners[foreignerId].GetTrust() + trust_delta,
+	                         MAX_REGARD
+	                        );
 
 	m_foreigners[foreignerId].SetTrust(new_trust);
 }
@@ -1299,7 +1290,8 @@ const ai::Regard Diplomat::GetTrust(const PLAYER_INDEX & foreignerId) const
 	return m_foreigners[foreignerId].GetTrust();
 }
 
-void Diplomat::SetTrust(const PLAYER_INDEX & foreignerId, const ai::Regard &trust) {
+void Diplomat::SetTrust(const PLAYER_INDEX & foreignerId, const ai::Regard &trust)
+{
 	m_foreigners[foreignerId].SetTrust(trust);
 }
 
@@ -1319,14 +1311,6 @@ ai::Regard Diplomat::GetBaseRegard(const PLAYER_INDEX foreignerId) const
 	{
 		return COLDWAR_REGARD;
 	}
-
-
-
-
-
-
-
-
 
 	return NEUTRAL_REGARD;
 }
@@ -1359,12 +1343,11 @@ void Diplomat::RecomputeRegard()
 			ai::Regard baseRegard = GetBaseRegard(foreignerId);
 
 			m_foreigners[foreigner].RecomputeRegard
-                (m_diplomacy[foreigner],
-				 NewTurnCount::GetCurrentRound(),
-				 baseRegard
-                );
+			    (m_diplomacy[foreigner],
+			     NewTurnCount::GetCurrentRound(),
+			     baseRegard
+			    );
 		}
-
 	}
 
 	ClearEffectiveRegardCache();
@@ -1384,14 +1367,8 @@ void Diplomat::UpdateRegard(const PLAYER_INDEX foreignerId)
 		RecomputeRegard(m_diplomacy[foreignerId], -1, baseRegard);
 }
 
-
-
-
-
-
 sint32 Diplomat::AddAgreement(const PLAYER_INDEX & foreignerId)
 {
-
 	ClearEffectiveRegardCache();
 
 	ai::Agreement agreement;
@@ -1417,9 +1394,8 @@ sint32 Diplomat::AddAgreement(const PLAYER_INDEX & foreignerId)
 			agreement.newsStrId = sender_proposal.newsStrId;
 		}
 	}
-
 	else if ( receiver_response.type == RESPONSE_COUNTER &&
-			  sender_response.type == RESPONSE_ACCEPT )
+	          sender_response.type == RESPONSE_ACCEPT )
 	{
 		agreement.proposal = receiver_response.counter;
 		agreement.explainStrId = receiver_response.explainStrId;
@@ -1428,7 +1404,6 @@ sint32 Diplomat::AddAgreement(const PLAYER_INDEX & foreignerId)
 
 	else
 	{
-
 		Assert(false);
 		return -1;
 	}
@@ -1452,7 +1427,6 @@ sint32 Diplomat::AddAgreement(const PLAYER_INDEX & foreignerId)
 
 	if (Execute_Agreement( agreement ))
 	{
-
 		AgreementMatrix::s_agreements.SetAgreement( agreement );
 	}
 
@@ -1479,16 +1453,15 @@ void Diplomat::EnactStopPiracy(const PLAYER_INDEX victimId, const PLAYER_INDEX p
 			if (army.IsValid() && (army.GetOwner() == pirateId))
 			{
 				g_gevManager->AddEvent
-                    (GEV_INSERT_Tail, GEV_SetPiratingArmy,
-					 GEA_TradeRoute, route,
-					 GEA_Army, 0,
-					 GEA_End
-                    );
+				    (GEV_INSERT_Tail, GEV_SetPiratingArmy,
+				     GEA_TradeRoute, route,
+				     GEA_Army, 0,
+				     GEA_End
+				   );
 			}
 		}
 	}
 }
-
 
 bool Diplomat::CanAfford( const PLAYER_INDEX senderId,
 						  const PLAYER_INDEX receiverId,
@@ -1520,7 +1493,6 @@ bool Diplomat::CanAfford( const PLAYER_INDEX senderId,
 
 bool Diplomat::Execute_Agreement( const ai::Agreement & agreement )
 {
-
 	if (!CanAfford(agreement.senderId, agreement.receiverId, agreement.proposal))
 		return false;
 
@@ -1571,12 +1543,11 @@ bool Diplomat::Execute_Agreement( const ai::Agreement & agreement )
 	return true;
 }
 
-void Diplomat::Execute_Proposal( const PLAYER_INDEX & sender,
-								 const PLAYER_INDEX & receiver,
-								 const PROPOSAL_TYPE & proposal_type,
-								 const DiplomacyArg & proposal_arg )
+void Diplomat::Execute_Proposal(const PLAYER_INDEX & sender,
+                                const PLAYER_INDEX & receiver,
+                                const PROPOSAL_TYPE & proposal_type,
+                                const DiplomacyArg & proposal_arg)
 {
-
 	Assert(g_player[receiver]);
 	Assert(g_player[sender]);
 	if (g_player[sender] == NULL || g_player[receiver] == NULL)
@@ -1805,7 +1776,6 @@ void Diplomat::DeclareWar(const PLAYER_INDEX foreignerId)
 
 		if (foreignerId == g_selected_item->GetCurPlayer())
 		{
-
 			so = new SlicObject((MBCHAR *)"DIPLOMACY_POPUP_DECLARE_WAR");
 			so->AddRecipient(foreignerId);
 			so->AddCivilisation(foreignerId) ;
@@ -1818,10 +1788,8 @@ void Diplomat::DeclareWar(const PLAYER_INDEX foreignerId)
 			so->AddCivilisation(foreignerId) ;
 			g_slicEngine->Execute(so);
 		}
-
 		else
 		{
-
 			so = new SlicObject((MBCHAR *)"128CivStartedWar");
 			so->AddAllRecipientsBut(m_playerId);
 			so->AddCivilisation(m_playerId) ;
@@ -1866,7 +1834,7 @@ void Diplomat::DeclareWar(const PLAYER_INDEX foreignerId)
 		g_network.Unblock(m_playerId);
 	}
 
-    g_theTradePool->BreakOffTrade(m_playerId, foreignerId);
+	g_theTradePool->BreakOffTrade(m_playerId, foreignerId);
 
 	player_ptr->CloseEmbassy(foreignerId);
 	foreigner_ptr->CloseEmbassy(m_playerId);
@@ -1910,16 +1878,10 @@ void Diplomat::SetEmbargo(const PLAYER_INDEX foreignerId, const bool state)
 
 bool Diplomat::GetEmbargo(const PLAYER_INDEX foreignerId) const
 {
-
 	if (AgreementMatrix::s_agreements.HasAgreement(m_playerId, foreignerId, PROPOSAL_TREATY_DECLARE_WAR))
 		return true;
 	return m_foreigners[foreignerId].GetEmbargo();
 }
-
-
-
-
-
 
 void Diplomat::AddRejection(const PLAYER_INDEX & foreignerId)
 {
@@ -1928,11 +1890,6 @@ void Diplomat::AddRejection(const PLAYER_INDEX & foreignerId)
 
 	const NewProposal & sender_proposal =
 		GetMyLastNewProposal(foreignerId);
-
-
-
-
-
 
 	if (sender_proposal.detail.first_type == PROPOSAL_REQUEST_HONOR_MILITARY_AGREEMENT ||
 		sender_proposal.detail.second_type == PROPOSAL_REQUEST_HONOR_MILITARY_AGREEMENT)
@@ -1967,12 +1924,8 @@ void Diplomat::AddRejection(const PLAYER_INDEX & foreignerId)
 	AddNewNegotiationEvent(foreignerId, negotiation_event);
 }
 
-
-
-
-
-
-const Threat & Diplomat::GetThreatById(const sint32 & id) const {
+const Threat & Diplomat::GetThreatById(const sint32 & id) const
+{
 	static Threat bad_threat;
 
 	ThreatList::const_iterator found = std::find(m_threats.begin(), m_threats.end(), id);
@@ -1982,20 +1935,19 @@ const Threat & Diplomat::GetThreatById(const sint32 & id) const {
 		return bad_threat;
 }
 
-void Diplomat::RemoveThreatById(const sint32 & id) {
-
+void Diplomat::RemoveThreatById(const sint32 & id)
+{
 	ThreatList::iterator found = std::find(m_threats.begin(), m_threats.end(), id);
 	if (found != m_threats.end())
 		m_threats.erase(found);
 	else
 	{
-
 		Assert(0);
 	}
 }
 
-sint32 Diplomat::AddThreat(const PLAYER_INDEX & foreignerId) {
-
+sint32 Diplomat::AddThreat(const PLAYER_INDEX & foreignerId)
+{
 	Threat threat;
 
 	const Response & receiver_response =
@@ -2016,7 +1968,6 @@ sint32 Diplomat::AddThreat(const PLAYER_INDEX & foreignerId) {
 	}
 	else
 	{
-
 		Assert(false);
 		return -1;
 	}
@@ -2041,7 +1992,8 @@ sint32 Diplomat::AddThreat(const PLAYER_INDEX & foreignerId) {
 	return threat.id;
 }
 
-const Diplomat::ThreatList & Diplomat::GetThreatList() const {
+const Diplomat::ThreatList & Diplomat::GetThreatList() const
+{
 	return m_threats;
 }
 
@@ -2064,13 +2016,13 @@ bool Diplomat::LaunchNuclearAttackOnCity(const Unit & city)
 		Assert(tmp_unit.IsValid());
 
 		if (tmp_unit.IsValid() && tmp_unit.GetDBRec()->HasNuclearAttack())
-        {
-		    if (tmp_unit->GetTargetCity().m_id == city.m_id)
-		    {
-		        unitutil_ExecuteMadLaunch(tmp_unit);
-			    return true;
-		    }
-        }
+		{
+			if (tmp_unit->GetTargetCity().m_id == city.m_id)
+			{
+				unitutil_ExecuteMadLaunch(tmp_unit);
+				return true;
+			}
+		}
 	}
 
 	return false;
@@ -2096,17 +2048,6 @@ bool Diplomat::ExecuteThreat(const Threat & threat)
 		trust_cost /= 2;
 		str_buf = "Threatened to destroy our city.";
 		break;
-
-
-
-
-
-
-
-
-
-
-
 
 	case THREAT_TRADE_EMBARGO:
 
@@ -2138,7 +2079,6 @@ bool Diplomat::ExecuteThreat(const Threat & threat)
 	return false;
 }
 
-
 bool Diplomat::HasThreat(const PLAYER_INDEX & foreignerId,
 						 const THREAT_TYPE type,
 						 Threat & threat) const
@@ -2161,7 +2101,6 @@ bool Diplomat::HasThreat(const PLAYER_INDEX & foreignerId,
 
 bool Diplomat::ComputeThreatResponse(const PLAYER_INDEX foreignerId, Response & threat_response) const
 {
-
 	if (GetPersonality()->GetConquestPassive())
 		return false;
 
@@ -2172,30 +2111,27 @@ bool Diplomat::ComputeThreatResponse(const PLAYER_INDEX foreignerId, Response & 
 		g_player[m_playerId]->GetRelativeStrength(foreignerId);
 
 	if (regard > FRIEND_REGARD)
-		{
-
-			if (!GetPersonality()->GetAlignmentEvil() &&
-				!GetPersonality()->GetTrustworthinessChaotic())
-				 return false;
-		}
+	{
+		if (!GetPersonality()->GetAlignmentEvil() &&
+			!GetPersonality()->GetTrustworthinessChaotic())
+			 return false;
+	}
 	else if (regard > NEUTRAL_REGARD)
-		{
+	{
+		if (!GetPersonality()->GetConquestAgressive() &&
+			!GetPersonality()->GetDiscoveryMilitary())
+			return false;
 
-			if (!GetPersonality()->GetConquestAgressive() &&
-				!GetPersonality()->GetDiscoveryMilitary())
-				return false;
-
-			if (sender_strength < DIPLOMATIC_STRENGTH_STRONG)
-				return false;
-		}
+		if (sender_strength < DIPLOMATIC_STRENGTH_STRONG)
+			return false;
+	}
 	else if (regard > COLDWAR_REGARD)
-		{
-
-			if (GetPersonality()->GetAlignmentGood() ||
-				GetPersonality()->GetConquestNeutral() ||
-				GetPersonality()->GetDiscoveryDiplomatic())
-				return false;
-		}
+	{
+		if (GetPersonality()->GetAlignmentGood() ||
+			GetPersonality()->GetConquestNeutral() ||
+			GetPersonality()->GetDiscoveryDiplomatic())
+			return false;
+	}
 
 	const Diplomat & foreign_diplomat = Diplomat::GetDiplomat(foreignerId);
 	const MapAnalysis & map_analysis = MapAnalysis::GetMapAnalysis();
@@ -2232,15 +2168,12 @@ bool Diplomat::ComputeThreatResponse(const PLAYER_INDEX foreignerId, Response & 
 		threaten_pirate = true;
 		threaten_special_attack = true;
 	}
-
 	else if (GetPersonality()->GetAlignmentEvil() ||
 			 GetPersonality()->GetConquestAgressive() ||
 			 GetPersonality()->GetDiscoveryMilitary())
 	{
-
 		if (agreements.TurnsAtWar(m_playerId, foreignerId) >= 0)
 		{
-
 			threaten_destroy_city &= (has_more_nukes || has_only_nano || has_only_bio);
 		}
 		else
@@ -2258,14 +2191,11 @@ bool Diplomat::ComputeThreatResponse(const PLAYER_INDEX foreignerId, Response & 
 			}
 		}
 	}
-
 	else if (GetPersonality()->GetDiscoveryScientist()||
 		GetPersonality()->GetDiscoveryEconomic())
 	{
-
 		if (agreements.TurnsAtWar(m_playerId, foreignerId) > 50)
 		{
-
 			threaten_destroy_city = (regard < HOTWAR_REGARD && trust < HOTWAR_REGARD);
 			threaten_destroy_city &= (has_more_nukes || has_only_nano || has_only_bio);
 		}
@@ -2288,10 +2218,8 @@ bool Diplomat::ComputeThreatResponse(const PLAYER_INDEX foreignerId, Response & 
 	else if (GetPersonality()->GetDiscoveryDiplomatic() &&
 		GetPersonality()->GetAlignmentNeutral())
 	{
-
 		if (agreements.TurnsAtWar(m_playerId, foreignerId) > 75)
 		{
-
 			threaten_destroy_city = (trust < MIN_REGARD) && (regard < HOTWAR_REGARD);
 			threaten_destroy_city &= (has_more_nukes || has_only_nano || has_only_bio);
 
@@ -2314,7 +2242,6 @@ bool Diplomat::ComputeThreatResponse(const PLAYER_INDEX foreignerId, Response & 
 
 	if (GetPersonality()->GetAlignmentGood())
 	{
-
 		if (agreements.TurnsAtWar(m_playerId, foreignerId) > 150)
 		{
 			if ((trust > MIN_REGARD) && (regard >= MIN_REGARD))
@@ -2368,34 +2295,11 @@ bool Diplomat::ComputeThreatResponse(const PLAYER_INDEX foreignerId, Response & 
 			return true;
 		}
 	}
-
-
-
-
-
 	else if (threaten_declare_war)
 	{
 		threat_response.threat.type = THREAT_DECLARE_WAR;
 		return true;
 	}
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 	else if (threaten_embargo)
 	{
 		threat_response.threat.type = THREAT_TRADE_EMBARGO;
@@ -2443,15 +2347,9 @@ bool Diplomat::GetAgreementToBreak(const PLAYER_INDEX foreignerId, ai::Agreement
 	return false;
 }
 
-
-
-
-
-
 void Diplomat::ConsiderResponse( const PLAYER_INDEX & foreignId,
 								 const Response & response )
 {
-
 	if (response.priority <= 0)
 		return;
 
@@ -2471,17 +2369,15 @@ void Diplomat::ConsiderResponse( const PLAYER_INDEX & foreignId,
 	Assert(response.senderId != -1);
 	Assert(response.receiverId != -1);
 
-
 	m_foreigners[foreignId].ConsiderResponse(response);
 
 	DPRINTF(k_DBG_DIPLOMACY,("  Player %d considers Response: %s for player %d.\n",
 			m_playerId, s_responseNames[response.type].c_str(), foreignId));
-
 }
 
-void Diplomat::ConsiderResponse( const PLAYER_INDEX senderId,
-								 const RESPONSE_TYPE response_type,
-								 const sint32 priority)
+void Diplomat::ConsiderResponse(const PLAYER_INDEX senderId,
+                                const RESPONSE_TYPE response_type,
+                                const sint32 priority)
 {
 	Assert(response_type == RESPONSE_REJECT || response_type == RESPONSE_ACCEPT);
 
@@ -2498,13 +2394,12 @@ void Diplomat::ConsiderResponse( const PLAYER_INDEX senderId,
 	ConsiderResponse( senderId, response);
 }
 
-void Diplomat::ConsiderCounterResponse( const PLAYER_INDEX senderId,
-									    const PROPOSAL_TYPE counterProposalType,
-									    const DiplomacyArg & argument,
-									    const sint32 priority,
-										const DIPLOMATIC_TONE tone)
+void Diplomat::ConsiderCounterResponse(const PLAYER_INDEX senderId,
+                                       const PROPOSAL_TYPE counterProposalType,
+                                       const DiplomacyArg & argument,
+                                       const sint32 priority,
+                                       const DIPLOMATIC_TONE tone)
 {
-
 	if (priority <= 0)
 		return;
 
@@ -2539,12 +2434,14 @@ void Diplomat::ConsiderCounterResponse( const PLAYER_INDEX senderId,
 	ConsiderResponse(senderId, response);
 }
 
-const Response & Diplomat::GetMyLastResponse(const PLAYER_INDEX & foreignId) const {
+const Response & Diplomat::GetMyLastResponse(const PLAYER_INDEX & foreignId) const
+{
 	return m_foreigners[foreignId].GetMyLastResponse();
 }
 
-void Diplomat::SetMyLastResponse( const PLAYER_INDEX & foreignId,
-								  const Response & response ) {
+void Diplomat::SetMyLastResponse(const PLAYER_INDEX & foreignId,
+                                 const Response & response)
+{
 	m_foreigners[foreignId].SetMyLastResponse(response);
 
 	DPRINTF(k_DBG_DIPLOMACY,("  Player %d sets Response: %s for player %d.\n",
@@ -2557,8 +2454,8 @@ void Diplomat::SetMyLastResponse( const PLAYER_INDEX & foreignId,
 	}
 }
 
-void Diplomat::ExecuteResponse( const PLAYER_INDEX sender,
-								const PLAYER_INDEX receiver )
+void Diplomat::ExecuteResponse(const PLAYER_INDEX sender,
+                               const PLAYER_INDEX receiver)
 {
 	Response response;
 	RESPONSE_TYPE other_response;
@@ -2631,17 +2528,13 @@ void Diplomat::ExecuteResponse( const PLAYER_INDEX sender,
 		response.type = RESPONSE_REJECT;
 	}
 
-
-	if (response.type == RESPONSE_ACCEPT) {
+	if (response.type == RESPONSE_ACCEPT)
+	{
 
 		DPRINTF(k_DBG_DIPLOMACY, ("\n"));
 		DPRINTF(k_DBG_DIPLOMACY, (">>> Agreement ACCEPTED by player %d.\n",
 			static_cast<sint32>(m_playerId)));
 		DPRINTF(k_DBG_DIPLOMACY, ("    (new agreement created)\n\n"));
-
-
-
-
 
 		DipWizard::NotifyResponse(response, m_playerId, other_player);
 		g_network.NotifyDiplomacyResponse(response, m_playerId, other_player);
@@ -2657,15 +2550,11 @@ void Diplomat::ExecuteResponse( const PLAYER_INDEX sender,
 	}
 
 	else if ( (response.type == RESPONSE_REJECT) &&
-			  (m_playerId == sender) ) {
-
+	          (m_playerId == sender) )
+	{
 		DPRINTF(k_DBG_DIPLOMACY, ("\n"));
 		DPRINTF(k_DBG_DIPLOMACY, (">>> Agreement REJECTED by player %d.\n\n",
 			static_cast<sint32>(m_playerId)));
-
-
-
-
 
 		if (other_response == RESPONSE_COUNTER)
 		{
@@ -2681,15 +2570,18 @@ void Diplomat::ExecuteResponse( const PLAYER_INDEX sender,
 			GEA_End);
 
 		return;
-	} else {
+	}
+	else
+	{
 		g_network.NotifyDiplomacyResponse(response, m_playerId, other_player);
 	}
 
 	const Response & sender_response =
-		Diplomat::GetDiplomat(sender).GetMyLastResponse(receiver);
+	    Diplomat::GetDiplomat(sender).GetMyLastResponse(receiver);
 	if ( (response.type != RESPONSE_ACCEPT) &&
-		 (m_playerId == receiver) &&
-		 (sender_response.type == RESPONSE_THREATEN)) {
+	     (m_playerId == receiver) &&
+	     (sender_response.type == RESPONSE_THREATEN))
+	{
 
 		DPRINTF(k_DBG_DIPLOMACY, ("\n"));
 		DPRINTF(k_DBG_DIPLOMACY, (">>> Threat REJECTED by player %d.\n",
@@ -2742,20 +2634,15 @@ void Diplomat::ExecuteResponse( const PLAYER_INDEX sender,
 	}
 }
 
-
-
-
 const Response & Diplomat::GetResponsePending(const PLAYER_INDEX foreignerId) const
 {
 	const Response & response = GetMyLastResponse(foreignerId);
 
 	if (response != s_badResponse)
 	{
-
 		if (response.senderId == m_playerId &&
 			GetReceiverHasInitiative(foreignerId) == false)
 			return s_badResponse;
-
 
 		if (response.receiverId == m_playerId &&
 			GetDiplomat(response.senderId).GetReceiverHasInitiative(m_playerId) == true)
@@ -2771,11 +2658,9 @@ const Response & Diplomat::GetResponse(const PLAYER_INDEX foreignerId) const
 
 	if (response != s_badResponse)
 	{
-
 		if (response.senderId == m_playerId &&
 			GetReceiverHasInitiative(foreignerId) == true)
 			return s_badResponse;
-
 
 		if (response.receiverId == m_playerId &&
 			GetDiplomat(response.senderId).GetReceiverHasInitiative(m_playerId) == false)
@@ -2835,7 +2720,6 @@ sint32 Diplomat::GetMotivationCount() const
 
 void Diplomat::SortMotivations()
 {
-
 	m_motivations.sort();
 }
 
@@ -2849,7 +2733,6 @@ const Motivation & Diplomat::GetCurrentMotivation() const
 
 StringId Diplomat::GetDiplomacyAdvice(SlicContext & sc, const PLAYER_INDEX & foreignerId) const
 {
-
 	sc.AddPlayer(m_playerId);
 
 	if (foreignerId == m_playerId || foreignerId <= 0)
@@ -2863,7 +2746,6 @@ StringId Diplomat::GetDiplomacyAdvice(SlicContext & sc, const PLAYER_INDEX & for
 
 	else
 	{
-
 		sc.AddPlayer(foreignerId);
 
 		MotivationList::const_iterator motivation_iter = m_lastMotivation[foreignerId];
@@ -2875,30 +2757,18 @@ StringId Diplomat::GetDiplomacyAdvice(SlicContext & sc, const PLAYER_INDEX & for
 			Diplomat::AddDiplomacyArgToSlicContext(sc, new_proposal.detail.second_arg);
 			return new_proposal.adviceStrId;
 		}
-
 		else if (motivation_iter != m_motivations.end())
 		{
 			return m_lastMotivation[foreignerId]->adviceStrId;
 		}
-
-
 		else
 		{
 			return m_diplomaticStates[foreignerId].adviceStrId;
 		}
-
 	}
 
 	return -1;
 }
-
-
-
-
-
-
-
-
 
 void Diplomat::ContinueDiplomacy(const PLAYER_INDEX & foreignerId) {
 
@@ -2910,40 +2780,36 @@ void Diplomat::ContinueDiplomacy(const PLAYER_INDEX & foreignerId) {
 	if (motivation_iter != m_motivations.end())
 		topMotivation = *motivation_iter;
 
-
-
-
-
 	bool end_diplomacy = false;
 	if ( Diplomat::GetDiplomat(foreignerId).GetMyLastResponse(m_playerId).type
-		 == RESPONSE_REJECT )
-		{
-			end_diplomacy = true;
-			response = RESPONSE_REJECT;
-		}
+	     == RESPONSE_REJECT )
+	{
+		end_diplomacy = true;
+		response = RESPONSE_REJECT;
+	}
 
 	else if ( ( Diplomat::GetDiplomat(foreignerId).GetMyLastResponse(m_playerId).type
-				== RESPONSE_COUNTER ) &&
-			  ( Diplomat::GetDiplomat(m_playerId).GetMyLastResponse(foreignerId).type
-				== RESPONSE_REJECT ) )
-		{
-			end_diplomacy = true;
-			response = RESPONSE_REJECT;
-		}
+	            == RESPONSE_COUNTER ) &&
+	          ( Diplomat::GetDiplomat(m_playerId).GetMyLastResponse(foreignerId).type
+	            == RESPONSE_REJECT ) )
+	{
+		end_diplomacy = true;
+		response = RESPONSE_REJECT;
+	}
 
 	else if ( ( Diplomat::GetDiplomat(m_playerId).GetMyLastResponse(foreignerId).type
-				== RESPONSE_THREATEN ) &&
-			  ( Diplomat::GetDiplomat(m_playerId).GetMyLastResponse(foreignerId).type
-				!= RESPONSE_ACCEPT ) )
-		{
-			end_diplomacy = true;
-			response = RESPONSE_REJECT;
-		}
+	            == RESPONSE_THREATEN ) &&
+	          ( Diplomat::GetDiplomat(m_playerId).GetMyLastResponse(foreignerId).type
+	            != RESPONSE_ACCEPT ) )
+	{
+		end_diplomacy = true;
+		response = RESPONSE_REJECT;
+	}
 	else
-		{
-			end_diplomacy = false;
-			response = RESPONSE_ACCEPT;
-		}
+	{
+		end_diplomacy = false;
+		response = RESPONSE_ACCEPT;
+	}
 
 	SetMyLastNegotiatedProposal( foreignerId,
 								 GetMyLastNewProposal(foreignerId).detail,
@@ -2959,7 +2825,6 @@ void Diplomat::ContinueDiplomacy(const PLAYER_INDEX & foreignerId) {
 	}
 	else
 	{
-
 		end_diplomacy = true;
 	}
 
@@ -2981,7 +2846,8 @@ void Diplomat::ContinueDiplomacy(const PLAYER_INDEX & foreignerId) {
 		if (m_outstandingProposals == 0)
 		{
 			if(!g_network.IsActive() ||
-			   (g_network.IsHost() && g_network.IsLocalPlayer(m_playerId))) {
+			   (g_network.IsHost() && g_network.IsLocalPlayer(m_playerId)))
+			{
 				g_director->AddBeginScheduler(m_playerId);
 			}
 		}
@@ -2999,23 +2865,23 @@ bool Diplomat::StartNegotiations(const PLAYER_INDEX hotseat_foreignerId)
 
 	m_outstandingProposals = 0;
 
-	if (g_network.IsHost() && !g_network.IsLocalPlayer(m_playerId)) {
-
+	if (g_network.IsHost() && !g_network.IsLocalPlayer(m_playerId))
+	{
 		return false;
 	}
 
 	bool        found       = false;
 
 	for
-    (
-        size_t foreignerIndex = 1;
-        foreignerIndex < m_foreigners.size();
-        ++foreignerIndex
-    )
+	(
+	    size_t foreignerIndex = 1;
+	    foreignerIndex < m_foreigners.size();
+	    ++foreignerIndex
+	)
 	{
 		PLAYER_INDEX    foreignerId = static_cast<PLAYER_INDEX>(foreignerIndex);
 
-        if (foreignerId == m_playerId)
+		if (foreignerId == m_playerId)
 			continue;
 
 		Player * foreigner_ptr = g_player[foreignerIndex];
@@ -3024,7 +2890,6 @@ bool Diplomat::StartNegotiations(const PLAYER_INDEX hotseat_foreignerId)
 
 		if (g_turn->IsHotSeat() || g_turn->IsEmail())
 		{
-
 			if (hotseat_foreignerId != PLAYER_UNASSIGNED)
 			{
 				if (hotseat_foreignerId != foreignerId)
@@ -3139,7 +3004,6 @@ bool Diplomat::InvalidNewProposal(const PLAYER_INDEX & foreignerId, const Diplom
 
 	if (rec->GetCategoryGift())
 	{
-
 		if (rec->GetHasAlly() &&
 			!AgreementMatrix::s_agreements.HasAgreement(foreignerId, PROPOSAL_TREATY_ALLIANCE))
 			return true;
@@ -3170,15 +3034,9 @@ bool Diplomat::InvalidNewProposal(const PLAYER_INDEX & foreignerId, const Diplom
 	}
 	else if (rec->GetCategoryRequest())
 	{
-
 		if (rec->GetHasAlly() &&
 			!AgreementMatrix::s_agreements.HasAgreement(m_playerId, PROPOSAL_TREATY_ALLIANCE))
 			return true;
-
-
-
-
-
 
 		if (rec->GetIsPirating() &&
 			!MapAnalysis::GetMapAnalysis().GetMaxPiracyLoss(m_playerId))
@@ -3200,18 +3058,12 @@ bool Diplomat::InvalidNewProposal(const PLAYER_INDEX & foreignerId, const Diplom
 			foreign_diplomat.GetEmbargo(m_playerId) == false)
 			return true;
 	}
-	else
-	{
 
-	}
 	return false;
 }
 
-void Diplomat::ChooseNewProposal(const PLAYER_INDEX & foreignerId) {
-
-
-
-
+void Diplomat::ChooseNewProposal(const PLAYER_INDEX & foreignerId)
+{
 	DPRINTF(k_DBG_DIPLOMACY,("Player %d choosing new proposal for player %d\n",m_playerId, foreignerId));
 
 	SetMyLastNewProposal( foreignerId, Diplomat::s_badNewProposal );
@@ -3221,16 +3073,16 @@ void Diplomat::ChooseNewProposal(const PLAYER_INDEX & foreignerId) {
 	MotivationList::iterator motivation_iter = m_lastMotivation[foreignerId];
 
 	if (motivation_iter == m_motivations.end())
-		{
-			DPRINTF(k_DBG_DIPLOMACY,("  No Motivations.\n"));
-		}
+	{
+		DPRINTF(k_DBG_DIPLOMACY,("  No Motivations.\n"));
+	}
 	else
-		{
-			Motivation topMotivation = *motivation_iter;
-			GAME_EVENT motivation_event = static_cast<GAME_EVENT>(0);
+	{
+		Motivation topMotivation = *motivation_iter;
+		GAME_EVENT motivation_event = static_cast<GAME_EVENT>(0);
 
-			switch (topMotivation.type)
-			{
+		switch (topMotivation.type)
+		{
 			case MOTIVATION_NONE:
 
 				Assert(0);
@@ -3265,19 +3117,17 @@ void Diplomat::ChooseNewProposal(const PLAYER_INDEX & foreignerId) {
 			case MOTIVATION_MAX:
 
 				Assert(0);
-			}
-
-			DPRINTF(k_DBG_DIPLOMACY,("  Player %d has top motivation: %s.\n",
-									 m_playerId, s_motivationNames[topMotivation.type].c_str()));
-
-			g_gevManager->AddEvent(GEV_INSERT_Tail, motivation_event,
-								   GEA_Player, m_playerId,
-								   GEA_Player, foreignerId,
-								   GEA_Int, static_cast<sint32>(topMotivation.type),
-								   GEA_End);
-
 		}
 
+		DPRINTF(k_DBG_DIPLOMACY,("  Player %d has top motivation: %s.\n",
+								 m_playerId, s_motivationNames[topMotivation.type].c_str()));
+
+		g_gevManager->AddEvent(GEV_INSERT_Tail, motivation_event,
+							   GEA_Player, m_playerId,
+							   GEA_Player, foreignerId,
+							   GEA_Int, static_cast<sint32>(topMotivation.type),
+							   GEA_End);
+	}
 
 	g_gevManager->AddEvent(GEV_INSERT_Tail, GEV_ReactionMotivation,
 		GEA_Player, m_playerId,
@@ -3287,10 +3137,9 @@ void Diplomat::ChooseNewProposal(const PLAYER_INDEX & foreignerId) {
 	m_outstandingProposals++;
 }
 
-
-void Diplomat::ConsiderNewProposal( const PLAYER_INDEX & foreignerId,
-									const NewProposal & newProposal ) {
-
+void Diplomat::ConsiderNewProposal(const PLAYER_INDEX & foreignerId,
+                                   const NewProposal & newProposal)
+{
 	Assert(newProposal.senderId != -1);
 	Assert(newProposal.receiverId != -1);
 
@@ -3307,12 +3156,14 @@ void Diplomat::ConsiderNewProposal( const PLAYER_INDEX & foreignerId,
 
 }
 
-const NewProposal & Diplomat::GetMyLastNewProposal(const PLAYER_INDEX & foreignerId) const {
+const NewProposal & Diplomat::GetMyLastNewProposal(const PLAYER_INDEX & foreignerId) const
+{
 	return (m_foreigners[foreignerId].GetMyLastNewProposal());
 }
 
-void Diplomat::SetMyLastNewProposal( const PLAYER_INDEX & foreignerId,
-									 const NewProposal & newProposal ) {
+void Diplomat::SetMyLastNewProposal(const PLAYER_INDEX & foreignerId,
+                                    const NewProposal & newProposal)
+{
 	m_foreigners[foreignerId].SetMyLastNewProposal(newProposal);
 
 	DPRINTF(k_DBG_DIPLOMACY,("  Player %d sets New Proposal for player %d: first  = %s.\n",
@@ -3391,23 +3242,23 @@ void Diplomat::ExecuteEventNewProposal( const PLAYER_INDEX & receiver )
 }
 
 void Diplomat::SetMyLastNegotiatedProposal( const PLAYER_INDEX & foreignerId,
-										    const ProposalData & data,
-										    const RESPONSE_TYPE & response )
+                                            const ProposalData & data,
+                                            const RESPONSE_TYPE & response )
 {
 	m_foreigners[foreignerId].SetMyLastNegotiatedProposal(data,response);
 }
 
-RESPONSE_TYPE Diplomat::GetMyLastNegotiatedProposal( const PLAYER_INDEX & foreignerId,
-													 ProposalData & data ) const
+RESPONSE_TYPE Diplomat::GetMyLastNegotiatedProposal(const PLAYER_INDEX & foreignerId,
+                                                    ProposalData & data ) const
 {
 	return m_foreigners[foreignerId].GetMyLastNegotiatedProposal(data);
 }
-
 
 bool Diplomat::GetNewProposalTimeout( const NewProposal & newProposal, const sint16 timeout_period ) const
 {
 	if (m_foreigners[newProposal.receiverId].GetNewProposalTimeout( newProposal, timeout_period))
 		return true;
+
 	return false;
 }
 
@@ -3417,7 +3268,7 @@ const NegotiationEventList & Diplomat::GetNegotiationEvents( const PLAYER_INDEX 
 }
 
 sint32 Diplomat::GetNewProposalPriority(const PLAYER_INDEX foreignerId,
-							  const PROPOSAL_TYPE proposalType ) const
+                                        const PROPOSAL_TYPE proposalType ) const
 {
 	Assert(s_proposalTypeToElemIndex[proposalType] < m_diplomacy[foreignerId].GetNumProposalElement());
 
@@ -3438,24 +3289,24 @@ sint32 Diplomat::GetNewProposalPriority(const PLAYER_INDEX foreignerId,
 }
 
 sint32 Diplomat::GetAcceptPriority(const PLAYER_INDEX foreignerId,
-						 const PROPOSAL_TYPE proposalType ) const
+                                   const PROPOSAL_TYPE proposalType ) const
 {
 	Assert(s_proposalTypeToElemIndex[proposalType] < m_diplomacy[foreignerId].GetNumProposalElement());
 
 	const DiplomacyRecord::ProposalElement * elem =
-		m_diplomacy[foreignerId].GetProposalElement(s_proposalTypeToElemIndex[proposalType]);
+	    m_diplomacy[foreignerId].GetProposalElement(s_proposalTypeToElemIndex[proposalType]);
 	sint32 value;
 	elem->GetAcceptPriority(value);
 	return value;
 }
 
 sint32 Diplomat::GetRejectPriority(const PLAYER_INDEX foreignerId,
-						 const PROPOSAL_TYPE proposalType ) const
+                                   const PROPOSAL_TYPE proposalType ) const
 {
 	Assert(s_proposalTypeToElemIndex[proposalType] < m_diplomacy[foreignerId].GetNumProposalElement());
 
 	const DiplomacyRecord::ProposalElement * elem =
-		m_diplomacy[foreignerId].GetProposalElement(s_proposalTypeToElemIndex[proposalType]);
+	    m_diplomacy[foreignerId].GetProposalElement(s_proposalTypeToElemIndex[proposalType]);
 
 	sint32 value;
 	elem->GetRejectPriority(value);
@@ -3463,7 +3314,7 @@ sint32 Diplomat::GetRejectPriority(const PLAYER_INDEX foreignerId,
 }
 
 sint32 Diplomat::GetSenderRegardResult(const PLAYER_INDEX foreignerId,
-							 const PROPOSAL_TYPE proposalType ) const
+                                       const PROPOSAL_TYPE proposalType ) const
 {
 	Assert(s_proposalTypeToElemIndex[proposalType] < m_diplomacy[foreignerId].GetNumProposalElement());
 
@@ -3476,7 +3327,7 @@ sint32 Diplomat::GetSenderRegardResult(const PLAYER_INDEX foreignerId,
 }
 
 sint32 Diplomat::GetReceiverRegardResult(const PLAYER_INDEX foreignerId,
-							   const PROPOSAL_TYPE proposalType ) const
+                                         const PROPOSAL_TYPE proposalType ) const
 {
 	Assert(s_proposalTypeToElemIndex[proposalType] < m_diplomacy[foreignerId].GetNumProposalElement());
 
@@ -3492,7 +3343,7 @@ sint32 Diplomat::GetReceiverRegardResult(const PLAYER_INDEX foreignerId,
 }
 
 sint32 Diplomat::GetViolationRegardCost(const PLAYER_INDEX foreignerId,
-							  const PROPOSAL_TYPE proposalType ) const
+                                        const PROPOSAL_TYPE proposalType ) const
 {
 	Assert(s_proposalTypeToElemIndex[proposalType] < m_diplomacy[foreignerId].GetNumProposalElement());
 
@@ -3505,7 +3356,7 @@ sint32 Diplomat::GetViolationRegardCost(const PLAYER_INDEX foreignerId,
 }
 
 sint32 Diplomat::GetViolationTrustCost(const PLAYER_INDEX foreignerId,
-							 const PROPOSAL_TYPE proposalType ) const
+                                       const PROPOSAL_TYPE proposalType ) const
 {
 	Assert(s_proposalTypeToElemIndex[proposalType] < m_diplomacy[foreignerId].GetNumProposalElement());
 
@@ -3517,9 +3368,6 @@ sint32 Diplomat::GetViolationTrustCost(const PLAYER_INDEX foreignerId,
 	return value;
 }
 
-
-
-
 const NewProposal & Diplomat::GetNewProposalPending(const PLAYER_INDEX foreignerId) const
 {
 	const NewProposal & new_proposal = GetMyLastNewProposal(foreignerId);
@@ -3530,7 +3378,6 @@ const NewProposal & Diplomat::GetNewProposalPending(const PLAYER_INDEX foreigner
 		if (new_proposal.senderId == m_playerId &&
 			GetReceiverHasInitiative(foreignerId) == false)
 			return s_badNewProposal;
-
 
 		if (new_proposal.receiverId == m_playerId &&
 			GetDiplomat(new_proposal.senderId).GetReceiverHasInitiative(m_playerId) == true)
@@ -3546,11 +3393,9 @@ const NewProposal & Diplomat::GetNewProposalAdvice(const PLAYER_INDEX foreignerI
 
 	if (new_proposal != s_badNewProposal)
 	{
-
 		if (new_proposal.senderId == m_playerId &&
 			GetReceiverHasInitiative(foreignerId) == true)
 			return s_badNewProposal;
-
 
 		if (new_proposal.receiverId == m_playerId &&
 			GetDiplomat(new_proposal.senderId).GetReceiverHasInitiative(m_playerId) == false)
@@ -3560,12 +3405,8 @@ const NewProposal & Diplomat::GetNewProposalAdvice(const PLAYER_INDEX foreignerI
 	return new_proposal;
 }
 
-void Diplomat::InitStrategicState() {
-
-
-
-
-
+void Diplomat::InitStrategicState()
+{
 	Assert(m_playerId >=0);
 
 	m_bestStrategicStates.clear();
@@ -3578,22 +3419,15 @@ void Diplomat::InitStrategicState() {
 	}
 	else
 	{
-
 		g_gevManager->AddEvent(GEV_INSERT_Tail, GEV_InitStrategicState,
-							   GEA_Player, m_playerId,
-							   GEA_End);
+		                       GEA_Player, m_playerId,
+		                       GEA_End);
 	}
-
 }
 
-void Diplomat::NextStrategicState() {
-
-
-
-
-
+void Diplomat::NextStrategicState()
+{
 	m_bestStrategicStates.clear();
-
 
 	if (GetPersonality()->GetIndex() == 0)
 	{
@@ -3603,10 +3437,9 @@ void Diplomat::NextStrategicState() {
 	}
 	else
 	{
-
 		g_gevManager->AddEvent(GEV_INSERT_Tail, GEV_NextStrategicState,
-							   GEA_Player, m_playerId,
-							   GEA_End);
+		                       GEA_Player, m_playerId,
+		                       GEA_End);
 	}
 }
 
@@ -3693,26 +3526,22 @@ void Diplomat::SetStrategy(const sint32 index)
 	}
 }
 
-void Diplomat::MergeStrategy(const sint32 index) {
+void Diplomat::MergeStrategy(const sint32 index)
+{
 	const StrategyRecord *strategy = g_theStrategyDB->Get(index);
 
-	if (strategy && strategy->GetNumInherit() > 0) {
+	if (strategy && strategy->GetNumInherit() > 0)
+	{
 		const StrategyRecord *inherit_strategy = strategy->GetInherit(0);
 
 		MergeStrategy(inherit_strategy->GetIndex());
 		m_strategy.Merge(*strategy);
 	}
-	else if(strategy) {
-
+	else if(strategy)
+	{
 		m_strategy.Merge(*strategy);
 	}
 }
-
-
-
-
-
-
 
 void Diplomat::InitDiplomaticState(const PLAYER_INDEX & foreignerId)
 {
@@ -3720,17 +3549,17 @@ void Diplomat::InitDiplomaticState(const PLAYER_INDEX & foreignerId)
 	m_diplomaticStates[foreignerId] = s_badAiState;
 
 	if (    g_player[m_playerId]             // Maybe this should be caught earlier
-		 && g_player[foreignerId]
-         && !g_player[foreignerId]->IsDead()
-         && (foreignerId != m_playerId)
-       )
-    {
-    	g_gevManager->AddEvent(GEV_INSERT_Tail, GEV_InitDiplomaticState,
-	                           GEA_Player, m_playerId,
-			                   GEA_Player, foreignerId,
-			                   GEA_End
-                              );
-    }
+	     && g_player[foreignerId]
+	     && !g_player[foreignerId]->IsDead()
+	     && (foreignerId != m_playerId)
+	   )
+	{
+		g_gevManager->AddEvent(GEV_INSERT_Tail, GEV_InitDiplomaticState,
+		                       GEA_Player, m_playerId,
+		                       GEA_Player, foreignerId,
+		                       GEA_End
+		                      );
+	}
 }
 
 void Diplomat::NextDiplomaticState( const PLAYER_INDEX & foreignerId )
@@ -3738,71 +3567,73 @@ void Diplomat::NextDiplomaticState( const PLAYER_INDEX & foreignerId )
 	m_bestDiplomaticState = s_badAiState;
 
 	g_gevManager->AddEvent(GEV_INSERT_Tail, GEV_NextDiplomaticState,
-                           GEA_Player, m_playerId,
-                           GEA_Player, foreignerId,
-			               GEA_End
-                          );
+	                       GEA_Player, m_playerId,
+	                       GEA_Player, foreignerId,
+	                       GEA_End
+	                      );
 
-    /// @todo Make this a game setting. It is not really a user profile setting.
-    sint32 const        baseExpiryTurn =
-        g_theProfileDB->GetValueByName("AutoExpireTreatyBase");
+	/// @todo Make this a game setting. It is not really a user profile setting.
+	sint32 const        baseExpiryTurn =
+	    g_theProfileDB->GetValueByName("AutoExpireTreatyBase");
 
-    if (k_EXPIRATION_NEVER == baseExpiryTurn)
-    {
-        // No action: agreements will not be terminated automatically.
-    }
-    else
-    {
-        // added by PFT 05 MAR 05: some agreements have limited duration
+	if (k_EXPIRATION_NEVER == baseExpiryTurn)
+	{
+		// No action: agreements will not be terminated automatically.
+	}
+	else
+	{
+		// added by PFT 05 MAR 05: some agreements have limited duration
 
-        // TODO: Check whether this is the right place to do this.
-        //       Maybe better use Agreement::SetExpires when starting the agreement?
+		// TODO: Check whether this is the right place to do this.
+		//       Maybe better use Agreement::SetExpires when starting the agreement?
 
-	    for (sint32 prop_index = 1; prop_index < PROPOSAL_MAX; ++prop_index)
-        {
-            PROPOSAL_TYPE const prop_type   = static_cast<PROPOSAL_TYPE>(prop_index);
+		for (sint32 prop_index = 1; prop_index < PROPOSAL_MAX; ++prop_index)
+		{
+			PROPOSAL_TYPE const prop_type   = static_cast<PROPOSAL_TYPE>(prop_index);
 
-	        if (AgreementMatrix::s_agreements.HasAgreement
-                    (m_playerId, foreignerId, prop_type)
-               )
-            {
-			    sint32 const    duration        =
-                    AgreementMatrix::s_agreements.GetAgreementDuration
-                        (m_playerId, foreignerId, prop_type);
+			if (AgreementMatrix::s_agreements.HasAgreement
+			        (m_playerId, foreignerId, prop_type)
+			   )
+			{
+				sint32 const    duration        =
+				    AgreementMatrix::s_agreements.GetAgreementDuration
+				        (m_playerId, foreignerId, prop_type);
 
-                sint32 const    expiryTurn      =
-                    ProposalAutoExpiryTurn(baseExpiryTurn, prop_type);
+				sint32 const    expiryTurn      =
+				    ProposalAutoExpiryTurn(baseExpiryTurn, prop_type);
 
-                if (duration == expiryTurn)
-                {
-                    AgreementMatrix::s_agreements.CancelAgreement
-                        (m_playerId, foreignerId, prop_type);
-			    }
-			    else if ((expiryTurn > 2 * WARN_EXPIRY_TURN_COUNT) &&
-                         (duration == expiryTurn - WARN_EXPIRY_TURN_COUNT)
-                        )
-                {
-                    SlicObject * so = new SlicObject("001TreatyToExpire");
-				    so->AddRecipient(m_playerId);
-				    so->AddCivilisation(foreignerId);
-			        g_slicEngine->Execute(so);
-			    }
-            }
-	    }
-    }
+				if (duration == expiryTurn)
+				{
+					AgreementMatrix::s_agreements.CancelAgreement
+					    (m_playerId, foreignerId, prop_type);
+				}
+				else if ((expiryTurn > 2 * WARN_EXPIRY_TURN_COUNT) &&
+				         (duration == expiryTurn - WARN_EXPIRY_TURN_COUNT)
+				        )
+				{
+					SlicObject * so = new SlicObject("001TreatyToExpire");
+					so->AddRecipient(m_playerId);
+					so->AddCivilisation(foreignerId);
+					g_slicEngine->Execute(so);
+				}
+			}
+		}
+	}
 }
 
-void Diplomat::ConsiderDiplomaticState( const PLAYER_INDEX & foreignerId, const AiState & state ) {
-
+void Diplomat::ConsiderDiplomaticState( const PLAYER_INDEX & foreignerId, const AiState & state )
+{
 	if (m_bestDiplomaticState.priority < state.priority)
 		m_bestDiplomaticState = state;
 }
 
-const AiState & Diplomat::GetBestDiplomaticState() const {
+const AiState & Diplomat::GetBestDiplomaticState() const
+{
 	return m_bestDiplomaticState;
 }
 
-const AiState & Diplomat::GetCurrentDiplomaticState( const PLAYER_INDEX & foreignerId ) const {
+const AiState & Diplomat::GetCurrentDiplomaticState( const PLAYER_INDEX & foreignerId ) const
+{
 	return m_diplomaticStates[foreignerId];
 }
 
@@ -3936,11 +3767,6 @@ void Diplomat::ChangeDiplomacy(const PLAYER_INDEX & foreignerId, const sint32 in
 	}
 }
 
-
-
-
-
-
 sint32 Diplomat::GetNextAdvance() const
 {
 	if (g_player[m_playerId] == NULL)
@@ -3995,7 +3821,6 @@ sint32 Diplomat::GetDesiredAdvanceFrom( const PLAYER_INDEX & foreignerId, const 
 
 	if (wanted_advance == rec->GetNumAdvance())
 	{
-
 		return -1;
 	}
 
@@ -4181,17 +4006,8 @@ StringId Diplomat::GetScienceAdvice(SlicContext & sc, StringId & advance_advice)
 		}
 	}
 
-
-
-
-
 	return -1;
 }
-
-
-
-
-
 
 sint32 Diplomat::GetTradeFrom(const PLAYER_INDEX & foreignId) const
 {
@@ -4207,15 +4023,15 @@ sint32 Diplomat::GetGoldSurplusPercent() const
 {
 	Assert(g_player[m_playerId] != NULL);
 	Assert(g_player[m_playerId]->m_gold != NULL);
-    sint32 lost_to_cleric;
+	sint32 lost_to_cleric;
 	sint32 lost_to_crime;
 	sint32 maintenance;
 	sint32 wages;
-    sint32 science;
+	sint32 science;
 	sint32 old_savings;
 	sint32 current_savings;
 	sint32 income;
-    g_player[m_playerId]->m_gold->
+	g_player[m_playerId]->m_gold->
 		GetGoldLevels(&income, &lost_to_cleric, &lost_to_crime, &maintenance,
 					  &wages, &science, &old_savings, &current_savings);
 
@@ -4226,7 +4042,7 @@ sint32 Diplomat::GetGoldSurplusPercent() const
 
 // Not used
 bool Diplomat::CanBuySurplus(const PLAYER_INDEX &foreignId) const {
-    /// @todo Check meaning: always returns false now.
+	/// @todo Check meaning: always returns false now.
 	sint32 goldReserve = 100;
 	sint32 minSurplusCost = 50;
 	return ((minSurplusCost > 0) && (minSurplusCost > goldReserve));
@@ -4249,16 +4065,17 @@ sint32 Diplomat::AtWarCount() const
 	sint32 atWarCount = 0;
 
 	for (size_t foreigner = 1; foreigner < m_foreigners.size(); ++foreigner)
-    {
-        PLAYER_INDEX const  foreignerId  = static_cast<PLAYER_INDEX>(foreigner);
-        if (    (foreignerId != m_playerId)
-             && AgreementMatrix::s_agreements.HasAgreement
-                    (m_playerId, foreignerId, PROPOSAL_TREATY_DECLARE_WAR)
-           )
-        {
-            ++atWarCount;
-        }
-    }
+	{
+		PLAYER_INDEX const  foreignerId  = static_cast<PLAYER_INDEX>(foreigner);
+		if (    (foreignerId != m_playerId)
+		     && AgreementMatrix::s_agreements.HasAgreement
+		            (m_playerId, foreignerId, PROPOSAL_TREATY_DECLARE_WAR)
+		   )
+		{
+			++atWarCount;
+		}
+	}
+
 	return atWarCount;
 }
 
@@ -4266,17 +4083,17 @@ sint32 Diplomat::EffectiveAtWarCount() const
 {
 	int atWarCount = 0;
 
-    /// @todo Check inconsistent inclusion of 0 (barbarians), see AtWarCount
-    for (size_t foreigner = 0; foreigner < m_foreigners.size(); ++foreigner)
-    {
-        PLAYER_INDEX const  foreignerId  = static_cast<PLAYER_INDEX>(foreigner);
-        if (    (foreignerId != m_playerId)
-             && TestEffectiveRegard(foreigner, HOTWAR_REGARD)
-           )
-        {
-            ++atWarCount;
-        }
-    }
+	/// @todo Check inconsistent inclusion of 0 (barbarians), see AtWarCount
+	for (size_t foreigner = 0; foreigner < m_foreigners.size(); ++foreigner)
+	{
+		PLAYER_INDEX const  foreignerId  = static_cast<PLAYER_INDEX>(foreigner);
+		if (    (foreignerId != m_playerId)
+		     && TestEffectiveRegard(foreigner, HOTWAR_REGARD)
+		   )
+		{
+			++atWarCount;
+		}
+	}
 
 	return atWarCount;
 }
@@ -4297,12 +4114,6 @@ bool Diplomat::TestPublicRegard(const PLAYER_INDEX & foreignerId, const ai::Rega
 		return ( regard >= FRIEND_REGARD );
 	return true;
 }
-
-
-
-
-
-
 
 bool Diplomat::TestEffectiveRegard(const PLAYER_INDEX & foreignerId, const ai::Regard & test_regard) const
 {
@@ -4328,7 +4139,7 @@ bool Diplomat::TestEffectiveRegard(const PLAYER_INDEX & foreignerId, const ai::R
 
 #ifdef _DEBUG
 	const bool test = ComputeEffectiveRegard(foreignerId,test_regard);
-    (void) test;
+	(void) test;
 #endif
 
 	return retVal;
@@ -4337,7 +4148,7 @@ bool Diplomat::TestEffectiveRegard(const PLAYER_INDEX & foreignerId, const ai::R
 void Diplomat::ClearEffectiveRegardCache()
 {
 	for (size_t i = 0; i < k_MAX_PLAYERS; ++i)
-    {
+	{
 		m_effectiveRegardCache[i].m_round = -666;
 	}
 }
@@ -4347,11 +4158,11 @@ bool Diplomat::ComputeEffectiveRegard(const PLAYER_INDEX & foreignerId, const ai
 	ai::Regard regard = m_foreigners[foreignerId].GetEffectiveRegard();
 
 	if (AgreementMatrix::s_agreements.HasAgreement
-            (m_playerId,
-		     foreignerId,
-		     PROPOSAL_TREATY_DECLARE_WAR
-            )
-       )
+	        (m_playerId,
+	         foreignerId,
+	         PROPOSAL_TREATY_DECLARE_WAR
+	        )
+	   )
 	{
 		return (test_regard < NEUTRAL_REGARD);
 	}
@@ -4384,7 +4195,6 @@ bool Diplomat::ComputeEffectiveRegard(const PLAYER_INDEX & foreignerId, const ai
 		{
 			if (!DesireWarWith(foreignerId))
 			{
-
 				if (AgreementMatrix::s_agreements.HasAgreement(m_playerId,
 					foreignerId,
 					PROPOSAL_TREATY_PEACE))
@@ -4415,9 +4225,6 @@ bool Diplomat::TestAlliedRegard(const PLAYER_INDEX & foreignerId) const
 		 AgreementMatrix::s_agreements.HasAgreement(m_playerId, foreignerId, PROPOSAL_TREATY_ALLIANCE) ||
 		 AgreementMatrix::s_agreements.HasAgreement(m_playerId, foreignerId, PROPOSAL_TREATY_MILITARY_PACT);
 }
-
-
-
 
 bool Diplomat::GetBorderIncursionBy(const PLAYER_INDEX & foreignerId) const
 {
@@ -4642,20 +4449,20 @@ void Diplomat::UpdateAttributes()
 bool Diplomat::GetTradeRoutePiracyRisk(const Unit & source_city, const Unit & dest_city) const
 {
 	for
-    (
-        PiracyHistoryList::const_iterator piracy_iter = m_piracyHistory.begin();
+	(
+	    PiracyHistoryList::const_iterator piracy_iter = m_piracyHistory.begin();
 	    piracy_iter != m_piracyHistory.end();
-        ++piracy_iter
-    )
+	    ++piracy_iter
+	)
 	{
 		if ((piracy_iter->m_sourceCity == source_city) &&
-			(piracy_iter->m_destinationCity == dest_city) &&
-			!AgreementMatrix::s_agreements.HasAgreement(piracy_iter->m_piratingPlayer,
-													   m_playerId, PROPOSAL_OFFER_STOP_PIRACY)
-           )
+		    (piracy_iter->m_destinationCity == dest_city) &&
+		    !AgreementMatrix::s_agreements.HasAgreement(piracy_iter->m_piratingPlayer,
+		                                                m_playerId, PROPOSAL_OFFER_STOP_PIRACY)
+		   )
 		{
-        	sint32 max_piracy_events;
-	        GetCurrentStrategy().GetMaxPiracyEvents(max_piracy_events);
+			sint32 max_piracy_events;
+			GetCurrentStrategy().GetMaxPiracyEvents(max_piracy_events);
 
 			return piracy_iter->m_accumEvents >= max_piracy_events;
 		}
@@ -4696,64 +4503,61 @@ void Diplomat::ComputeTradeRoutePiracyRisk()
 	sint32 piracy_regard_cost;
 
 	for (sint32 i = 0; i < num_cities; i++)
-		{
-			city = player_ptr->m_all_cities->Access(i);
-			Assert(city.IsValid());
+	{
+		city = player_ptr->m_all_cities->Access(i);
+		Assert(city.IsValid());
 
-			for (sint32 r = 0; r < city.CD()->GetTradeSourceList()->Num(); r++) {
-				route = city.CD()->GetTradeSourceList()->Access(r);
+		for (sint32 r = 0; r < city.CD()->GetTradeSourceList()->Num(); r++) {
+			route = city.CD()->GetTradeSourceList()->Access(r);
 
-				if (route->IsBeingPirated())
-					{
+			if (route->IsBeingPirated())
+			{
+				piracy.m_sourceCity = route->GetSource();
+				piracy.m_destinationCity = route->GetDestination();
+				piracy.m_piratingPlayer =
+				route->GetPiratingArmy().GetOwner();
 
-						piracy.m_sourceCity = route->GetSource();
-						piracy.m_destinationCity = route->GetDestination();
-						piracy.m_piratingPlayer =
-							route->GetPiratingArmy().GetOwner();
+				GetCurrentDiplomacy(piracy.m_piratingPlayer).
+				GetPerRoutePiracyRegardCost(piracy_regard_cost);
 
-						GetCurrentDiplomacy(piracy.m_piratingPlayer).
-							GetPerRoutePiracyRegardCost(piracy_regard_cost);
+				LogRegardEvent( piracy.m_piratingPlayer,
+								piracy_regard_cost,
+								REGARD_EVENT_GOLD,
+								piracy_str_id );
 
-						LogRegardEvent( piracy.m_piratingPlayer,
-										piracy_regard_cost,
-										REGARD_EVENT_GOLD,
-										piracy_str_id );
+				piracy_iter = std::find(m_piracyHistory.begin(),
+								        m_piracyHistory.end(),
+								        piracy);
 
-						piracy_iter = std::find(m_piracyHistory.begin(),
-										        m_piracyHistory.end(),
-										        piracy);
-
-						if (piracy_iter != m_piracyHistory.end())
-							{
-
-								piracy_iter->m_accumEvents++;
-								piracy_iter->m_lastTurn = cur_round;
-							}
-						else
-							{
-
-								piracy.m_accumEvents = 1;
-								piracy.m_lastTurn = cur_round;
-								m_piracyHistory.push_front(piracy);
-							}
-					}
+				if (piracy_iter != m_piracyHistory.end())
+				{
+					piracy_iter->m_accumEvents++;
+					piracy_iter->m_lastTurn = cur_round;
+				}
+				else
+				{
+					piracy.m_accumEvents = 1;
+					piracy.m_lastTurn = cur_round;
+					m_piracyHistory.push_front(piracy);
+				}
 			}
 		}
+	}
 }
 
 bool Diplomat::GetTradeRoutePiracyRisk(const PLAYER_INDEX foreignerId) const
 {
 	for
-    (
-        PiracyHistoryList::const_iterator piracy_iter = m_piracyHistory.begin();
+	(
+	    PiracyHistoryList::const_iterator piracy_iter = m_piracyHistory.begin();
 	    piracy_iter != m_piracyHistory.end();
-        ++piracy_iter
-    )
+	    ++piracy_iter
+	)
 	{
 		if ((piracy_iter->m_piratingPlayer == foreignerId) &&
-			!AgreementMatrix::s_agreements.HasAgreement
-                (piracy_iter->m_piratingPlayer, m_playerId, PROPOSAL_OFFER_STOP_PIRACY)
-           )
+		     !AgreementMatrix::s_agreements.HasAgreement
+		        (piracy_iter->m_piratingPlayer, m_playerId, PROPOSAL_OFFER_STOP_PIRACY)
+		   )
 		{
 			return true;
 		}
@@ -4791,16 +4595,16 @@ void Diplomat::ComputeIncursionPermission()
 		PLAYER_INDEX foreignerId = static_cast<PLAYER_INDEX>(foreignerIndex);
 
 		if (    (foreignerId == m_playerId)                 // own territory
-            ||  !player_ptr->HasContactWith(foreignerId)    // never met
-            ||  agreements.HasAgreement                     // military pact
-                    (m_playerId, foreignerId, PROPOSAL_TREATY_MILITARY_PACT)
-            ||  agreements.HasAgreement                     // alliance
-                    (m_playerId, foreignerId, PROPOSAL_TREATY_ALLIANCE)
-            ||  (!agreements.HasAgreement                   // (almost) war
-                    (m_playerId, foreignerId, PROPOSAL_OFFER_WITHDRAW_TROOPS) &&
-                 TestEffectiveRegard(foreignerId, COLDWAR_REGARD)
-                )
-           )
+		    ||  !player_ptr->HasContactWith(foreignerId)    // never met
+		    ||  agreements.HasAgreement                     // military pact
+		            (m_playerId, foreignerId, PROPOSAL_TREATY_MILITARY_PACT)
+		    ||  agreements.HasAgreement                     // alliance
+		            (m_playerId, foreignerId, PROPOSAL_TREATY_ALLIANCE)
+		    ||  (!agreements.HasAgreement                   // (almost) war
+		            (m_playerId, foreignerId, PROPOSAL_OFFER_WITHDRAW_TROOPS) &&
+		         TestEffectiveRegard(foreignerId, COLDWAR_REGARD)
+		        )
+		   )
 		{
 			m_incursionPermission |= (1 << foreignerId);
 		}
@@ -4839,7 +4643,6 @@ sint32 Diplomat::GetLastColdwarAttack(const PLAYER_INDEX foreignerId) const
 
 PLAYER_INDEX Diplomat::ComputeNuclearLaunchTarget()
 {
-
 	m_nuclearAttackTarget = -1;
 
 	if ((m_strategy.GetNuclearFirstStrikeDisabled() &&
@@ -4847,15 +4650,6 @@ PLAYER_INDEX Diplomat::ComputeNuclearLaunchTarget()
 		(!m_strategy.GetNuclearFirstStrikeEnabled() &&
 		 !m_strategy.GetNuclearTargetingEnabled()))
 		return -1;
-
-
-
-
-
-
-
-
-
 
 	sint32 our_nuke_count =
 		MapAnalysis::GetMapAnalysis().GetNuclearWeaponsCount(m_playerId);
@@ -4874,14 +4668,13 @@ PLAYER_INDEX Diplomat::ComputeNuclearLaunchTarget()
 			our_vulnerable_city_count++;
 	}
 
-
 	sint32 tmp_nuke_count;
 	for
-    (
-        size_t foreignerIndex = 1;
-        foreignerIndex < s_theDiplomats.size();
-        ++foreignerIndex
-    )
+	(
+	    size_t foreignerIndex = 1;
+	    foreignerIndex < s_theDiplomats.size();
+	    ++foreignerIndex
+	)
 	{
 		player_ptr = g_player[foreignerIndex];
 		if (player_ptr == NULL)
@@ -4967,18 +4760,18 @@ void Diplomat::TargetNuclearAttack(const PLAYER_INDEX foreignerId, const bool la
 	Unit unit;
 	std::list<Unit> weapon_list;
 	for (sint32 i = 0; i < num_armies; i++)
-    {
+	{
 		unit = player_ptr->m_all_units->Access(i);
 
 		if (unit.GetDBRec()->HasNuclearAttack())
-        {
-    		if (unit->GetArmy().m_id != 0)
-            {
-			    unit->GetArmy()->ClearOrders();
-            }
+		{
+			if (unit->GetArmy().m_id != 0)
+			{
+				unit->GetArmy()->ClearOrders();
+			}
 
-		    weapon_list.push_back(unit);
-        }
+			weapon_list.push_back(unit);
+		}
 	}
 
 	bool no_first_strike = false;
@@ -5023,22 +4816,22 @@ void Diplomat::TargetNuclearAttack(const PLAYER_INDEX foreignerId, const bool la
 			target_pos = city_iter->second->GetPos();
 
 			for
-            (
-                nuke_iter = weapon_list.begin();
+			(
+			    nuke_iter = weapon_list.begin();
 			    nuke_iter != weapon_list.end();
 			    ++nuke_iter
-            )
+			)
 			{
-                if (nuke_iter->IsValid())
-                {
-				    weapon_pos = nuke_iter->RetPos();
-				    tmp_nuke_dist = MapPoint::GetSquaredDistance(target_pos, weapon_pos);
-				    if (tmp_nuke_dist < closest_nuke_dist)
-				    {
-					    closest_nuke_dist = tmp_nuke_dist;
-					    closest_nuke_iter = nuke_iter;
-				    }
-                }
+				if (nuke_iter->IsValid())
+				{
+					weapon_pos = nuke_iter->RetPos();
+					tmp_nuke_dist = MapPoint::GetSquaredDistance(target_pos, weapon_pos);
+					if (tmp_nuke_dist < closest_nuke_dist)
+					{
+						closest_nuke_dist = tmp_nuke_dist;
+						closest_nuke_iter = nuke_iter;
+					}
+				}
 			}
 
 			bool close_enough = false;
@@ -5051,12 +4844,10 @@ void Diplomat::TargetNuclearAttack(const PLAYER_INDEX foreignerId, const bool la
 
 			if (close_enough)
 			{
-
 				(*closest_nuke_iter)->SetTargetCity(city_iter->second);
 
 				if (launch_now && !no_first_strike)
 				{
-
 					unitutil_ExecuteMadLaunch(*closest_nuke_iter);
 				}
 
@@ -5066,9 +4857,7 @@ void Diplomat::TargetNuclearAttack(const PLAYER_INDEX foreignerId, const bool la
 			}
 			else
 			{
-
 				city_iter = nuke_city_list.erase(city_iter);
-
 			}
 		}
 		continue_targeting = (weapon_list.size() > 0) && (nuke_city_list.size() > 0);
@@ -5084,17 +4873,17 @@ void Diplomat::ComputeNukeTargets(NukeTargetList & city_list, const PLAYER_INDEX
 	city_list.clear();
 
 	for
-    (
-        size_t foreignerIndex = 0;
-        foreignerIndex < s_theDiplomats.size();
-        ++foreignerIndex
-    )
+	(
+	    size_t foreignerIndex = 0;
+	    foreignerIndex < s_theDiplomats.size();
+	    ++foreignerIndex
+	)
 	{
 		player_ptr = g_player[foreignerIndex];
 		if (player_ptr == NULL)
 			continue;
 
-        PLAYER_INDEX foreignerId = static_cast<PLAYER_INDEX>(foreignerIndex);
+		PLAYER_INDEX foreignerId = static_cast<PLAYER_INDEX>(foreignerIndex);
 
 		if (foreignerId == m_playerId)
 			continue;
@@ -5103,13 +4892,11 @@ void Diplomat::ComputeNukeTargets(NukeTargetList & city_list, const PLAYER_INDEX
 
 		if (targetId != PLAYER_UNASSIGNED)
 		{
-
 			if (foreignerId != targetId)
 				continue;
 		}
 		else
 		{
-
 			if (regard >= COLDWAR_REGARD)
 				continue;
 
@@ -5153,21 +4940,21 @@ void Diplomat::DisbandNuclearWeapons(const double percent)
 
 	sint32  total_weapons = 0;
 	Unit    unit;
-    sint32  i;
+	sint32  i;
 
 	for (i = player_ptr->m_all_units->Num() - 1; i >= 0; --i)
-    {
+	{
 		unit = player_ptr->m_all_units->Access(i);
 		if (unit.IsValid() && unit.GetDBRec()->HasNuclearAttack())
-        {
+		{
 			++total_weapons;
-        }
+		}
 	}
 
 	sint32 goal_weapons = static_cast<sint32>(total_weapons * (1.0 - percent));
 
 	for (i = player_ptr->m_all_units->Num() - 1; i >= 0 && (total_weapons > goal_weapons); --i)
-    {
+	{
 		unit = player_ptr->m_all_units->Access(i);
 		if (unit.IsValid() && unit.GetDBRec()->HasNuclearAttack())
 		{
@@ -5182,28 +4969,28 @@ void Diplomat::DisbandNuclearWeapons(const double percent)
 void Diplomat::DisbandBioWeapons(const double percent)
 {
 	Player *    player_ptr = g_player[m_playerId];
-    Assert(player_ptr && player_ptr->m_all_units);
+	Assert(player_ptr && player_ptr->m_all_units);
 
 	if (player_ptr == NULL)
 		return;
 
 	sint32  total_weapons = 0;
 	Unit    unit;
-    sint32  i;
+	sint32  i;
 
 	for (i = player_ptr->m_all_units->Num() - 1; i >= 0; --i)
-    {
+	{
 		unit = player_ptr->m_all_units->Access(i);
 		if (unit.IsValid() && unit.GetDBRec()->HasBioTerror())
-        {
+		{
 			++total_weapons;
-        }
+		}
 	}
 
 	sint32 goal_weapons = static_cast<sint32>(total_weapons * (1.0 - percent));
 
 	for (i = player_ptr->m_all_units->Num() - 1; i >= 0 && (total_weapons > goal_weapons); --i)
-    {
+	{
 		unit = player_ptr->m_all_units->Access(i);
 		if (unit.IsValid() && unit.GetDBRec()->HasBioTerror())
 		{
@@ -5225,21 +5012,21 @@ void Diplomat::DisbandNanoWeapons(const double percent)
 
 	sint32  total_weapons = 0;
 	Unit    unit;
-    sint32  i;
+	sint32  i;
 
 	for (i = player_ptr->m_all_units->Num() - 1; i >= 0; --i)
-    {
+	{
 		unit = player_ptr->m_all_units->Access(i);
 		if (unit.IsValid() && unit.GetDBRec()->HasCreateParks())
-        {
+		{
 			++total_weapons;
-        }
+		}
 	}
 
 	sint32 goal_weapons = static_cast<sint32>(total_weapons * (1.0 - percent));
 
 	for(i = player_ptr->m_all_units->Num() - 1; i >= 0 && (total_weapons > goal_weapons); --i)
-    {
+	{
 		unit = player_ptr->m_all_units->Access(i);
 		if (unit.IsValid() && unit.GetDBRec()->HasCreateParks())
 		{
@@ -5542,12 +5329,12 @@ bool Diplomat::CanFormAlliance(const PLAYER_INDEX foreignerId)
 	Assert(foreigner_ptr);
 
 	for
-    (
-        size_t thirdPartyIndex = 1;
-        thirdPartyIndex < m_foreigners.size();
-        ++thirdPartyIndex
-    )
-    {
+	(
+	    size_t thirdPartyIndex = 1;
+	    thirdPartyIndex < m_foreigners.size();
+	    ++thirdPartyIndex
+	)
+	{
 		PLAYER_INDEX thirdpartyId   = static_cast<PLAYER_INDEX>(thirdPartyIndex);
 		if (thirdpartyId == m_playerId ||
 			thirdpartyId == foreignerId)
@@ -5621,7 +5408,7 @@ void Diplomat::ThrowParty(const PLAYER_INDEX foreignerId)
 		sint32 regard_bonus;
 		StringId strId;
 
-//Add random regard bonus generator for throw party
+		//Add random regard bonus generator for throw party
 		GetCurrentDiplomacy(foreignerId).GetHoldReceptionRegardBonus(regard_bonus);
 
 		g_theStringDB->GetStringID("REGARD_EVENT_HOLD_RECEPTION",strId);
@@ -5728,8 +5515,10 @@ void Diplomat::HasLaunchedNanoAttack(const bool val)
 
 void Diplomat::ClearInitiatives()
 {
-	for (sint32 p = 0; p < k_MAX_PLAYERS; p++) {
-		if(g_player[p]) {
+	for (sint32 p = 0; p < k_MAX_PLAYERS; p++)
+	{
+		if(g_player[p])
+		{
 			SetReceiverHasInitiative(p, false);
 			Diplomat::GetDiplomat(p).SetReceiverHasInitiative(m_playerId, false);
 			SetMyLastNewProposal(p, Diplomat::s_badNewProposal);
@@ -5747,13 +5536,12 @@ bool Diplomat::FirstTurnOfWar() const
 
 	bool at_war = false;
 	for
-    (
-        PLAYER_INDEX foreignerId = 1;
-        static_cast<size_t>(foreignerId) < m_foreigners.size();
-        ++foreignerId
-    )
+	(
+	    PLAYER_INDEX foreignerId = 1;
+	    static_cast<size_t>(foreignerId) < m_foreigners.size();
+	    ++foreignerId
+	)
 	{
-
 		if (foreignerId == m_playerId)
 			continue;
 

--- a/ctp2_code/gs/gameobj/TradeRoute.cpp
+++ b/ctp2_code/gs/gameobj/TradeRoute.cpp
@@ -144,32 +144,6 @@ void TradeRoute::GetSourceResource(ROUTE_TYPE &type, sint32 &resource) const
 	GetData()->GetSourceResource(type, resource);
 }
 
-void TradeRoute::SetLastTimePirated(sint32 currentTurn)
-{
-	AccessData()->SetLastTimePirated(currentTurn);
-}
-
-sint32 TradeRoute::GetLastTimePirated() const
-{
-	return GetData()->GetLastTimePirated();
-}
-
-void TradeRoute::IncreaseAccumulatedTimePirated()
-{
-	AccessData()->IncreaseAccumulatedTimePirated();
-}
-
-void TradeRoute::ResetAccumulatedTimePirated()
-{
-	AccessData()->ResetAccumulatedTimePirated();
-}
-
-uint16 TradeRoute::GetAccumulatedTimePirated()
-{
-	return GetData()->GetAccumulatedTimePirated();
-}
-
-
 BOOL TradeRoute::PassesThrough(sint32 player) const
 {
 	return GetData()->PassesThrough(player);

--- a/ctp2_code/gs/gameobj/TradeRoute.cpp
+++ b/ctp2_code/gs/gameobj/TradeRoute.cpp
@@ -144,20 +144,31 @@ void TradeRoute::GetSourceResource(ROUTE_TYPE &type, sint32 &resource) const
 	GetData()->GetSourceResource(type, resource);
 }
 
-TradeRoute TradeRoute::GetRecip() const
+void TradeRoute::SetLastTimePirated(sint32 currentTurn)
 {
-	return GetData()->GetRecip();
+	AccessData()->SetLastTimePirated(currentTurn);
 }
 
-TradeRoute TradeRoute::AccessRecip()
+sint32 TradeRoute::GetLastTimePirated() const
 {
-	return AccessData()->AccessRecip();
+	return GetData()->GetLastTimePirated();
 }
 
-void TradeRoute::SetRecip(TradeRoute route)
+void TradeRoute::IncreaseAccumulatedTimePirated()
 {
-	AccessData()->SetRecip(route);
+	AccessData()->IncreaseAccumulatedTimePirated();
 }
+
+void TradeRoute::ResetAccumulatedTimePirated()
+{
+	AccessData()->ResetAccumulatedTimePirated();
+}
+
+uint16 TradeRoute::GetAccumulatedTimePirated()
+{
+	return GetData()->GetAccumulatedTimePirated();
+}
+
 
 BOOL TradeRoute::PassesThrough(sint32 player) const
 {

--- a/ctp2_code/gs/gameobj/TradeRoute.cpp
+++ b/ctp2_code/gs/gameobj/TradeRoute.cpp
@@ -40,11 +40,6 @@ void TradeRoute::RemoveAllReferences(CAUSE_KILL_TRADE_ROUTE cause)
 	g_director->TradeActorDestroy(*this);
 	TradeRouteData* data = AccessData();
 
-
-
-
-
-
 	Unit source(data->GetSource()), dest(data->GetDestination());
 
 
@@ -70,10 +65,10 @@ void TradeRoute::RemoveAllReferences(CAUSE_KILL_TRADE_ROUTE cause)
 		}
 	}
 
-    if ((NULL != g_player)  &&
-        (NULL != g_player[GetPayingFor()])) {
-    	g_player[GetPayingFor()]->RemoveTradeRoute(*this, cause);
-    }
+	if ((NULL != g_player)  &&
+	    (NULL != g_player[GetPayingFor()])) {
+		g_player[GetPayingFor()]->RemoveTradeRoute(*this, cause);
+	}
 
 	data->RemoveFromCells();
 
@@ -85,9 +80,6 @@ void TradeRoute::RemoveAllReferences(CAUSE_KILL_TRADE_ROUTE cause)
 		AccessRecip().KillRoute();
 	}
 #endif
-
-
-
 
 	if(g_network.IsHost()) {
 		g_network.Enqueue(new NetInfo(NET_INFO_CODE_KILL_TRADE_ROUTE, (uint32)*this, (uint32)cause));
@@ -117,13 +109,13 @@ PLAYER_INDEX TradeRoute::GetPayingFor() const
 
 const TradeRouteData* TradeRoute::GetData() const
 {
-    Assert(g_theTradePool);
+	Assert(g_theTradePool);
 	return g_theTradePool->GetTradeRoute(*this);
 }
 
 TradeRouteData* TradeRoute::AccessData() const
 {
-    Assert(g_theTradePool);
+	Assert(g_theTradePool);
 	return g_theTradePool->AccessTradeRoute(*this);
 }
 
@@ -209,12 +201,12 @@ uint32 TradeRoute::GetOutlineColor() const
 
 void TradeRoute::SetColor( uint32 color )
 {
-	 AccessData()->SetColor(color);
+	AccessData()->SetColor(color);
 }
 
 void TradeRoute::SetOutlineColor( uint32 color )
 {
-	 AccessData()->SetOutlineColor(color);
+	AccessData()->SetOutlineColor(color);
 }
 
 void TradeRoute::ReturnPath(const PLAYER_INDEX owner, DynamicArray<MapPoint> &waypoints,

--- a/ctp2_code/gs/gameobj/TradeRoute.h
+++ b/ctp2_code/gs/gameobj/TradeRoute.h
@@ -102,10 +102,10 @@ public:
 	StringId GetResourceName() const;
 
 	void ReturnPath(const PLAYER_INDEX owner, DynamicArray<MapPoint> &waypoints,
-					DynamicArray<MapPoint> &fullpath,
-					double &cost);
+	                DynamicArray<MapPoint> &fullpath,
+	                double &cost);
 	void SetPath(DynamicArray<MapPoint> &fullpath,
-				 DynamicArray<MapPoint> &waypoints);
+	             DynamicArray<MapPoint> &waypoints);
 
 	void BeginTurn();
 

--- a/ctp2_code/gs/gameobj/TradeRoute.h
+++ b/ctp2_code/gs/gameobj/TradeRoute.h
@@ -63,12 +63,6 @@ public:
 
 	void GetSourceResource(ROUTE_TYPE &type, sint32 &resource) const;
 
-	void     SetLastTimePirated(sint32 currentTurn);
-	sint32   GetLastTimePirated() const;
-	void IncreaseAccumulatedTimePirated();
-	void    ResetAccumulatedTimePirated();
-	uint16    GetAccumulatedTimePirated();
-
 	BOOL PassesThrough(sint32 player) const;
 
 	BOOL CrossesWater() const;

--- a/ctp2_code/gs/gameobj/TradeRoute.h
+++ b/ctp2_code/gs/gameobj/TradeRoute.h
@@ -63,12 +63,13 @@ public:
 
 	void GetSourceResource(ROUTE_TYPE &type, sint32 &resource) const;
 
-	TradeRoute GetRecip() const;
-	TradeRoute AccessRecip();
-	void SetRecip(TradeRoute route);
+	void     SetLastTimePirated(sint32 currentTurn);
+	sint32   GetLastTimePirated() const;
+	void IncreaseAccumulatedTimePirated();
+	void    ResetAccumulatedTimePirated();
+	uint16    GetAccumulatedTimePirated();
 
 	BOOL PassesThrough(sint32 player) const;
-	void SetTariff(sint32 player, BOOL b);
 
 	BOOL CrossesWater() const;
 

--- a/ctp2_code/gs/gameobj/TradeRouteData.cpp
+++ b/ctp2_code/gs/gameobj/TradeRouteData.cpp
@@ -118,7 +118,7 @@ TradeRouteData::TradeRouteData
 TradeRouteData::TradeRouteData(CivArchive &archive) : GameObj(0)
 {
 	m_astarPath = new Path;
-	m_dontAdjustPointsWhenKilled = FALSE;
+	m_dontAdjustPointsWhenKilled = false;
 	Serialize(archive);
 }
 
@@ -331,7 +331,7 @@ void TradeRouteData::ReturnPath
 
 	fullpath.Insert(waypoints[0]);
 	MapPoint pnt;
-	m_crossesWater = FALSE;
+	m_crossesWater = false;
 	for (int p = 1; p < m_astarPath->Num(); p++) {
 		WORLD_DIRECTION d;
 		m_astarPath->GetCurrentDir(d);
@@ -340,7 +340,7 @@ void TradeRouteData::ReturnPath
 		if(r) {
 			fullpath.Insert(pnt);
 			if(g_theWorld->IsWater(pnt)) {
-				m_crossesWater = TRUE;
+				m_crossesWater = true;
 			}
 		}
 
@@ -585,7 +585,7 @@ double TradeRouteData::GetCost() const
 
 void TradeRouteData::DontAdjustPointsWhenKilled()
 {
-	m_dontAdjustPointsWhenKilled = TRUE;
+	m_dontAdjustPointsWhenKilled = true;
 }
 
 sint32 TradeRouteData::GetValue() const

--- a/ctp2_code/gs/gameobj/TradeRouteData.cpp
+++ b/ctp2_code/gs/gameobj/TradeRouteData.cpp
@@ -50,52 +50,51 @@
 #include "radarmap.h"
 #include "tradeutil.h"
 
-
 extern TradeAstar g_theTradeAstar;
 
 TradeRouteData::TradeRouteData
 (
-	const TradeRoute    route,
-	const Unit          source,
-	const Unit          dest,
-	const PLAYER_INDEX  owner,
-	const ROUTE_TYPE    sourceType,
-	const sint32        sourceResource,
-	PLAYER_INDEX        paying_for,
-	sint32              gold_in_return
+    const TradeRoute    route,
+    const Unit          source,
+    const Unit          dest,
+    const PLAYER_INDEX  owner,
+    const ROUTE_TYPE    sourceType,
+    const sint32        sourceResource,
+    PLAYER_INDEX        paying_for,
+    sint32              gold_in_return
 )
 :
-	GameObj                         (route.m_id),
+    GameObj                         (route.m_id),
     CityRadiusCallback              (),
-	m_transportCost                 (0.0),
-	m_owner                         (owner),
-	m_payingFor                     (paying_for),
-	m_piratingArmy                  (),
-	m_sourceRouteType               (sourceType),
-	m_sourceResource                (sourceResource),
-	m_crossesWater                  (false),
-	m_isActive                      (false),
-	m_color                         (g_colorSet->GetColor(COLOR_YELLOW)),
-	m_outline                       (g_colorSet->GetColor(COLOR_BLACK)),
-	m_selectedIndex                 (0),
-	m_valid                         (false),
-	m_gold_in_return                (gold_in_return),
-	m_path_selection_state          (k_TRADEROUTE_NO_PATH),
-	m_sourceCity                    (source),
-	m_destinationCity               (dest),
-	m_recip                         (),
-	m_path                          (),
-	m_wayPoints                     (),
-	m_selectedPath                  (),
-	m_selectedWayPoints             (),
-	m_setPath                       (),
-	m_setWayPoints                  (),
-	m_astarPath                     (new Path()),
-	m_dontAdjustPointsWhenKilled    (false)
+    m_transportCost                 (0.0),
+    m_owner                         (owner),
+    m_payingFor                     (paying_for),
+    m_piratingArmy                  (),
+    m_sourceRouteType               (sourceType),
+    m_sourceResource                (sourceResource),
+    m_crossesWater                  (false),
+    m_isActive                      (false),
+    m_color                         (g_colorSet->GetColor(COLOR_YELLOW)),
+    m_outline                       (g_colorSet->GetColor(COLOR_BLACK)),
+    m_selectedIndex                 (0),
+    m_valid                         (false),
+    m_gold_in_return                (gold_in_return),
+    m_path_selection_state          (k_TRADEROUTE_NO_PATH),
+    m_sourceCity                    (source),
+    m_destinationCity               (dest),
+    m_recip                         (),
+    m_path                          (),
+    m_wayPoints                     (),
+    m_selectedPath                  (),
+    m_selectedWayPoints             (),
+    m_setPath                       (),
+    m_setWayPoints                  (),
+    m_astarPath                     (new Path()),
+    m_dontAdjustPointsWhenKilled    (false)
 {
-    std::fill(m_passesThrough, m_passesThrough + k_MAX_PLAYERS, FALSE);
+	std::fill(m_passesThrough, m_passesThrough + k_MAX_PLAYERS, FALSE);
 	MapPoint sPos   (m_sourceCity.RetPos());
-    MapPoint dPos   (m_destinationCity.RetPos());
+	MapPoint dPos   (m_destinationCity.RetPos());
 
 	AddWayPoint(sPos);
 	AddWayPoint(dPos);
@@ -122,7 +121,7 @@ TradeRouteData::TradeRouteData(CivArchive &archive) : GameObj(0)
 }
 
 TradeRouteData::TradeRouteData(TradeRouteData* copyme, uint32 new_id)
-	: GameObj(new_id)
+    : GameObj(new_id)
 {
 	*this = *copyme;
 	m_astarPath = new Path;
@@ -145,7 +144,7 @@ void TradeRouteData::RemoveFromCells()
 	TradeRoute route(m_id);
 	sint32 const    num = m_path.Num();
 	for (sint32 i = 0; i < num; i++)
-    {
+	{
 		if(g_theWorld)
 			g_theWorld->GetCell(m_path[i])->DelTradeRoute(route);
 		if(g_radarMap)
@@ -171,7 +170,6 @@ TradeRoute TradeRouteData::AccessRecip()
 
 void TradeRouteData::SetRecip(TradeRoute route)
 {
-
 	Assert(FALSE);
 
 	m_recip = route;
@@ -183,7 +181,7 @@ void TradeRouteData::CheckSquareForCity(MapPoint const & pos)
 	Unit city = g_theWorld->GetCell(pos)->GetCity();
 
 	if (city.IsValid())
-    {
+	{
 		m_passesThrough[city.GetOwner()] = TRUE;
 	}
 }
@@ -221,57 +219,57 @@ bool TradeRouteData::GeneratePath()
 	sint32 const    nwp     = m_wayPoints.Num();
 
 	for (sint32 wp = 0; wp < nwp - 1; ++wp)
-    {
+	{
 		if (wp == 0)
-        {
+		{
 			if (!g_theTradeAstar.FindPath
-                    (m_payingFor, m_wayPoints[wp], m_wayPoints[wp + 1],
-					 *m_astarPath, cost, FALSE
-                    )
-               )
-            {
+			        ( m_payingFor, m_wayPoints[wp], m_wayPoints[wp + 1],
+			         *m_astarPath, cost, FALSE
+			        )
+			   )
+			{
 				return false;
-            }
+			}
 		}
-        else
-        {
-	        Path    partialAstarPath;
+		else
+		{
+			Path    partialAstarPath;
 			if (g_theTradeAstar.FindPath
-                    (m_payingFor, m_wayPoints[wp], m_wayPoints[wp + 1],
-					 partialAstarPath, cost, FALSE
-                    )
-               )
-            {
-    			m_astarPath->Concat(partialAstarPath);
-            }
-            else
-            {
-                return false;
-            }
+			        (m_payingFor, m_wayPoints[wp], m_wayPoints[wp + 1],
+			         partialAstarPath, cost, FALSE
+			        )
+			   )
+			{
+				m_astarPath->Concat(partialAstarPath);
+			}
+			else
+			{
+				return false;
+			}
 		}
 
 		m_transportCost += cost;
 	}
 
 	m_transportCost = std::max<double>
-        (1.0, (double)((int)tradeutil_GetNetTradeCosts(m_transportCost)));
+	    (1.0, (double)((int)tradeutil_GetNetTradeCosts(m_transportCost)));
 
 	m_path.Insert(m_wayPoints[0]);
 	MapPoint pnt;
 	for (sint32 p = 1; p < m_astarPath->Num(); p++)
-    {
+	{
 		WORLD_DIRECTION d;
 		m_astarPath->GetCurrentDir(d);
 		sint32 r = m_path[p-1].GetNeighborPosition(d, pnt);
 		Assert(r);
 
 		if (r)
-        {
+		{
 			m_path.Insert(pnt);
 			g_theWorld->GetCell(pnt)->AddTradeRoute(m_id);
 			g_radarMap->RedrawTile(&pnt);
 			if (g_theWorld->IsWater(pnt))
-            {
+			{
 				m_crossesWater = true;
 			}
 		}
@@ -279,7 +277,7 @@ bool TradeRouteData::GeneratePath()
 		m_astarPath->IncDir();
 	}
 
-    ENQUEUE();
+	ENQUEUE();
 	return true;
 }
 
@@ -288,7 +286,7 @@ void TradeRouteData::SetPath(DynamicArray<MapPoint> &fullpath,
 {
 	m_setPath.Clear();
 	for (int p = 0; p < fullpath.Num(); p++)
-    {
+	{
 		m_setPath.Insert(fullpath[p]);
 	}
 }
@@ -296,16 +294,16 @@ void TradeRouteData::SetPath(DynamicArray<MapPoint> &fullpath,
 void TradeRouteData::BeginTurn()
 {
 	if (m_setPath.Num() > 0)
-    {
+	{
 		RemoveFromCells();
 		m_path.Clear();
 		m_wayPoints.Clear();
 		for (int p = 0; p < m_setPath.Num(); p++)
-        {
+		{
 			m_path.Insert(m_setPath[p]);
 		}
 		for (int wp = 0; wp < m_setWayPoints.Num(); wp++)
-        {
+		{
 			m_wayPoints.Insert(m_setWayPoints[wp]);
 		}
 		m_setPath.Clear();
@@ -318,7 +316,7 @@ void TradeRouteData::ReturnPath
     const PLAYER_INDEX          owner,
     DynamicArray<MapPoint> &    waypoints,
     DynamicArray<MapPoint> &    fullpath,
-	double &                    cost
+    double &                    cost
 )
 {
 	fullpath.Clear();
@@ -332,9 +330,9 @@ void TradeRouteData::ReturnPath
 	sint32  r;
 
 	for (int wp = 0; wp < nwp - 1; wp++)
-    {
+	{
 		if (wp == 0)
-        {
+		{
 			r = g_theTradeAstar.FindPath(owner, waypoints[wp], waypoints[wp + 1],
 			                             *m_astarPath, partialcost, FALSE);
 			Assert(r);
@@ -473,10 +471,8 @@ StringId TradeRouteData::GetResourceName() const
 #endif
 }
 
-
 BOOL TradeRouteData::InitSelectedData()
 {
-
 	if (m_selectedPath.Num()) return FALSE;
 
 	m_selectedPath = m_path;
@@ -488,7 +484,6 @@ BOOL TradeRouteData::InitSelectedData()
 
 BOOL TradeRouteData::IsSelectedPathSame()
 {
-
 	if (m_path.Num() != m_selectedPath.Num()) return FALSE;
 
 	for ( sint32 i = 0 ; i < m_path.Num() ; i++ )
@@ -500,15 +495,15 @@ BOOL TradeRouteData::IsSelectedPathSame()
 sint32 TradeRouteData::AddSelectedWayPoint(const MapPoint &pos)
 {
 	for (sint32 wp = 0; wp < m_selectedWayPoints.Num(); ++wp)
-    {
+	{
 		if (pos == m_selectedWayPoints[wp])
 		{
 			m_selectedIndex = wp;
-            return m_selectedIndex;
+			return m_selectedIndex;
 		}
-    }
+	}
 
-    sint32 wpIndex  = 0;
+	sint32 wpIndex  = 0;
 	for (int i = 0; i < m_selectedPath.Num(); ++i)
 	{
 		if (pos == m_selectedPath[i])
@@ -516,20 +511,20 @@ sint32 TradeRouteData::AddSelectedWayPoint(const MapPoint &pos)
 			m_selectedWayPoints.InsertBefore(pos, wpIndex);
 			break;
 		}
-        else if (m_selectedPath[i] == m_selectedWayPoints[wpIndex])
-        {
-            ++wpIndex;
-        }
+		else if (m_selectedPath[i] == m_selectedWayPoints[wpIndex])
+		{
+			++wpIndex;
+		}
 	}
 
-    m_selectedIndex = wpIndex;
-    return m_selectedIndex;
+	m_selectedIndex = wpIndex;
+	return m_selectedIndex;
 }
 
 void TradeRouteData::GenerateSelectedPath(const MapPoint &pos)
 {
 	if ((m_selectedIndex == 0) || (m_selectedIndex == m_selectedWayPoints.Num()))
-        return;
+		return;
 
 	DynamicArray<MapPoint> tempWp = m_selectedWayPoints;
 	tempWp[m_selectedIndex] = pos;
@@ -561,14 +556,12 @@ BOOL TradeRouteData::IsPosInPath(const MapPoint &pos)
 
 void TradeRouteData::UpdateSelectedCellData(TradeRoute &route)
 {
-
 	for ( sint32 i = 0 ; i < m_selectedPath.Num() ; i++ )
 		g_theWorld->GetCell(m_selectedPath[i])->AddTradeRoute(route);
 }
 
 void TradeRouteData::ClearSelectedCellData(TradeRoute &route)
 {
-
 	for ( sint32 i = 0 ; i < m_selectedPath.Num() ; i++ )
 		g_theWorld->GetCell(m_selectedPath[i])->DelTradeRoute(route);
 }

--- a/ctp2_code/gs/gameobj/TradeRouteData.cpp
+++ b/ctp2_code/gs/gameobj/TradeRouteData.cpp
@@ -79,6 +79,7 @@ TradeRouteData::TradeRouteData
     m_selectedIndex                 (0),
     m_valid                         (false),
     m_accumilatedTimesPirated       (0),
+    m_pirate                        (PLAYER_UNASSIGNED),
     m_gold_in_return                (gold_in_return),
     m_path_selection_state          (k_TRADEROUTE_NO_PATH),
     m_sourceCity                    (source),
@@ -372,8 +373,7 @@ TradeRouteData::Serialize(CivArchive &archive)
 		archive.PutSINT8(m_valid);
 		archive.PutUINT16(m_accumilatedTimesPirated);
 
-		sint8 empty = 0;
-		archive.PutSINT8(empty); // Unused bytes
+		archive.PutSINT8(m_pirate);
 		archive << m_payingFor;
 		archive << m_gold_in_return;
 
@@ -417,7 +417,7 @@ TradeRouteData::Serialize(CivArchive &archive)
 		m_valid = archive.GetSINT8(); // Split former BOOL m_valid, so that we can save something in the gap
 		m_accumilatedTimesPirated = archive.GetUINT16();
 
-		sint8 empty = archive.GetSINT8(); // Unused 8 bytes
+		m_pirate = archive.GetSINT8();
 		archive >> m_payingFor;
 		archive >> m_gold_in_return;
 

--- a/ctp2_code/gs/gameobj/TradeRouteData.h
+++ b/ctp2_code/gs/gameobj/TradeRouteData.h
@@ -74,6 +74,7 @@ private:
 
 	bool m_valid;
 	sint16 m_accumilatedTimesPirated;
+	sint8 m_pirate;
 
 	sint32 m_gold_in_return;
 
@@ -126,11 +127,13 @@ public:
 	void SetSource(Unit source);
 	void SetDestination(Unit dest);
 
-	void     SetLastTimePirated(sint32 currentTurn)       {        m_piratedLastTime = currentTurn; }
-	sint32   GetLastTimePirated()                   const { return m_piratedLastTime; }
-	void IncreaseAccumulatedTimePirated()                 {        m_accumilatedTimesPirated++; }
-	void    ResetAccumulatedTimePirated()                 {        m_accumilatedTimesPirated = 0; }
-	uint16    GetAccumulatedTimePirated()           const { return m_accumilatedTimesPirated; }
+	void      SetLastTimePirated(sint32 currentTurn)       {        m_piratedLastTime = currentTurn; }
+	sint32    GetLastTimePirated()                   const { return m_piratedLastTime; }
+	void IncreaseAccumulatedTimePirated()                  {        m_accumilatedTimesPirated++; }
+	void    ResetAccumulatedTimePirated()                  {        m_accumilatedTimesPirated = 0; }
+	uint16    GetAccumulatedTimePirated()            const { return m_accumilatedTimesPirated; }
+	void      SetPirate(sint8 pirate)                      {        m_pirate = pirate; }
+	sint8     GetPirate()                            const { return m_pirate; }
 
 	double GetCost() const;
 	void SetCost(double cost);

--- a/ctp2_code/gs/gameobj/TradeRouteData.h
+++ b/ctp2_code/gs/gameobj/TradeRouteData.h
@@ -94,7 +94,7 @@ private:
 
 	Path *m_astarPath;
 
-	BOOL m_dontAdjustPointsWhenKilled;
+	bool m_dontAdjustPointsWhenKilled;
 
 	void CheckSquareForCity(MapPoint const & pos);
 
@@ -183,7 +183,7 @@ public:
 	void Serialize(CivArchive &archive);
 
 	void DontAdjustPointsWhenKilled();
-	BOOL GetDontAdjustPoints() const { return m_dontAdjustPointsWhenKilled; }
+	bool GetDontAdjustPoints() const { return m_dontAdjustPointsWhenKilled; }
 
 	sint32 GetValue() const;
 

--- a/ctp2_code/gs/gameobj/TradeRouteData.h
+++ b/ctp2_code/gs/gameobj/TradeRouteData.h
@@ -65,14 +65,15 @@ private:
 	sint32 m_sourceResource;
 	BOOL m_passesThrough[k_MAX_PLAYERS];
 	BOOL m_crossesWater;
-	BOOL m_isActive;
+	bool m_isActive;
 
 	uint32	m_color;
 	uint32	m_outline;
 
 	sint32	m_selectedIndex;
 
-	BOOL m_valid;
+	bool m_valid;
+	sint16 m_accumilatedTimesPirated;
 
 	sint32 m_gold_in_return;
 
@@ -80,7 +81,7 @@ private:
 
 	Unit m_sourceCity;
 	Unit m_destinationCity;
-	TradeRoute m_recip;
+	sint32 m_piratedLastTime;
 
 	DynamicArray<MapPoint> m_path;
 	DynamicArray<MapPoint> m_wayPoints;
@@ -125,9 +126,11 @@ public:
 	void SetSource(Unit source);
 	void SetDestination(Unit dest);
 
-	TradeRoute GetRecip() const;
-	TradeRoute AccessRecip();
-	void SetRecip(TradeRoute route);
+	void     SetLastTimePirated(sint32 currentTurn)       {        m_piratedLastTime = currentTurn; }
+	sint32   GetLastTimePirated()                   const { return m_piratedLastTime; }
+	void IncreaseAccumulatedTimePirated()                 {        m_accumilatedTimesPirated++; }
+	void    ResetAccumulatedTimePirated()                 {        m_accumilatedTimesPirated = 0; }
+	uint16    GetAccumulatedTimePirated()           const { return m_accumilatedTimesPirated; }
 
 	double GetCost() const;
 	void SetCost(double cost);

--- a/ctp2_code/gs/gameobj/TradeRouteData.h
+++ b/ctp2_code/gs/gameobj/TradeRouteData.h
@@ -78,11 +78,6 @@ private:
 
 	sint32	m_path_selection_state;
 
-
-
-
-
-
 	Unit m_sourceCity;
 	Unit m_destinationCity;
 	TradeRoute m_recip;
@@ -96,9 +91,6 @@ private:
 	DynamicArray<MapPoint> m_setWayPoints;
 
 	Path *m_astarPath;
-
-
-
 
 	BOOL m_dontAdjustPointsWhenKilled;
 

--- a/ctp2_code/net/general/net_traderoute.cpp
+++ b/ctp2_code/net/general/net_traderoute.cpp
@@ -59,6 +59,9 @@ void NetTradeRoute::Packetize(uint8 *buf, uint16 & size)
 	PUSHLONG((uint32)(m_routeData->m_piratedLastTime));
 	PUSHLONG((uint32)(m_routeData->m_piratingArmy.m_id));
 	PUSHSHORT((uint16)(m_routeData->m_accumilatedTimesPirated));
+	PUSHBYTE(m_routeData->m_valid);
+	PUSHBYTE(m_routeData->m_pirate);
+
 	PUSHSHORT((uint16)(m_routeData->m_path.Num()));
 	for(i = 0; i < m_routeData->m_path.Num(); i++) {
 		PUSHSHORT((uint16)m_routeData->m_path[i].x);
@@ -134,6 +137,8 @@ void NetTradeRoute::Unpacketize(uint16 id, uint8 *buf, uint16 size)
 	PULLLONG(m_routeData->m_piratedLastTime);
 	PULLLONG(m_routeData->m_piratingArmy.m_id);
 	PULLSHORT(m_routeData->m_accumilatedTimesPirated);
+	PULLBYTE(m_routeData->m_valid);
+	PULLBYTE(m_routeData->m_pirate);
 
 	PULLSHORT(numWp);
 

--- a/ctp2_code/net/general/net_traderoute.cpp
+++ b/ctp2_code/net/general/net_traderoute.cpp
@@ -56,7 +56,9 @@ void NetTradeRoute::Packetize(uint8 *buf, uint16 & size)
 
 	PUSHLONG((uint32)(m_routeData->m_sourceCity));
 	PUSHLONG((uint32)(m_routeData->m_destinationCity));
-	PUSHLONG((uint32)(m_routeData->m_recip));
+	PUSHLONG((uint32)(m_routeData->m_piratedLastTime));
+	PUSHLONG((uint32)(m_routeData->m_piratingArmy.m_id));
+	PUSHSHORT((uint16)(m_routeData->m_accumilatedTimesPirated));
 	PUSHSHORT((uint16)(m_routeData->m_path.Num()));
 	for(i = 0; i < m_routeData->m_path.Num(); i++) {
 		PUSHSHORT((uint16)m_routeData->m_path[i].x);
@@ -71,7 +73,6 @@ void NetTradeRoute::Unpacketize(uint16 id, uint8 *buf, uint16 size)
 	uint32 passesThrough;
 	uint32 sourceCityID;
 	uint32 destCityID;
-	uint32 recip;
 	uint16 numWp;
 	sint32 i;
 
@@ -130,15 +131,16 @@ void NetTradeRoute::Unpacketize(uint16 id, uint8 *buf, uint16 size)
 		}
 	}
 
-	PULLLONG(recip);
-	m_routeData->m_recip = TradeRoute(recip);
+	PULLLONG(m_routeData->m_piratedLastTime);
+	PULLLONG(m_routeData->m_piratingArmy.m_id);
+	PULLSHORT(m_routeData->m_accumilatedTimesPirated);
 
 	PULLSHORT(numWp);
 
 	m_routeData->RemoveFromCells();
 
 	m_routeData->m_path.Clear();
-    PLAYER_INDEX owner;
+	PLAYER_INDEX owner;
 	for(i = 0; i < numWp; i++) {
 		MapPoint pnt;
 		PULLSHORTTYPE(pnt.x, sint16);


### PR DESCRIPTION
Save and load the piracy history so that the AI would cancel its trades routes when they have been pirated too often even after reloads.

This pull request fixes the issue found in https://github.com/civctp2/civctp2/pull/132#issuecomment-489365578.

Note that so far I only have tested whether, it can load old save games with trade routes and can save and reload those again.