### PR TITLE
List gold lost to piracy in trade advisor

### DIFF
--- a/ctp2_code/ui/interface/trademanager.cpp
+++ b/ctp2_code/ui/interface/trademanager.cpp
@@ -540,10 +540,7 @@ void TradeManager::UpdateAdviceWindow()
 	for(i = 0; i < g_player[pl]->m_all_cities->Num(); i++) {
 		Unit city = g_player[pl]->m_all_cities->Access(i);
 		totalRoutes += city.CD()->GetTradeSourceList()->Num();
-		sint32 r;
-		for(r = 0; r < city.CD()->GetTradeSourceList()->Num(); r++) {
-			totalProfit += city.CD()->GetTradeSourceList()->Access(r)->GetValue();
-		}
+		totalProfit += city.CD()->GetGoldFromTradeRoutes(); // takes piracy and wonder bonus into account
 	}
 
 	child = (ctp2_Static *)aui_Ldl::GetObject(s_tradeAdviceBlock, "Profit");

--- a/ctp2_code/ui/interface/trademanager.cpp
+++ b/ctp2_code/ui/interface/trademanager.cpp
@@ -536,16 +536,23 @@ void TradeManager::UpdateAdviceWindow()
 		child->SetText(buf);
 	}
 
-	sint32 i, totalProfit = 0, totalRoutes = 0;
+	sint32 i, totalProfit = 0, totalPiracy = 0, totalRoutes = 0;
 	for(i = 0; i < g_player[pl]->m_all_cities->Num(); i++) {
 		Unit city = g_player[pl]->m_all_cities->Access(i);
 		totalRoutes += city.CD()->GetTradeSourceList()->Num();
 		totalProfit += city.CD()->GetGoldFromTradeRoutes(); // takes piracy and wonder bonus into account
+		totalPiracy += city.CD()->GetGoldLostToPiracy(); // takes wonder bonus into account
 	}
 
 	child = (ctp2_Static *)aui_Ldl::GetObject(s_tradeAdviceBlock, "Profit");
 	if(child) {
 		sprintf(buf, "%d", totalProfit);
+		child->SetText(buf);
+	}
+
+	child = (ctp2_Static *)aui_Ldl::GetObject(s_tradeAdviceBlock, "Piracy");
+	if(child) {
+		sprintf(buf, "%d", totalPiracy);
 		child->SetText(buf);
 	}
 

--- a/ctp2_data/chinese/gamedata/ldl_str.txt
+++ b/ctp2_data/chinese/gamedata/ldl_str.txt
@@ -2411,6 +2411,7 @@ str_ldl_TradeSellingToCity 		"给这座城市"
 str_ldl_CaravansAvailable 		"可动用商队："
 str_ldl_CaravansInUse 			"使用中商队："
 str_ldl_TotalTradeProfit 		"整体贸易利润："
+str_ldl_TotalPiracyLoss				"Total Piracy Loss:"
 str_ldl_TotalTradeRoutes 		"全部贸易路线："
 
 str_ldl_TradeTitle 			"贸  易  官"

--- a/ctp2_data/chinese/uidata/layouts/trademanager.ldl
+++ b/ctp2_data/chinese/uidata/layouts/trademanager.ldl
@@ -514,6 +514,28 @@ TradeAdvice:CTP2_WINDOW {
 		string text "str_ldl_0"
 	}
 
