### PR TITLE
Save m_goldFromTransitRoutes instead of m_foodVatPollution

### DIFF
--- a/ctp2_code/gs/gameobj/CityData.cpp
+++ b/ctp2_code/gs/gameobj/CityData.cpp
@@ -402,7 +402,6 @@ CityData::CityData(PLAYER_INDEX owner, Unit hc, const MapPoint &center_point)
 	m_total_pollution                   (0),
 	m_cityPopulationPollution           (0),
 	m_cityIndustrialPollution           (0),
-	m_foodVatPollution                  (0),
 	m_cityPollutionCleaner              (0),
 	m_contribute_materials              (true),
 	m_contribute_military               (true),
@@ -665,7 +664,7 @@ void CityData::Serialize(CivArchive &archive)
 		archive.PutSINT32(m_total_pollution);
 		archive.PutSINT32(m_cityPopulationPollution);
 		archive.PutSINT32(m_cityIndustrialPollution);
-		archive.PutSINT32(m_foodVatPollution);
+		archive.PutSINT32(m_goldFromTransitRoutes);
 		archive.PutSINT32(m_cityPollutionCleaner);
 		tmp = static_cast<BOOL>(m_contribute_materials);
 		archive.PutSINT32(tmp); // Was BOOL
@@ -823,7 +822,7 @@ void CityData::Serialize(CivArchive &archive)
 		m_total_pollution                = archive.GetSINT32();
 		m_cityPopulationPollution        = archive.GetSINT32();
 		m_cityIndustrialPollution        = archive.GetSINT32();
-		m_foodVatPollution               = archive.GetSINT32();
+		m_goldFromTransitRoutes          = archive.GetSINT32();
 		m_cityPollutionCleaner           = archive.GetSINT32();
 		m_contribute_materials           = archive.GetSINT32() != FALSE; // Was BOOL
 		m_contribute_military            = archive.GetSINT32() != FALSE; // Was BOOL
@@ -1405,7 +1404,7 @@ void CityData::Copy(CityData *copy)
 	m_total_pollution                    = copy->m_total_pollution;
 	m_cityPopulationPollution            = copy->m_cityPopulationPollution;
 	m_cityIndustrialPollution            = copy->m_cityIndustrialPollution;
-	m_foodVatPollution                   = copy->m_foodVatPollution;
+	m_goldFromTransitRoutes              = copy->m_goldFromTransitRoutes;
 	m_cityPollutionCleaner               = copy->m_cityPollutionCleaner;
 	m_contribute_materials               = copy->m_contribute_materials;
 	m_contribute_military                = copy->m_contribute_military;
@@ -2093,7 +2092,7 @@ void CityData::CalcPollution(void)
 	m_cityPopulationPollution   = populationPolluting;
 	m_cityIndustrialPollution   = productionPolluting;
 	m_total_pollution           =
-	            populationPolluting + productionPolluting + m_foodVatPollution +
+	            populationPolluting + productionPolluting +
 	            static_cast<sint32>(populationPolluting * buildingPopulationPercentage) +
 	            static_cast<sint32>(productionPolluting * buildingProductionPercentage) +
 	            static_cast<sint32>(buildingPollution);

--- a/ctp2_code/gs/gameobj/citydata.h
+++ b/ctp2_code/gs/gameobj/citydata.h
@@ -217,7 +217,6 @@ private:
 	sint32            m_total_pollution;
 	sint32            m_cityPopulationPollution;
 	sint32            m_cityIndustrialPollution;
-	sint32            m_foodVatPollution;
 	sint32            m_cityPollutionCleaner;
 	sint32            m_spied_upon;                      // A counter
 	sint32            m_franchise_owner;
@@ -1029,7 +1028,6 @@ private:
 		DPRINTF(k_DBG_AI, ("m_total_pollution: %d\n", sizeof(m_total_pollution)));
 		DPRINTF(k_DBG_AI, ("m_cityPopulationPollution: %d\n", sizeof(m_cityPopulationPollution)));
 		DPRINTF(k_DBG_AI, ("m_cityIndustrialPollution: %d\n", sizeof(m_cityIndustrialPollution)));
-		DPRINTF(k_DBG_AI, ("m_foodVatPollution: %d\n", sizeof(m_foodVatPollution)));
 		DPRINTF(k_DBG_AI, ("m_cityPollutionCleaner: %d\n", sizeof(m_cityPollutionCleaner)));
 		DPRINTF(k_DBG_AI, ("m_contribute_materials: %d\n", sizeof(m_contribute_materials)));
 		DPRINTF(k_DBG_AI, ("m_contribute_military: %d\n", sizeof(m_contribute_military)));
@@ -1168,7 +1166,6 @@ private:
 		DPRINTF(k_DBG_AI, ("m_total_pollution: %d\n", m_total_pollution));
 		DPRINTF(k_DBG_AI, ("m_cityPopulationPollution: %d\n", m_cityPopulationPollution));
 		DPRINTF(k_DBG_AI, ("m_cityIndustrialPollution: %d\n", m_cityIndustrialPollution));
-		DPRINTF(k_DBG_AI, ("m_foodVatPollution: %d\n", m_foodVatPollution));
 		DPRINTF(k_DBG_AI, ("m_cityPollutionCleaner: %d\n", m_cityPollutionCleaner));
 		DPRINTF(k_DBG_AI, ("m_contribute_materials: %d\n", m_contribute_materials));
 		DPRINTF(k_DBG_AI, ("m_contribute_military: %d\n", m_contribute_military));

--- a/ctp2_code/net/general/net_city.cpp
+++ b/ctp2_code/net/general/net_city.cpp
@@ -380,7 +380,7 @@ void NetCity2::Packetize(uint8* buf, uint16 &size)
 
 
 
-	PUSHLONG(m_data->m_foodVatPollution);
+	PUSHLONG(m_data->m_goldFromTransitRoutes);
 	sint8 govSetting = -1;
 	if(m_data->m_useGovernor) {
 		govSetting = (sint8)m_data->m_buildListSequenceIndex;
@@ -458,7 +458,7 @@ void NetCity2::Unpacketize(uint16 id, uint8 *buf, uint16 size)
 
 	PULLLONG(m_data->m_accumulated_food);
 
-	PULLLONG(m_data->m_foodVatPollution);
+	PULLLONG(m_data->m_goldFromTransitRoutes);
 
 	sint8 govSetting;
 	PULLBYTE(govSetting);


### PR DESCRIPTION
Concerning https://github.com/civctp2/civctp2/pull/147#issuecomment-509025872 this PR removes the unused `m_foodVatPollution` and saves `m_goldFromTransitRoutes` instead such that the total gold from transit routes is even uptodate when loading a game.