### PR TITLE
Limit turns a Franchise stays effective

### DIFF
--- a/ctp2_code/ctp/civapp.cpp
+++ b/ctp2_code/ctp/civapp.cpp
@@ -758,9 +758,10 @@ bool CivApp::InitializeAppDB(void)
 	g_theProgressWindow->StartCountingTo( 40 );
 
 	MBCHAR	fullpath[_MAX_PATH];
-	sprintf(fullpath, "%s%s%s", C3DIR_DIRECT, FILE_SEP, g_constdb_filename);
+	g_civPaths->FindFile(C3DIR_DIRECT, g_constdb_filename, fullpath);
 
-	if (CI_FileExists(fullpath) && g_theConstDB->Parse(C3DIR_DIRECT, g_constdb_filename))
+	if (CI_FileExists(fullpath) &&
+	    g_theConstDB->Parse(C3DIR_DIRECT, g_constdb_filename))
 	{
 		fprintf(stderr, "%s L%d: Using Const.txt from user space!\n", __FILE__, __LINE__);
 	}

--- a/ctp2_code/ctp/civapp.cpp
+++ b/ctp2_code/ctp/civapp.cpp
@@ -757,7 +757,14 @@ bool CivApp::InitializeAppDB(void)
 
 	g_theProgressWindow->StartCountingTo( 40 );
 
-	if (!g_theConstDB->Parse(C3DIR_GAMEDATA, g_constdb_filename))
+	MBCHAR	fullpath[_MAX_PATH];
+	sprintf(fullpath, "%s%s%s", C3DIR_DIRECT, FILE_SEP, g_constdb_filename);
+
+	if (CI_FileExists(fullpath) && g_theConstDB->Parse(C3DIR_DIRECT, g_constdb_filename))
+	{
+		fprintf(stderr, "%s L%d: Using Const.txt from user space!\n", __FILE__, __LINE__);
+	}
+	else if (!g_theConstDB->Parse(C3DIR_GAMEDATA, g_constdb_filename))
 	{
 		return false;
 	}

--- a/ctp2_code/ctp/civapp.cpp
+++ b/ctp2_code/ctp/civapp.cpp
@@ -758,9 +758,8 @@ bool CivApp::InitializeAppDB(void)
 	g_theProgressWindow->StartCountingTo( 40 );
 
 	MBCHAR	fullpath[_MAX_PATH];
-	g_civPaths->FindFile(C3DIR_DIRECT, g_constdb_filename, fullpath);
 
-	if (CI_FileExists(fullpath) &&
+	if (c3files_getfilesize(C3DIR_DIRECT, g_constdb_filename) > 0 && // includes FindFile
 	    g_theConstDB->Parse(C3DIR_DIRECT, g_constdb_filename))
 	{
 		fprintf(stderr, "%s L%d: Using Const.txt from user space!\n", __FILE__, __LINE__);

--- a/ctp2_code/gs/gameobj/CityData.cpp
+++ b/ctp2_code/gs/gameobj/CityData.cpp
@@ -5971,7 +5971,7 @@ void CityData::SetCapitol()
 void CityData::MakeFranchise(sint32 player)
 {
 	m_franchise_owner = player;
-	m_franchiseTurnsRemaining = -1;
+	m_franchiseTurnsRemaining = g_theConstDB->Get(0)->GetTurnsFranchised(); // do not use SetFranchiseTurnsRemaining here, as it resets the owner for -1
 }
 
 sint32 CityData::GetFranchiseTurnsRemaining() const

--- a/ctp2_code/gs/newdb/Const.cdb
+++ b/ctp2_code/gs/newdb/Const.cdb
@@ -153,6 +153,7 @@ Const : alsire {
 	Int    GossipMapRadius                        aka GOSSIP_MAP_RADIUS
 	Float  HearGossipChance                       aka HEAR_GOSSIP_CHANCE
 	Float  FranchiseEffect                        aka FRANCHISE_EFFECT
+	Int    TurnsFranchised                        aka TURNS_FRANCHISED
 	Int    TurnsToSueFranchise                    aka TURNS_TO_SUE_FRANCHISE
 
 	Float  SlaverEliteChance                      aka SLAVER_ELITE_CHANCE

--- a/ctp2_data/default/gamedata/Const.txt
+++ b/ctp2_data/default/gamedata/Const.txt
@@ -191,6 +191,7 @@ GOSSIP_MAP_RADIUS       10      # When a map is revealed through gossip, a circl
                                 # this radius appears
 HEAR_GOSSIP_CHANCE       0.02   # How likely a diplomat next to a capitol is to hear gossip
 FRANCHISE_EFFECT         0.1    # How much production a franchise steals
+TURNS_FRANCHISED        -1      # How many turns a franchise will be effective, -1: infinit
 TURNS_TO_SUE_FRANCHISE   0      # How many turns a lawsuit takes to expel a franchise
 
 SLAVER_ELITE_CHANCE 0.0 # Chance of a slaver becoming elite in a successful raid

--- a/run.sh
+++ b/run.sh
@@ -8,6 +8,7 @@ xauth nlist $DISPLAY < /dev/null | sed -e 's/^..../ffff/' | xauth -f $XAUTH nmer
 mkdir -p $HOME/.civctp2/save/
 touch $HOME/.civctp2/userprofile.txt # file must exist for docker file-vol
 touch $HOME/.civctp2/userkeymap.txt # file must exist for docker file-vol
+touch $HOME/.civctp2/Const.txt # file must exist for docker file-vol
 ## use -v to specify the folder with OGGs (TrackXX.ogg) for the game music, e.g.:
 ## ./run.sh -v $HOME/ctp2CD/ctp2_program/ctp/music/:/opt/ctp2/ctp2_program/ctp/music/:ro registry.gitlab.com/civctp2/civctp2/master:latest ./ctp2 fullscreen
 docker run \
@@ -22,6 +23,7 @@ docker run \
        --user="diUser" \
        -v $HOME/.civctp2/userprofile.txt:/opt/ctp2/ctp2_program/ctp/userprofile.txt \
        -v $HOME/.civctp2/userkeymap.txt:/opt/ctp2/ctp2_program/ctp/userkeymap.txt \
+       -v $HOME/.civctp2/Const.txt:/opt/ctp2/ctp2_program/ctp/Const.txt \
        -v $HOME/.civctp2/save/:/opt/ctp2/ctp2_program/ctp/save \
        $@
 


### PR DESCRIPTION
This PR should be based on #167. It allows the user to provide a modified `Const.txt` in user space, e.g. ~/.civctp2/ (where also `userprofile.txt` and `userkeymap.txt` are placed).
The default  `Const.txt` is then extended to provide a variable for how many turns a Franchise stays active `TurnsFranchised`, initilized with `-1` (infinit) as in the original code.
With this PR a user can copy the default `Const.txt` to user space and modify values, e.g.  `TurnsFranchised` to limit the turns a Franchise is active.
This can make the game more insteresting, since that keeps your Corporate Branches busy. Without this (and without #103) a single Corporate Branch was sufficient to Franchise all foreign cities, without the AI being able to counter either the unit nor the installed Franchises.
With #167, it is now possible to remove Franchises with a Lawer (as it was inteded) but that option is only available to AIs which can already built Lawers, other AIs have no means of getting rid of a Franchise. With this PR the Franchise can at least be made to end after some turns, which also motivates to built more than one Corporate Branch and to re-visit Franchised cities (see also #166).