+	PiracyLabel:CTP2_HEADER_FONT {
+		string objecttype "ctp2_Static"
+		int xpix 30
+		int ypix 309
+		int widthpix 108
+		int heightpix 20
+		string just "right"
+		string pattern "uptg20e.tga"
+		string text "str_ldl_TotalPiracyLoss"
+		# Tooltip
+		# string	statustext	"STATUSBAR_TRADEMAN_ADV_TOTAL_PIRACY_DISPLAY"
+	}
+	Piracy:CTP2_HEADER_FONT:CTP2_STATIC_BASE {
+		int xpix 138
+		int ypix 309
+		int widthpix 58
+		int heightpix 20
+		string pattern "uptg20e.tga"
+		int bevelwidth 0
+		string text "str_ldl_0"
+	}
+
 	Background {
 		string objecttype "ctp2_Static"
 		int widthpix 224

--- a/ctp2_data/english/gamedata/ldl_str.txt
+++ b/ctp2_data/english/gamedata/ldl_str.txt
@@ -2411,6 +2411,7 @@ str_ldl_TradeSellingToCity			"To This City"
 str_ldl_CaravansAvailable			"Caravans Available:"
 str_ldl_CaravansInUse				"Caravans in use:"
 str_ldl_TotalTradeProfit			"Total Trade Profit:"
+str_ldl_TotalPiracyLoss				"Total Piracy Loss:"
 str_ldl_TotalTradeRoutes			"Total Trade Routes:"
 
 str_ldl_TradeTitle				"T R A D E   M A N A G E R"

--- a/ctp2_data/english/uidata/layouts/trademanager.ldl
+++ b/ctp2_data/english/uidata/layouts/trademanager.ldl
@@ -514,6 +514,28 @@ TradeAdvice:CTP2_WINDOW {
 		string text "str_ldl_0"
 	}
 
+	PiracyLabel:CTP2_HEADER_FONT {
+		string objecttype "ctp2_Static"
+		int xpix 30
+		int ypix 309
+		int widthpix 108
+		int heightpix 20
+		string just "right"
+		string pattern "uptg20e.tga"
+		string text "str_ldl_TotalPiracyLoss"
+		# Tooltip
+		# string	statustext	"STATUSBAR_TRADEMAN_ADV_TOTAL_PIRACY_DISPLAY"
+	}
+	Piracy:CTP2_HEADER_FONT:CTP2_STATIC_BASE {
+		int xpix 138
+		int ypix 309
+		int widthpix 58
+		int heightpix 20
+		string pattern "uptg20e.tga"
+		int bevelwidth 0
+		string text "str_ldl_0"
+	}
+
 	Background {
 		string objecttype "ctp2_Static"
 		int widthpix 224

--- a/ctp2_data/french/gamedata/ldl_str.txt
+++ b/ctp2_data/french/gamedata/ldl_str.txt
@@ -2411,6 +2411,7 @@ str_ldl_TradeSellingToCity			"A cette ville"
 str_ldl_CaravansAvailable			"Caravanes dispo. :"
 str_ldl_CaravansInUse				"Caravanes util. :"
 str_ldl_TotalTradeProfit			"Total profits :"
+str_ldl_TotalPiracyLoss				"Total Piracy Loss:"
 str_ldl_TotalTradeRoutes			"Total routes :"
 
 str_ldl_TradeTitle				"GESTIONNAIRE DE COMMERCE"

--- a/ctp2_data/french/uidata/layouts/trademanager.ldl
+++ b/ctp2_data/french/uidata/layouts/trademanager.ldl
@@ -514,6 +514,28 @@ TradeAdvice:CTP2_WINDOW {
 		string text "str_ldl_0"
 	}
 
+	PiracyLabel:CTP2_HEADER_FONT {
+		string objecttype "ctp2_Static"
+		int xpix 30
+		int ypix 309
+		int widthpix 108
+		int heightpix 20
+		string just "right"
+		string pattern "uptg20e.tga"
+		string text "str_ldl_TotalPiracyLoss"
+		# Tooltip
+		# string	statustext	"STATUSBAR_TRADEMAN_ADV_TOTAL_PIRACY_DISPLAY"
+	}
+	Piracy:CTP2_HEADER_FONT:CTP2_STATIC_BASE {
+		int xpix 138
+		int ypix 309
+		int widthpix 58
+		int heightpix 20
+		string pattern "uptg20e.tga"
+		int bevelwidth 0
+		string text "str_ldl_0"
+	}
+
 	Background {
 		string objecttype "ctp2_Static"
 		int widthpix 224

--- a/ctp2_data/german/gamedata/ldl_str.txt
+++ b/ctp2_data/german/gamedata/ldl_str.txt
@@ -2411,6 +2411,7 @@ str_ldl_TradeSellingToCity			"Handelspartner"
 str_ldl_CaravansAvailable			"Karawanen:"
 str_ldl_CaravansInUse				"Im Einsatz:"
 str_ldl_TotalTradeProfit			"Einnahmen:"
+str_ldl_TotalPiracyLoss				"Total Piracy Loss:"
 str_ldl_TotalTradeRoutes			"Handelswege:"
 
 str_ldl_TradeTitle				"H A N D E L S M A N A G E R"

--- a/ctp2_data/german/uidata/layouts/trademanager.ldl
+++ b/ctp2_data/german/uidata/layouts/trademanager.ldl
@@ -514,6 +514,28 @@ TradeAdvice:CTP2_WINDOW {
 		string text "str_ldl_0"
 	}
 
+	PiracyLabel:CTP2_HEADER_FONT {
+		string objecttype "ctp2_Static"
+		int xpix 30
+		int ypix 309
+		int widthpix 108
+		int heightpix 20
+		string just "right"
+		string pattern "uptg20e.tga"
+		string text "str_ldl_TotalPiracyLoss"
+		# Tooltip
+		# string	statustext	"STATUSBAR_TRADEMAN_ADV_TOTAL_PIRACY_DISPLAY"
+	}
+	Piracy:CTP2_HEADER_FONT:CTP2_STATIC_BASE {
+		int xpix 138
+		int ypix 309
+		int widthpix 58
+		int heightpix 20
+		string pattern "uptg20e.tga"
+		int bevelwidth 0
+		string text "str_ldl_0"
+	}
+
 	Background {
 		string objecttype "ctp2_Static"
 		int widthpix 224

--- a/ctp2_data/italian/gamedata/ldl_str.txt
+++ b/ctp2_data/italian/gamedata/ldl_str.txt
@@ -2411,6 +2411,7 @@ str_ldl_TradeSellingToCity			"A questa città"
 str_ldl_CaravansAvailable			"Carovane disponibili:"
 str_ldl_CaravansInUse				"Carovane attive:"
 str_ldl_TotalTradeProfit			"Profitto totale:"
+str_ldl_TotalPiracyLoss				"Total Piracy Loss:"
 str_ldl_TotalTradeRoutes			"Totale rotte:"
 
 str_ldl_TradeTitle				"G E S T I O N E  C O M M E R C I A L E"

--- a/ctp2_data/italian/uidata/layouts/trademanager.ldl
+++ b/ctp2_data/italian/uidata/layouts/trademanager.ldl
@@ -514,6 +514,28 @@ TradeAdvice:CTP2_WINDOW {
 		string text "str_ldl_0"
 	}
 
+	PiracyLabel:CTP2_HEADER_FONT {
+		string objecttype "ctp2_Static"
+		int xpix 30
+		int ypix 309
+		int widthpix 108
+		int heightpix 20
+		string just "right"
+		string pattern "uptg20e.tga"
+		string text "str_ldl_TotalPiracyLoss"
+		# Tooltip
+		# string	statustext	"STATUSBAR_TRADEMAN_ADV_TOTAL_PIRACY_DISPLAY"
+	}
+	Piracy:CTP2_HEADER_FONT:CTP2_STATIC_BASE {
+		int xpix 138
+		int ypix 309
+		int widthpix 58
+		int heightpix 20
+		string pattern "uptg20e.tga"
+		int bevelwidth 0
+		string text "str_ldl_0"
+	}
+
 	Background {
 		string objecttype "ctp2_Static"
 		int widthpix 224

--- a/ctp2_data/japanese/gamedata/ldl_str.txt
+++ b/ctp2_data/japanese/gamedata/ldl_str.txt
@@ -2523,6 +2523,7 @@ str_ldl_TradeSellingToCity 		"販売先"
 str_ldl_CaravansAvailable 		"利用可能なｷｬﾗﾊﾞﾝ:"
 str_ldl_CaravansInUse 			"使用中のｷｬﾗﾊﾞﾝ:"
 str_ldl_TotalTradeProfit 		"貿易の合計収益:"
+str_ldl_TotalPiracyLoss				"Total Piracy Loss:"
 str_ldl_TotalTradeRoutes 		"貿易ﾙｰﾄの合計数:"
 
 str_ldl_TradeTitle 			"貿易管理"

--- a/ctp2_data/japanese/uidata/layouts/trademanager.ldl
+++ b/ctp2_data/japanese/uidata/layouts/trademanager.ldl
@@ -514,6 +514,28 @@ TradeAdvice:CTP2_WINDOW {
 		string text "str_ldl_0"
 	}
 
+	PiracyLabel:CTP2_HEADER_FONT {
+		string objecttype "ctp2_Static"
+		int xpix 30
+		int ypix 309
+		int widthpix 108
+		int heightpix 20
+		string just "right"
+		string pattern "uptg20e.tga"
+		string text "str_ldl_TotalPiracyLoss"
+		# Tooltip
+		# string	statustext	"STATUSBAR_TRADEMAN_ADV_TOTAL_PIRACY_DISPLAY"
+	}
+	Piracy:CTP2_HEADER_FONT:CTP2_STATIC_BASE {
+		int xpix 138
+		int ypix 309
+		int widthpix 58
+		int heightpix 20
+		string pattern "uptg20e.tga"
+		int bevelwidth 0
+		string text "str_ldl_0"
+	}
+
 	Background {
 		string objecttype "ctp2_Static"
 		int widthpix 224

--- a/ctp2_data/spanish/gamedata/ldl_str.txt
+++ b/ctp2_data/spanish/gamedata/ldl_str.txt
@@ -2411,6 +2411,7 @@ str_ldl_TradeSellingToCity			"A esta ciudad"
 str_ldl_CaravansAvailable			"Caravanas disponibles:"
 str_ldl_CaravansInUse				"Caravanas en uso:"
 str_ldl_TotalTradeProfit			"Benef. com. total:"
+str_ldl_TotalPiracyLoss				"Total Piracy Loss:"
 str_ldl_TotalTradeRoutes			"Rutas com. totales:"
 
 str_ldl_TradeTitle				"A D M I N I S T R A C I Ó N   C O M E R C I A L"

--- a/ctp2_data/spanish/uidata/layouts/trademanager.ldl
+++ b/ctp2_data/spanish/uidata/layouts/trademanager.ldl
@@ -514,6 +514,28 @@ TradeAdvice:CTP2_WINDOW {
 		string text "str_ldl_0"
 	}
 
+	PiracyLabel:CTP2_HEADER_FONT {
+		string objecttype "ctp2_Static"
+		int xpix 30
+		int ypix 309
+		int widthpix 108
+		int heightpix 20
+		string just "right"
+		string pattern "uptg20e.tga"
+		string text "str_ldl_TotalPiracyLoss"
+		# Tooltip
+		# string	statustext	"STATUSBAR_TRADEMAN_ADV_TOTAL_PIRACY_DISPLAY"
+	}
+	Piracy:CTP2_HEADER_FONT:CTP2_STATIC_BASE {
+		int xpix 138
+		int ypix 309
+		int widthpix 58
+		int heightpix 20
+		string pattern "uptg20e.tga"
+		int bevelwidth 0
+		string text "str_ldl_0"
+	}
+
 	Background {
 		string objecttype "ctp2_Static"
 		int widthpix 224


### PR DESCRIPTION
Motivated by https://github.com/civctp2/civctp2/pull/126#issuecomment-489472244 this PR offers an entry in the advisor of the trade manager that lists the total amount of gold lost due to piracy.