### PR TITLE
Clerics and Televangelists can now be build under any government

### DIFF
--- a/ctp2_data/default/gamedata/Units.txt
+++ b/ctp2_data/default/gamedata/Units.txt
@@ -879,7 +879,6 @@ UNIT_CLERIC {
    EnableAdvance ADVANCE_THEOLOGY
    ObsoleteAdvance ADVANCE_MASS_MEDIA
    UpgradeTo UNIT_TELEVANGELIST
-   GovernmentType GOVERNMENT_THEOCRACY
    ActiveDefenseRange 0
    LossMoveToDmgNone
    MaxFuel 0
@@ -4013,7 +4012,6 @@ UNIT_TELEVANGELIST {
    MaxMovePoints 400
    VisionRange 2
    EnableAdvance ADVANCE_MASS_MEDIA
-   GovernmentType GOVERNMENT_THEOCRACY
    ActiveDefenseRange 0
    LossMoveToDmgNone
    MaxFuel 0


### PR DESCRIPTION
For now, this is something for testing. This is a way to solve the issue #129 that the AI can only build Clerics and Televangelists for a very short time, since it is only for roughly a few turns in Theocracy the time needed to research Fascism.

There are still alternatives to slove this problem for instance to introduce Fascim later in the tech tree, as suggested in #130.

..\ctp2_data\default\gamedata\Units.txt