### PR TITLE
make Diplomats un-expelleable, which strengthens AI

### DIFF
--- a/ctp2_data/default/gamedata/Units.txt
+++ b/ctp2_data/default/gamedata/Units.txt
@@ -1279,7 +1279,6 @@ UNIT_DIPLOMAT {
    MaxFuel 0
    IgnoreZOC
    NoZoc
-   CanBeExpelled
    CantCaptureCity
    EstablishEmbassy
    ThrowParty


### PR DESCRIPTION
This PR makes Diplomats un-expelleable, which seems to strengthen the AI due to diplomatic effects. For example the AI code seems to take into account the info gained from an embassy, resulting in e.g. more advance exchange, which over all helps each AI civ to get better, which in turn makes the game more challenging and therefore interesting. While I'm not fully sure about my preference concerning #103 (which inspired this PR) it seems quite appropriat to make Diplomats immune against expelling, since they are very vulnerable and no stealth unit and it is can be problematic to accompany them with a military unit. While I find it odd that a Lawer or Coorporate Branch can block a road or railway for a 12 unit army, this does not seems so unrealistic for a Diplomat. Independen of that, immune Diplomats seem to hep the AI to be a more challenging opponent.