### PR TITLE
Correct city name told in enslave settler message

### DIFF
--- a/ctp2_code/gs/gameobj/armyevent.cpp
+++ b/ctp2_code/gs/gameobj/armyevent.cpp
@@ -1488,6 +1488,16 @@ STDEHANDLER(EnslaveSettlerEvent)
 		                       GEA_City,    home_city.m_id,
 		                       GEA_Player,  settlerOwner,
 		                       GEA_End);
+
+		SlicObject *so = new SlicObject("139SettlerSlavedVictim");
+		so->AddRecipient(settlerOwner);
+		g_slicEngine->Execute(so);
+
+		so = new SlicObject("137SlaveryCompleteAttacker");
+		so->AddRecipient(slaverOwner);
+		so->AddCivilisation(slaverOwner);
+		so->AddCity(home_city);
+		g_slicEngine->Execute(so);
 	}
 	// else No action: the slaver does not have any cities
 

--- a/ctp2_data/default/gamedata/script.slc
+++ b/ctp2_data/default/gamedata/script.slc
@@ -1925,6 +1925,7 @@ messagebox '135ReformCityVictim' {
 messagebox '137SlaveryCompleteAttacker' {
 	Text(ID_SLAVERY_COMPLETE_ATTACKER) ;
 	MessageType("CAPTURE_SLAVES");
+	EyePoint(city[0].location);
 }
 
 messagebox '137SlaveCompleteVictim' {


### PR DESCRIPTION
This PR solves #51, which only concerned enslaving settlers. It seems the bug is caused by different results for the slave-city of `IsSlaveRaidPossible` and `GetSlaveCity`.

With this PR:
![ss_2019-10-12_19:36:09](https://user-images.githubusercontent.com/21012234/66705499-c10ef080-ed27-11e9-95f4-6a71557365c0.png)
![ss_2019-10-12_19:39:12](https://user-images.githubusercontent.com/21012234/66705521-2367f100-ed28-11e9-9b8b-972637db2181.png)

Without this PR:
![ss_2019-10-12_19:33:41](https://user-images.githubusercontent.com/21012234/66705505-cbc98580-ed27-11e9-8374-429395637aa5.png)
![ss_2019-10-12_19:29:33](https://user-images.githubusercontent.com/21012234/66705520-2367f100-ed28-11e9-9575-3b9b11de1867.png)

This PR also adds an eye point to the message to ease jumping to the city in order to check its status with the new slave.