### PR TITLE
Update city influence at end of turn to account for newly available territory

### DIFF
--- a/ctp2_code/gs/gameobj/CityData.cpp
+++ b/ctp2_code/gs/gameobj/CityData.cpp
@@ -5155,6 +5155,9 @@ void CityData::EndTurn()
 	}
 
 	m_build_queue.EndTurn();
+
+	// let city expand if adjacent city is gone or has shrunk
+	GenerateCityInfluence(m_home_city.RetPos(), m_sizeIndex);
 }
 
 void CityData::CalcHappiness(sint32 &virtualGoldSpent, bool isFirstPass)

--- a/ctp2_code/gs/gameobj/CityInfluenceIterator.cpp
+++ b/ctp2_code/gs/gameobj/CityInfluenceIterator.cpp
@@ -129,7 +129,7 @@ bool ExpandInfluence(Unit &city, const MapPoint &centerPos, MapPoint curPos,
 	Cell *cell = g_theWorld->GetCell(curPos);
 
 	if(cell->GetScratch() != 0) return false;
-	if(cell->GetCityOwner().m_id != 0 && cell->GetCityOwner().m_id != city.m_id) return false;
+	if(cell->GetCityOwner().m_id != 0 && cell->GetCityOwner().m_id != city.m_id) return false; // prevents assignment of tiles owned by other adjacent city
 	if(UnitData::GetDistance(centerPos, curPos, 0) > rec->GetSquaredRadius()) return false;
 
 	cell->SetCityOwner(city);
@@ -283,7 +283,7 @@ void GenerateCityInfluence(const MapPoint &cpos, sint32 size)
 {
 	Assert(g_theWorld->GetCell(cpos)->HasCity());
 	Unit					city		= g_theWorld->GetCell(cpos)->GetCity();
-	sint32 const			intRadius	= RadiusFromIndex(size);
+//	sint32 const			intRadius	= RadiusFromIndex(size);
 	ClearScratch(cpos, size);
 	g_theWorld->GetCell(cpos)->SetScratch(1);
 


### PR DESCRIPTION
PR concerning #141:
The idea is to call `AdjustSizeIndices`
https://github.com/civctp2/civctp2/blob/247c8dc9c9be287194605ea5ba1f555884f3e0d7/ctp2_code/gs/gameobj/CityData.cpp#L8574-L8654
at the end of every turn to enable accounting for newly available territory if an adjacent city was destroyed or has shrunk. It is not clear to me though where growing is accounted for since
https://github.com/civctp2/civctp2/blob/247c8dc9c9be287194605ea5ba1f555884f3e0d7/ctp2_code/gs/gameobj/CityData.cpp#L8624-L8631
only seems to cover shrinkage, tough it only seems to consider adding city-ownership to a tile and not its removal.
@MartinGuehmann any idea on this? Am I investigating the wrong code sections?
Should the accounting be done else where than at the end of each turn, e.g. at the beginning?
