### PR TITLE
Change the way trade routes are drawn on the map

### DIFF
--- a/ctp2_code/gfx/layers/citylayer.cpp
+++ b/ctp2_code/gfx/layers/citylayer.cpp
@@ -143,6 +143,23 @@ void DrawTradeRouteSegment(aui_Surface *surf, MapPoint &pos, WORLD_DIRECTION dir
 	if (x1 >= 0 && y1 >= 0 && x2 >= 0 && y2 >= 0 &&
 		x1 < surf->Width() && y1 < surf->Height() && x2 < surf->Width() && y2 < surf->Height()) {
 
+		primitives_DrawDashedLine16(surf,x1,y1,x2,y2,route, k_TRADE_DASH_LEN);
+	}
+
+	if (x1==x2) {
+		x1++;
+		x2++;
+	} else {
+		y1++;
+		y2++;
+	}
+
+	tempRect.right++;
+	tempRect.bottom++;
+
+	if (x1 >= 0 && y1 >= 0 && x2 >= 0 && y2 >= 0 &&
+		x1 < surf->Width() && y1 < surf->Height() && x2 < surf->Width() && y2 < surf->Height()) {
+
 		primitives_DrawDashedLine16(surf,x1,y1,x2,y2,outline, k_TRADE_DASH_LEN);
 	}
 

--- a/ctp2_code/gfx/layers/citylayer.cpp
+++ b/ctp2_code/gfx/layers/citylayer.cpp
@@ -140,11 +140,13 @@ void DrawTradeRouteSegment(aui_Surface *surf, MapPoint &pos, WORLD_DIRECTION dir
 	tempRect.right++;
 	tempRect.bottom++;
 
+	/* do not draw an "outline" for a trade route, this looks iritating and makes it difficult to recognize the main color
 	if (x1 >= 0 && y1 >= 0 && x2 >= 0 && y2 >= 0 &&
 		x1 < surf->Width() && y1 < surf->Height() && x2 < surf->Width() && y2 < surf->Height()) {
 
 		primitives_DrawDashedAALine16(surf,x1,y1,x2,y2,outline, k_TRADE_DASH_LEN);
 	}
+	*/
 
 	g_tiledMap->AddDirtyRectToMix(tempRect);
 

--- a/ctp2_code/gfx/layers/citylayer.cpp
+++ b/ctp2_code/gfx/layers/citylayer.cpp
@@ -140,13 +140,11 @@ void DrawTradeRouteSegment(aui_Surface *surf, MapPoint &pos, WORLD_DIRECTION dir
 	tempRect.right++;
 	tempRect.bottom++;
 
-	/* do not draw an "outline" for a trade route, this looks iritating and makes it difficult to recognize the main color
 	if (x1 >= 0 && y1 >= 0 && x2 >= 0 && y2 >= 0 &&
 		x1 < surf->Width() && y1 < surf->Height() && x2 < surf->Width() && y2 < surf->Height()) {
 
-		primitives_DrawDashedAALine16(surf,x1,y1,x2,y2,outline, k_TRADE_DASH_LEN);
+		primitives_DrawDashedLine16(surf,x1,y1,x2,y2,outline, k_TRADE_DASH_LEN);
 	}
-	*/
 
 	g_tiledMap->AddDirtyRectToMix(tempRect);
 

--- a/ctp2_code/gfx/layers/citylayer.cpp
+++ b/ctp2_code/gfx/layers/citylayer.cpp
@@ -51,7 +51,7 @@ extern Background		*g_background;
 #include "screenmanager.h"
 extern ScreenManager	*g_screenManager;
 
-#define k_TRADE_DASH_LEN 10
+#define k_TRADE_DASH_LEN 5
 
 void DrawTradeRouteSegment(aui_Surface *surf, MapPoint &pos, WORLD_DIRECTION dir,
 							uint16 route, uint16 outline)

--- a/ctp2_code/gfx/layers/citylayer.cpp
+++ b/ctp2_code/gfx/layers/citylayer.cpp
@@ -126,7 +126,7 @@ void DrawTradeRouteSegment(aui_Surface *surf, MapPoint &pos, WORLD_DIRECTION dir
 	if (x1 >= 0 && y1 >= 0 && x2 >= 0 && y2 >= 0 &&
 		x1 < surf->Width() && y1 < surf->Height() && x2 < surf->Width() && y2 < surf->Height()) {
 
-		primitives_DrawDashedAALine16(surf,x1,y1,x2,y2,route,k_TRADE_DASH_LEN);
+		primitives_DrawLine16(surf,x1,y1,x2,y2,route);
 	}
 
 	if (x1==x2) {

--- a/ctp2_code/gfx/layers/citylayer.cpp
+++ b/ctp2_code/gfx/layers/citylayer.cpp
@@ -126,7 +126,7 @@ void DrawTradeRouteSegment(aui_Surface *surf, MapPoint &pos, WORLD_DIRECTION dir
 	if (x1 >= 0 && y1 >= 0 && x2 >= 0 && y2 >= 0 &&
 		x1 < surf->Width() && y1 < surf->Height() && x2 < surf->Width() && y2 < surf->Height()) {
 
-		primitives_DrawLine16(surf,x1,y1,x2,y2,route);
+		primitives_DrawDashedLine16(surf,x1,y1,x2,y2,route,k_TRADE_DASH_LEN);
 	}
 
 	if (x1==x2) {

--- a/ctp2_code/gs/gameobj/TradePool.cpp
+++ b/ctp2_code/gs/gameobj/TradePool.cpp
@@ -92,7 +92,7 @@ void TradePool::Draw(aui_Surface* surface)
 
 		DrawTradeRoute(surface, (DynamicArray<MapPoint>*)m_all_routes->Access(i).GetPath(),
 			g_colorSet->GetPlayerColor(route.GetOwner()),
-			(uint16)route.GetOutlineColor());
+			g_colorSet->GetPlayerColor(route.GetOwner()));
 
 #if 0
 

--- a/ctp2_code/gs/gameobj/TradePool.cpp
+++ b/ctp2_code/gs/gameobj/TradePool.cpp
@@ -92,7 +92,7 @@ void TradePool::Draw(aui_Surface* surface)
 
 		DrawTradeRoute(surface, (DynamicArray<MapPoint>*)m_all_routes->Access(i).GetPath(),
 			g_colorSet->GetPlayerColor(route.GetOwner()),
-			g_colorSet->GetPlayerColor(route.GetOwner()));
+			(uint16)route.GetOutlineColor());
 
 #if 0
 

--- a/ctp2_code/ui/aui_utils/primitives.cpp
+++ b/ctp2_code/ui/aui_utils/primitives.cpp
@@ -1032,7 +1032,7 @@ PRIMITIVES_ERRCODE primitives_DrawDashedLine16(
 	uint16 *    pDest       = (uint16 *)(pSurfBase + y1 * surfPitch + (x1 << 1));
 	*pDest = color;
 
-	sint32 draw = length;
+	sint32 draw = length / 2; // start with only half the dash length for more evenly distributed dashes
 	sint32 skip = 0;
 
 	if (absdx >= absdy)

--- a/ctp2_code/ui/aui_utils/primitives.cpp
+++ b/ctp2_code/ui/aui_utils/primitives.cpp
@@ -1006,7 +1006,8 @@ PRIMITIVES_ERRCODE primitives_DrawDashedLine16(
 	sint32 y1,
 	sint32 x2,
 	sint32 y2,
-	Pixel16 color
+	Pixel16 color,
+	sint32 length
 	)
 {
 	Assert(pSurface);
@@ -1031,6 +1032,9 @@ PRIMITIVES_ERRCODE primitives_DrawDashedLine16(
 	uint16 *    pDest       = (uint16 *)(pSurfBase + y1 * surfPitch + (x1 << 1));
 	*pDest = color;
 
+	sint32 draw = length;
+	sint32 skip = 0;
+
 	if (absdx >= absdy)
 	{
 		for (sint32 i=absdx;i;i--)
@@ -1043,8 +1047,20 @@ PRIMITIVES_ERRCODE primitives_DrawDashedLine16(
 			}
 			x1 += sdx;
 
-			pDest = (uint16 *)(pSurfBase + y1 * surfPitch + (x1 << 1));
-			*pDest = color;
+			if ( draw  ) {
+			        pDest = (uint16 *)(pSurfBase + y1 * surfPitch + (x1 << 1));
+			        *pDest = color;
+				draw--;
+				if ( !draw ) {
+					skip = length;
+				}
+			}
+			else {
+				skip--;
+				if ( !skip ) {
+					draw = length;
+				}
+			}
 		}
 	}
 	else
@@ -1059,8 +1075,20 @@ PRIMITIVES_ERRCODE primitives_DrawDashedLine16(
 			}
 			y1 += sdy;
 
-			pDest = (uint16 *)(pSurfBase + y1 * surfPitch + (x1 << 1));
-			*pDest = color;
+			if ( draw  ) {
+			        pDest = (uint16 *)(pSurfBase + y1 * surfPitch + (x1 << 1));
+			        *pDest = color;
+				draw--;
+				if ( !draw ) {
+					skip = length;
+				}
+			}
+			else {
+				skip--;
+				if ( !skip ) {
+					draw = length;
+				}
+			}
 		}
 	}
 

--- a/ctp2_code/ui/aui_utils/primitives.h
+++ b/ctp2_code/ui/aui_utils/primitives.h
@@ -67,7 +67,8 @@ PRIMITIVES_ERRCODE  primitives_Scale16(aui_Surface *pSrc, aui_Surface *pDst, con
 
 PRIMITIVES_ERRCODE	primitives_DrawLine16(aui_Surface *pSurface,
 			  sint32 x1,sint32 y1,sint32 x2,sint32 y2,Pixel16 color);
-
+PRIMITIVES_ERRCODE	primitives_DrawDashedLine16(aui_Surface *pSurface,
+			  sint32 x1,sint32 y1,sint32 x2,sint32 y2,Pixel16 color);
 
 PRIMITIVES_ERRCODE	primitives_DrawText(aui_Surface *pDirectSurface,
 				sint32 x, sint32 y, const MBCHAR *pString,COLORREF color, bool bg);

--- a/ctp2_code/ui/aui_utils/primitives.h
+++ b/ctp2_code/ui/aui_utils/primitives.h
@@ -68,7 +68,7 @@ PRIMITIVES_ERRCODE  primitives_Scale16(aui_Surface *pSrc, aui_Surface *pDst, con
 PRIMITIVES_ERRCODE	primitives_DrawLine16(aui_Surface *pSurface,
 			  sint32 x1,sint32 y1,sint32 x2,sint32 y2,Pixel16 color);
 PRIMITIVES_ERRCODE	primitives_DrawDashedLine16(aui_Surface *pSurface,
-			  sint32 x1,sint32 y1,sint32 x2,sint32 y2,Pixel16 color);
+			  sint32 x1,sint32 y1,sint32 x2,sint32 y2,Pixel16 color, sint32 length = 0);
 
 PRIMITIVES_ERRCODE	primitives_DrawText(aui_Surface *pDirectSurface,
 				sint32 x, sint32 y, const MBCHAR *pString,COLORREF color, bool bg);


### PR DESCRIPTION
This PR consists of commits that change the way trade routes are drawn on the map. So far a trade route has a black "outline":

![ss_2019-07-02_23:30:08](https://user-images.githubusercontent.com/21012234/60617352-dba20700-9dd3-11e9-8bf3-f94daa87db7e.png)

together with the line anti-aliasing it is hard in some cases to recognize the color of the owner.

https://github.com/civctp2/civctp2/commit/64ac72f4fe3af92b6b6fb6d74f97f11cc52c4c5b replaces the "outline" color black with the color of the player (which is already used for the main line):

![ss_2019-07-02_23:27:01](https://user-images.githubusercontent.com/21012234/60617522-363b6300-9dd4-11e9-9239-7ef21bbf9271.png)

https://github.com/civctp2/civctp2/commit/f7bb70f13caf392d7816566773b05a8d9352aed5 removes the outline completely, leading to thinner trade route lines, in a way more elegant but due to the anti-aliasing also less well visible:

![ss_2019-07-02_23:22:46](https://user-images.githubusercontent.com/21012234/60617639-6aaf1f00-9dd4-11e9-8448-2bdfb0160631.png)

Currently, I'm not sure which version is best.
