### PR TITLE
Debug breaking withdraw troops agreement and its question-message

### DIFF
--- a/ctp2_code/gs/gameobj/ArmyData.cpp
+++ b/ctp2_code/gs/gameobj/ArmyData.cpp
@@ -6706,6 +6706,10 @@ bool ArmyData::ExecuteMoveOrder(Order *order)
 	}
 	else
 	{
+		if(DoLeaveOurLandsCheck(order->m_point, UNIT_ORDER_MOVE_TO)){
+		    return false;
+		    }
+
 		g_gevManager->AddEvent(GEV_INSERT_AfterCurrent,
 		                       GEV_MoveArmy,
 		                       GEA_Army, m_id,

--- a/ctp2_code/gs/gameobj/ArmyData.cpp
+++ b/ctp2_code/gs/gameobj/ArmyData.cpp
@@ -6814,6 +6814,7 @@ void ArmyData::CheckLoadSleepingCargoFromCity(Order *order)
 // Remark(s)  : Actually, not used. Must be left over from CTP1
 //
 //----------------------------------------------------------------------------
+/* commented, since not used any more
 bool ArmyData::Move(WORLD_DIRECTION d, Order *order)
 {
 	MapPoint oldPos = m_pos;
@@ -6923,6 +6924,7 @@ bool ArmyData::Move(WORLD_DIRECTION d, Order *order)
 	}
 	return false;
 }
+*/
 
 bool ArmyData::FinishMove(WORLD_DIRECTION d, MapPoint &newPos, UNIT_ORDER_TYPE order)
 {

--- a/ctp2_code/gs/gameobj/ArmyData.cpp
+++ b/ctp2_code/gs/gameobj/ArmyData.cpp
@@ -9965,12 +9965,9 @@ bool ArmyData::DoLeaveOurLandsCheck(const MapPoint &newPos,
 				|| (g_network.IsClient()
 				&&  g_network.IsLocalPlayer(m_owner))
 				){
-					char turnBuf[32];
-					sprintf(turnBuf, "%d", ag.GetTurns() + 1);
 					SlicObject *so = new SlicObject("13IAEnteringLands");
 					so->AddCivilisation(m_owner);
 					so->AddCivilisation(cell->GetOwner());
-					so->AddAction(turnBuf);
 					so->AddLocation(newPos);
 					so->AddOrder(order_type);
 					so->AddRecipient(m_owner);

--- a/ctp2_code/gs/gameobj/ArmyData.cpp
+++ b/ctp2_code/gs/gameobj/ArmyData.cpp
@@ -9939,7 +9939,7 @@ bool ArmyData::GetInciteUprisingCost( const MapPoint &point, sint32 &attackCost 
 	return true;
 }
 
-//Probably left over from CTP1
+////Possibly left over from CTP1, but now used in CTP2
 bool ArmyData::DoLeaveOurLandsCheck(const MapPoint &newPos,
 									UNIT_ORDER_TYPE order_type)
 {
@@ -9959,9 +9959,8 @@ bool ArmyData::DoLeaveOurLandsCheck(const MapPoint &newPos,
 			}
 		}
 		if(atLeastOneNonSpecialUnit) {
-			Agreement ag = g_player[cell->GetOwner()]->FindAgreement(AGREEMENT_TYPE_DEMAND_LEAVE_OUR_LANDS, m_owner);
-			if(g_theAgreementPool->IsValid(ag) && ag.GetRecipient() == m_owner) {
-
+		        //// similar to ArmyData::InterceptTrade()
+			if(AgreementMatrix::s_agreements.HasAgreement(cell->GetOwner(), m_owner, PROPOSAL_REQUEST_WITHDRAW_TROOPS)){
 				if(!g_player[m_owner]->IsRobot()
 				|| (g_network.IsClient()
 				&&  g_network.IsLocalPlayer(m_owner))
@@ -9982,7 +9981,7 @@ bool ArmyData::DoLeaveOurLandsCheck(const MapPoint &newPos,
 				}
 				else
 				{
-					ag.AccessData()->RecipientIsViolating(cell->GetOwner(), true);
+					Diplomat::GetDiplomat(cell->GetOwner()).LogViolationEvent(m_owner, PROPOSAL_REQUEST_WITHDRAW_TROOPS);
 				}
 			}
 		}

--- a/ctp2_code/gs/gameobj/ArmyData.h
+++ b/ctp2_code/gs/gameobj/ArmyData.h
@@ -434,7 +434,7 @@ public:
     bool ExecuteMoveOrder(Order *order);
 
     void CheckLoadSleepingCargoFromCity(Order *order);
-    bool Move(WORLD_DIRECTION, Order *order);
+//  bool Move(WORLD_DIRECTION, Order *order); // commented, since not used any more
     bool FinishMove(WORLD_DIRECTION d, MapPoint &newPos, UNIT_ORDER_TYPE order);
     bool FinishAttack(Order *order);
     bool CheckSpecialUnitMove(const MapPoint &pos);

--- a/ctp2_code/gs/slic/slicfunc.cpp
+++ b/ctp2_code/gs/slic/slicfunc.cpp
@@ -4495,8 +4495,11 @@ SFN_ERROR Slic_BreakLeaveOurLands::Call(SlicArgList *args)
 	if(!g_player[cellOwner])
 		return SFN_ERROR_DEAD_PLAYER;
 
-	sint32 i;
-	for(i = g_player[unitOwner]->m_agreed->Num() - 1; i >= 0; i--) {
+	if (AgreementMatrix::s_agreements.HasAgreement(
+		cellOwner,
+		unitOwner,
+		PROPOSAL_REQUEST_WITHDRAW_TROOPS)){
+	    /* expecting sync of agrrements over network to be handled by Diplomat::LogViolationEvent or dependent events
 		Agreement ag = g_player[unitOwner]->m_agreed->Access(i);
 		if(g_theAgreementPool->IsValid(ag) &&
 		   ag.GetRecipient() == unitOwner &&
@@ -4508,9 +4511,11 @@ SFN_ERROR Slic_BreakLeaveOurLands::Call(SlicArgList *args)
 				g_network.Enqueue(new NetInfo(NET_INFO_CODE_VIOLATE_AGREEMENT,
 											  ag.m_id, unitOwner));
 			}
-
-			ag.AccessData()->RecipientIsViolating(unitOwner, TRUE);
 		}
+	    */
+	    
+	    Diplomat & diplomat = Diplomat::GetDiplomat(cellOwner);
+	    diplomat.LogViolationEvent(unitOwner, PROPOSAL_REQUEST_WITHDRAW_TROOPS);
 	}
 	return SFN_ERROR_OK;
 }


### PR DESCRIPTION
This PR resolves a bug that prevented the (CTP1) question-message for entering lands of a civ with a standing withdraw-troops (leave-our-lands) agreement, solving a part of #157.

This PR relates to #172.