### PR TITLE
Converted and franchise city icons updated independent of FOW

### DIFF
--- a/ctp2_code/gfx/tilesys/tiledraw.cpp
+++ b/ctp2_code/gfx/tilesys/tiledraw.cpp
@@ -3436,15 +3436,8 @@ void TiledMap::DrawCityNames(aui_Surface * surf, sint32 layer)
 					owner                = ucell.m_unseenCell->GetCityOwner();
 					isBioInfected        = ucell.m_unseenCell->IsBioInfected();
 					isNanoInfected       = ucell.m_unseenCell->IsNanoInfected();
-					Unit unit;
-					if (g_theWorld->GetTopVisibleUnit(pos,unit) && unit.IsCity()){// city might be destroyed
-					    isConverted          = unit.GetData()->GetCityData()->IsConverted();
-					    isFranchised         = unit.GetData()->GetCityData()->IsFranchised();
-					    }
-					else{// in case city was destroyed since last visit
-					    isConverted          = ucell.m_unseenCell->IsConverted();
-					    isFranchised         = ucell.m_unseenCell->IsFranchised();
-					    }
+					isConverted          = ucell.m_unseenCell->IsConverted();
+					isFranchised         = ucell.m_unseenCell->IsFranchised();
 					isInjoined           = ucell.m_unseenCell->IsInjoined();
 					wasHappinessAttacked = ucell.m_unseenCell->WasHappinessAttacked();
 					isRioting            = ucell.m_unseenCell->IsRioting();

--- a/ctp2_code/gfx/tilesys/tiledraw.cpp
+++ b/ctp2_code/gfx/tilesys/tiledraw.cpp
@@ -3436,8 +3436,15 @@ void TiledMap::DrawCityNames(aui_Surface * surf, sint32 layer)
 					owner                = ucell.m_unseenCell->GetCityOwner();
 					isBioInfected        = ucell.m_unseenCell->IsBioInfected();
 					isNanoInfected       = ucell.m_unseenCell->IsNanoInfected();
-					isConverted          = ucell.m_unseenCell->IsConverted();
-					isFranchised         = ucell.m_unseenCell->IsFranchised();
+					Unit unit;
+					if (g_theWorld->GetTopVisibleUnit(pos,unit) && unit.IsCity()){// city might be destroyed
+					    isConverted          = unit.GetData()->GetCityData()->IsConverted();
+					    isFranchised         = unit.GetData()->GetCityData()->IsFranchised();
+					    }
+					else{// in case city was destroyed since last visit
+					    isConverted          = ucell.m_unseenCell->IsConverted();
+					    isFranchised         = ucell.m_unseenCell->IsFranchised();
+					    }
 					isInjoined           = ucell.m_unseenCell->IsInjoined();
 					wasHappinessAttacked = ucell.m_unseenCell->WasHappinessAttacked();
 					isRioting            = ucell.m_unseenCell->IsRioting();

--- a/ctp2_code/gs/gameobj/CityData.cpp
+++ b/ctp2_code/gs/gameobj/CityData.cpp
@@ -300,6 +300,7 @@
 #include "UnitPool.h"                   // g_theUnitPool
 #include "UnitRecord.h"
 #include "unitutil.h"
+#include "UnseenCell.h"
 #include "WonderRecord.h"
 #include "WonderTracker.h"
 #include "wonderutil.h"
@@ -5977,6 +5978,16 @@ void CityData::RemoveFranchise()
 {
 	if(m_franchise_owner < 0) // according to CityData::Unconvert
 		return;
+
+	//// let the owner of the franchise know about its removal, see https://github.com/civctp2/civctp2/pull/166
+	MapPoint pos; // needed to get un-seen cell at this city pos
+	UnseenCellCarton ucell;
+
+	m_home_city.GetPos(pos);
+	if(g_player[m_franchise_owner]->GetLastSeen(pos, ucell)) // get un-seen cell of franchise owner
+	    {
+	    ucell.m_unseenCell->SetIsFranchised(false); // remove franchise flag
+	    }
 
 	m_franchise_owner = -1;
 	m_franchiseTurnsRemaining = -1;

--- a/ctp2_code/gs/gameobj/CityData.cpp
+++ b/ctp2_code/gs/gameobj/CityData.cpp
@@ -4912,8 +4912,7 @@ void CityData::DoTurnCounters()
 	}
 	else if(m_franchiseTurnsRemaining == 0) // only zero is meant to reset a Franchise (owner), positive numbers define turns until Franchise is removed, -1 is the default for infinit Franchise, see https://github.com/civctp2/civctp2/pull/167
 	{
-		m_franchise_owner = -1; // owner == -1 means no Franchise
-		m_franchiseTurnsRemaining = -1;
+		RemoveFranchise();
 	}
 }
 
@@ -5974,6 +5973,15 @@ void CityData::MakeFranchise(sint32 player)
 	m_franchiseTurnsRemaining = -1;
 }
 
+void CityData::RemoveFranchise()
+{
+	if(m_franchise_owner < 0) // according to CityData::Unconvert
+		return;
+
+	m_franchise_owner = -1;
+	m_franchiseTurnsRemaining = -1;
+}
+
 sint32 CityData::GetFranchiseTurnsRemaining() const
 {
 	return m_franchiseTurnsRemaining;
@@ -5984,8 +5992,7 @@ void CityData::SetFranchiseTurnsRemaining(sint32 turns)
 	m_franchiseTurnsRemaining = turns;
 	if(turns < 1)
 	{
-		m_franchiseTurnsRemaining = -1;
-		m_franchise_owner = -1;
+		RemoveFranchise();
 	}
 }
 
@@ -6598,8 +6605,7 @@ void CityData::ResetCityOwner(sint32 owner)
 	NewGovernment(g_player[m_owner]->m_government_type);
 
 	m_walls_nullified = false;
-	m_franchiseTurnsRemaining = 0;
-	m_franchise_owner = -1;
+	RemoveFranchise(); // Franchise removed in contrast to conversion, see below
 	m_watchfulTurns = 0;
 	m_bioInfectionTurns = 0;
 	m_bioInfectedBy = -1;

--- a/ctp2_code/gs/gameobj/CityData.cpp
+++ b/ctp2_code/gs/gameobj/CityData.cpp
@@ -6357,6 +6357,16 @@ void CityData::Unconvert(bool makeUnhappy)
 	if(m_convertedTo < 0)
 		return;
 
+	//// let the owner of the conversion know about its removal, see https://github.com/civctp2/civctp2/pull/166
+	MapPoint pos; // needed to get un-seen cell at this city pos
+	UnseenCellCarton ucell;
+
+	m_home_city.GetPos(pos);
+	if(g_player[m_convertedTo]->GetLastSeen(pos, ucell)) // get un-seen cell of conversion owner
+	    {
+	    ucell.m_unseenCell->SetIsConverted(false); // remove conversion flag
+	    }
+
 	m_convertedTo = -1;
 	m_convertedGold = 0;
 	if(makeUnhappy) {

--- a/ctp2_code/gs/gameobj/citydata.h
+++ b/ctp2_code/gs/gameobj/citydata.h
@@ -602,6 +602,7 @@ public:
 	bool IsCapitol() const;
 
 	void MakeFranchise(sint32 player);
+	void RemoveFranchise();
 	sint32 GetFranchiseOwner() const { return m_franchise_owner;}
 	sint32 GetFranchiseTurnsRemaining() const;
 	void SetFranchiseTurnsRemaining(sint32 turns);


### PR DESCRIPTION
because they indicate a state of extra income and a stop of income would reveal this.
PR in relation to #158.