### PR TITLE
Re-introduce turnBuf which was removed in ec67297c1

### DIFF
--- a/ctp2_code/gs/gameobj/ArmyData.cpp
+++ b/ctp2_code/gs/gameobj/ArmyData.cpp
@@ -5913,10 +5913,6 @@ ORDER_RESULT ArmyData::InterceptTrade()
 						m_owner,
 						PROPOSAL_OFFER_STOP_PIRACY))
 					{
-						char turnBuf[32];
-						Agreement ag = g_player[cell->GetOwner()]->FindAgreement(AGREEMENT_TYPE_NO_PIRACY, m_owner);
-						sprintf(turnBuf, "%d", ag.GetTurns() + 1);
-						
 						SlicObject *so = new SlicObject("12IABreakNoPiracy");
 						so->AddRecipient(m_owner);
 						so->AddCivilisation(m_owner);
@@ -5924,7 +5920,14 @@ ORDER_RESULT ArmyData::InterceptTrade()
 						so->AddUnit(m_array[i]);
 						so->AddLocation(m_pos);
 						so->AddOrder(UNIT_ORDER_INTERCEPT_TRADE);
-						so->AddAction(turnBuf);
+						
+						char turnBuf[32];
+						Agreement ag = g_player[cell->GetOwner()]->FindAgreement(AGREEMENT_TYPE_NO_PIRACY, m_owner);
+						if(g_theAgreementPool->IsValid(ag) && ag.GetRecipient() == m_owner){
+						    sprintf(turnBuf, "%d", ag.GetTurns() + 1);
+						    so->AddAction(turnBuf);
+						    }
+
 						g_slicEngine->Execute(so);
 
 						g_selected_item->ForceDirectorSelect(Army(m_id));

--- a/ctp2_code/gs/gameobj/ArmyData.cpp
+++ b/ctp2_code/gs/gameobj/ArmyData.cpp
@@ -5913,6 +5913,11 @@ ORDER_RESULT ArmyData::InterceptTrade()
 						m_owner,
 						PROPOSAL_OFFER_STOP_PIRACY))
 					{
+						/// @todo Check what is missing here. turnBuf is never
+						///       initialised, so the effect of so->AddAction
+						///       is unpredictable.
+						
+						char turnBuf[32];
 						SlicObject *so = new SlicObject("12IABreakNoPiracy");
 						so->AddRecipient(m_owner);
 						so->AddCivilisation(m_owner);
@@ -5920,6 +5925,7 @@ ORDER_RESULT ArmyData::InterceptTrade()
 						so->AddUnit(m_array[i]);
 						so->AddLocation(m_pos);
 						so->AddOrder(UNIT_ORDER_INTERCEPT_TRADE);
+						so->AddAction(turnBuf);
 						g_slicEngine->Execute(so);
 
 						g_selected_item->ForceDirectorSelect(Army(m_id));

--- a/ctp2_code/gs/gameobj/ArmyData.cpp
+++ b/ctp2_code/gs/gameobj/ArmyData.cpp
@@ -5913,11 +5913,10 @@ ORDER_RESULT ArmyData::InterceptTrade()
 						m_owner,
 						PROPOSAL_OFFER_STOP_PIRACY))
 					{
-						/// @todo Check what is missing here. turnBuf is never
-						///       initialised, so the effect of so->AddAction
-						///       is unpredictable.
-						
 						char turnBuf[32];
+						Agreement ag = g_player[cell->GetOwner()]->FindAgreement(AGREEMENT_TYPE_NO_PIRACY, m_owner);
+						sprintf(turnBuf, "%d", ag.GetTurns() + 1);
+						
 						SlicObject *so = new SlicObject("12IABreakNoPiracy");
 						so->AddRecipient(m_owner);
 						so->AddCivilisation(m_owner);


### PR DESCRIPTION
The commits of this PR would re-introduce `turnBuf` (which was removed in ec67297c1 without any comment) for asking to break a no-piracy treaty, and once were part of #154.
However the game crashes when pirating with these changes, nor does this PR seem to help solving #152.