### PR TITLE
Update city icon in case of over conversion/franchise

### DIFF
--- a/ctp2_code/gs/gameobj/CityData.cpp
+++ b/ctp2_code/gs/gameobj/CityData.cpp
@@ -5970,7 +5970,16 @@ void CityData::SetCapitol()
 void CityData::MakeFranchise(sint32 player)
 {
 	if(m_franchise_owner != player){// remove foreign franchise to update city icon for former owner
-	    RemoveFranchise();
+	    if(m_franchise_owner > 0){// m_franchise_owner < 0 means not franchised
+		SlicObject *so = new SlicObject("911SueFranchiseCompleteVictim");
+		so->AddRecipient(GetFranchiseOwner());
+		so->AddCity(m_home_city);
+		so->AddGold(0);// misuseing AddGold for passing the remaining franchise turns
+		so->AddGold(GetProductionLostToFranchise());
+		g_slicEngine->Execute(so);
+		}
+
+	    RemoveFranchise();// must be after message because m_franchise_owner is set to -1
 	    }
 
 	m_franchise_owner = player;
@@ -6349,7 +6358,15 @@ void CityData::ConvertTo(sint32 player, CONVERTED_BY by)
 		return;
 
 	if(m_convertedTo != player){// remove foreign conversion to update city icon for former owner
-	    Unconvert(false);// do not cause unhappiness in this case
+	    if(m_convertedTo > 0){// m_convertedTo < 0 means not converted
+		SlicObject *so = new SlicObject("135ReformCityVictim");
+		so->AddRecipient(IsConvertedTo());
+		so->AddCity(m_home_city);
+		so->AddGold(GetConvertedGold());
+		g_slicEngine->Execute(so);
+		}
+
+	    Unconvert(false);// do not cause unhappiness in this case, has to be after message (sets m_convertedTo to -1)
 	    }
 	
 	m_convertedTo = player;

--- a/ctp2_code/gs/gameobj/CityData.cpp
+++ b/ctp2_code/gs/gameobj/CityData.cpp
@@ -5969,6 +5969,10 @@ void CityData::SetCapitol()
 
 void CityData::MakeFranchise(sint32 player)
 {
+	if(m_franchise_owner != player){// remove foreign franchise to update city icon for former owner
+	    RemoveFranchise();
+	    }
+
 	m_franchise_owner = player;
 	m_franchiseTurnsRemaining = g_theConstDB->Get(0)->GetTurnsFranchised(); // do not use SetFranchiseTurnsRemaining here, as it resets the owner for -1
 
@@ -6344,6 +6348,10 @@ void CityData::ConvertTo(sint32 player, CONVERTED_BY by)
 	if(IsProtectedFromConversion())
 		return;
 
+	if(m_convertedTo != player){// remove foreign conversion to update city icon for former owner
+	    Unconvert(false);// do not cause unhappiness in this case
+	    }
+	
 	m_convertedTo = player;
 	m_convertedBy = by;
 

--- a/ctp2_data/chinese/gamedata/info_str.txt
+++ b/ctp2_data/chinese/gamedata/info_str.txt
@@ -378,7 +378,7 @@ IMMUNE_TO_PLAGUE_VICTIM 		"{city[0].name}ÓÉÓÚËÈ½¨ÓĞÎ¢ÉúÎï°²È«ÉèÊ©£¬ËÈÓµÓĞ¶ÔÉú»¯¹
 ## Reform City ##
 ## All Military Unit Action ##
 REFORM_CITY 				"{city[0].name}ËÈÍê³ÉÖØÕû£¬¸ÃÊĞÊĞÃñ²»ÔÙÎªÍâ¹úËù¿ØÖÆ¡£"
-REFORM_CITY_VICTIM			"Foreign inquisitors have reformed the city of {city[0].name} and its citizens are no longer under our influence. They used to pay {gold[0].value} gold."
+REFORM_CITY_VICTIM			"The citizens of the formerly converted city of {city[0].name} are no longer under our influence. They used to pay {gold[0].value} gold."
 
 ## Sell Indulgences ##
 ## Cleric Attack ##

--- a/ctp2_data/english/gamedata/info_str.txt
+++ b/ctp2_data/english/gamedata/info_str.txt
@@ -380,7 +380,7 @@ IMMUNE_TO_PLAGUE_VICTIM			"{city[0].name} is immune to the insidious effects of 
 ## Reform City ##
 ## All Military Unit Action ##
 REFORM_CITY				"We have succeeded in reforming {city[0].name}. Its citizens are no longer under foreign influence."
-REFORM_CITY_VICTIM			"Foreign inquisitors have reformed the city of {city[0].name} and its citizens are no longer under our influence. They used to pay {gold[0].value} gold."
+REFORM_CITY_VICTIM			"The citizens of the formerly converted city of {city[0].name} are no longer under our influence. They used to pay {gold[0].value} gold."
 
 ## Sell Indulgences ##
 ## Cleric Attack ##

--- a/ctp2_data/german/gamedata/info_str.txt
+++ b/ctp2_data/german/gamedata/info_str.txt
@@ -380,7 +380,7 @@ IMMUNE_TO_PLAGUE_VICTIM			"Da dort ein Bio-Schutzfilter installiert ist, sind di
 ## Reform City ##
 ## All Military Unit Action ##
 REFORM_CITY				"Wir haben die Stadt {city[0].name} erfolgreich reformiert. Die dortige Bevölkerung steht nicht länger unter fremdem Einfluss."
-REFORM_CITY_VICTIM			"Fremde Inquisitoren haben die Stadt {city[0].name} reformiert und ihre Bürger stehen nicht mehr unter unserem Einfluss. Sie zahlten jede Runde {gold[0].value} Gold."
+REFORM_CITY_VICTIM			"Die Bürger der zuvor zu uns konvertierten Stadt {city[0].name} stehen nicht mehr unter unserem Einfluss. Sie zahlten jede Runde {gold[0].value} Gold."
 
 ## Sell Indulgences ##
 ## Cleric Attack ##

--- a/ctp2_data/italian/gamedata/info_str.txt
+++ b/ctp2_data/italian/gamedata/info_str.txt
@@ -380,7 +380,7 @@ IMMUNE_TO_PLAGUE_VICTIM			"{city[0].name} è immune agli effetti delle armi biolo
 ## Reform City ##
 ## All Military Unit Action ##
 REFORM_CITY				"Siamo riusciti a riformare {city[0].name}. I suoi cittadini non sono più sotto l'influenza straniera."
-REFORM_CITY_VICTIM			"Foreign inquisitors have reformed the city of {city[0].name} and its citizens are no longer under our influence. They used to pay {gold[0].value} gold."
+REFORM_CITY_VICTIM			"The citizens of the formerly converted city of {city[0].name} are no longer under our influence. They used to pay {gold[0].value} gold."
 
 ## Sell Indulgences ##
 ## Cleric Attack ##

--- a/ctp2_data/spanish/gamedata/info_str.txt
+++ b/ctp2_data/spanish/gamedata/info_str.txt
@@ -380,7 +380,7 @@ IMMUNE_TO_PLAGUE_VICTIM			"{city[0].name} es inmune a los devastadores efectos d
 ## Reform City ##
 ## All Military Unit Action ##
 REFORM_CITY				"Hemos conseguido reformar {city[0].name}. Sus ciudadanos ya no están bajo la influencia extranjera."
-REFORM_CITY_VICTIM			"Foreign inquisitors have reformed the city of {city[0].name} and its citizens are no longer under our influence. They used to pay {gold[0].value} gold."
+REFORM_CITY_VICTIM			"The citizens of the formerly converted city of {city[0].name} are no longer under our influence. They used to pay {gold[0].value} gold."
 
 ## Sell Indulgences ##
 ## Cleric Attack ##


### PR DESCRIPTION
Concernign #194, this PR updates the city icon in case of over conversion/franchise:

Before over-conversion:
![ss_2019-10-12_18:05:25](https://user-images.githubusercontent.com/21012234/66704403-f281bf00-ed1b-11e9-89c8-22be491614db.png)

After over-conversion with this PR:
![ss_2019-10-12_18:03:09](https://user-images.githubusercontent.com/21012234/66704400-edbd0b00-ed1b-11e9-9550-9e4a79f25203.png)

Without this PR:
![ss_2019-10-12_18:27:42](https://user-images.githubusercontent.com/21012234/66704635-147c4100-ed1e-11e9-9c18-d5a66f2d181f.png)

Going there shows:
![ss_2019-10-12_18:03:52](https://user-images.githubusercontent.com/21012234/66704660-645b0800-ed1e-11e9-8156-ae717f6f9b5b.png)
