### PR TITLE
Splitter civs inherit the age of their parent civ

### DIFF
--- a/ctp2_code/gs/gameobj/Civilisation.cpp
+++ b/ctp2_code/gs/gameobj/Civilisation.cpp
@@ -164,9 +164,10 @@ void civilisation_CreateNewPlayer(sint32 pi, sint32 old_owner)
 	    (old_owner >= 0) && g_player[old_owner]
 	   )
 	{
-	    delete g_player[pi]->m_advances;
+		delete g_player[pi]->m_advances;
 		g_player[pi]->m_advances = new Advances(*(g_player[old_owner]->m_advances));
 		g_player[pi]->m_advances->SetOwner(pi);
+		g_player[pi]->m_age = g_player[old_owner]->m_age;
 		g_player[old_owner]->GiveMap(pi);
 	}
 


### PR DESCRIPTION
So far when a city becomes independent and forms a new civilization it inherits all the advances of its parent civilization. Since the advances define, in which age a civilization is, the age should also be inherited. Otherwise the new civilization is the first age until it discovers a new advance.
..\ctp2_code\gs\gameobj\Civilisation.cpp