### PR TITLE
Debug liberate city

### DIFF
--- a/ctp2_code/gs/gameobj/armyevent.cpp
+++ b/ctp2_code/gs/gameobj/armyevent.cpp
@@ -627,6 +627,7 @@ STDEHANDLER(ArmyGetExpelledOrderEvent)
 	SlicObject *so = new SlicObject("42UnitExpelled");
 	so->AddCivilisation(player);
 	so->AddRecipient(victim);
+	so->AddLocation(pos);
 	g_slicEngine->Execute(so);
 
 	return GEV_HD_Continue;

--- a/ctp2_code/gs/slic/slicfunc.cpp
+++ b/ctp2_code/gs/slic/slicfunc.cpp
@@ -7547,6 +7547,15 @@ SFN_ERROR Slic_Liberate::Call(SlicArgList *args)
 	//if(!args->GetInt(0, cause))
 	//	return GEV_HD_Continue;
 
+    //// give conquering units to barbars
+    Cell *cell = g_theWorld->GetCell(city.RetPos());
+    sint32 i, n = cell->GetNumUnits();
+
+    for(i = 0; i < n; i++) {
+	Unit u = cell->AccessUnit(i);	    
+	u.ResetUnitOwner(PLAYER_INDEX_VANDALS, CAUSE_REMOVE_ARMY_DIPLOMACY);
+	}
+
     city.ResetCityOwner(PLAYER_INDEX_VANDALS, FALSE, CAUSE_REMOVE_CITY_DIPLOMACY);
 
     return SFN_ERROR_OK;

--- a/ctp2_code/gs/slic/slicfunc.cpp
+++ b/ctp2_code/gs/slic/slicfunc.cpp
@@ -7547,16 +7547,23 @@ SFN_ERROR Slic_Liberate::Call(SlicArgList *args)
 	//if(!args->GetInt(0, cause))
 	//	return GEV_HD_Continue;
 
-    //// give conquering units to barbars
+    city.ResetCityOwner(PLAYER_INDEX_VANDALS, FALSE, CAUSE_REMOVE_CITY_DIPLOMACY); // must be before sending armies home otherwise NearestFriendlyCityWithRoom returns the current city
+
+    //// send conquering units home
     Cell *cell = g_theWorld->GetCell(city.RetPos());
     sint32 i, n = cell->GetNumUnits();
 
+    MapPoint 		cpos;
+    UnitDynamicArray    revealed;
     for(i = 0; i < n; i++) {
-	Unit u = cell->AccessUnit(i);	    
-	u.ResetUnitOwner(PLAYER_INDEX_VANDALS, CAUSE_REMOVE_ARMY_DIPLOMACY);
+	Unit u = cell->AccessUnit(i);
+	if(u.NearestFriendlyCityWithRoom(cpos, n, u.GetArmy())){
+	    u.SetPosition(cpos, revealed);
+	    }
+	else{
+	    u.Kill(CAUSE_REMOVE_ARMY_EXPELLED_NO_CITIES, PLAYER_INDEX_VANDALS);
+	    }
 	}
-
-    city.ResetCityOwner(PLAYER_INDEX_VANDALS, FALSE, CAUSE_REMOVE_CITY_DIPLOMACY);
 
     return SFN_ERROR_OK;
 }

--- a/ctp2_code/gs/slic/slicfunc.cpp
+++ b/ctp2_code/gs/slic/slicfunc.cpp
@@ -7566,21 +7566,8 @@ SFN_ERROR Slic_Liberate::Call(SlicArgList *args)
     if(n > 0) {
 	for(i = 0; i < n; i++) {
 	    if(foundCity) {
-		Army newArmy;
-		if(expelled[i].GetArmy().Num() > 1) { // put unit in its own army, similar to ArmyData::UngroupUnits / ArmyData::RemainNumUnits
-		    newArmy = g_player[expelled[i].GetOwner()]->GetNewArmy(CAUSE_NEW_ARMY_EXPELLED); // new army for unit
-		    g_gevManager->AddEvent(GEV_INSERT_AfterCurrent, GEV_AddUnitToArmy, // put unit in new (empty) army
-			GEA_Unit, expelled[i],
-			GEA_Army, newArmy,
-			GEA_Int, CAUSE_NEW_ARMY_EXPELLED,
-			GEA_End);
-		    }
-		else {
-		    newArmy = expelled[i].GetArmy();
-		    }
-		
 		g_gevManager->AddEvent(GEV_INSERT_AfterCurrent, GEV_GetExpelledOrder,
-		    GEA_Army, newArmy,
+		    GEA_Army, expelled[i].GetArmy(),
 		    GEA_MapPoint, cpos,
 		    GEA_Player, PLAYER_INDEX_VANDALS,
 		    GEA_End);

--- a/ctp2_code/gs/slic/slicfunc.cpp
+++ b/ctp2_code/gs/slic/slicfunc.cpp
@@ -7567,9 +7567,15 @@ SFN_ERROR Slic_Liberate::Call(SlicArgList *args)
 	for(i = 0; i < n; i++) {
 	    if(foundCity) {
 		Army newArmy;
-		if(expelled[i].GetArmy().Num() > 1) {
-		    newArmy = g_player[expelled[i].GetOwner()]->GetNewArmy(CAUSE_NEW_ARMY_EXPELLED);
-		    } else {
+		if(expelled[i].GetArmy().Num() > 1) { // put unit in its own army, similar to ArmyData::UngroupUnits / ArmyData::RemainNumUnits
+		    newArmy = g_player[expelled[i].GetOwner()]->GetNewArmy(CAUSE_NEW_ARMY_EXPELLED); // new army for unit
+		    g_gevManager->AddEvent(GEV_INSERT_AfterCurrent, GEV_AddUnitToArmy, // put unit in new (empty) army
+			GEA_Unit, expelled[i],
+			GEA_Army, newArmy,
+			GEA_Int, CAUSE_NEW_ARMY_EXPELLED,
+			GEA_End);
+		    }
+		else {
 		    newArmy = expelled[i].GetArmy();
 		    }
 		
@@ -7578,14 +7584,6 @@ SFN_ERROR Slic_Liberate::Call(SlicArgList *args)
 		    GEA_MapPoint, cpos,
 		    GEA_Player, PLAYER_INDEX_VANDALS,
 		    GEA_End);
-		
-		if(expelled[i].GetArmy().Num() > 1) {
-		    g_gevManager->AddEvent(GEV_INSERT_AfterCurrent, GEV_AddUnitToArmy,
-			GEA_Unit, expelled[i],
-			GEA_Army, newArmy,
-			GEA_Int, CAUSE_NEW_ARMY_EXPELLED,
-			GEA_End);
-		    }
 		}
 	    else {
 		expelled[i].Kill(CAUSE_REMOVE_ARMY_EXPELLED_NO_CITIES, PLAYER_INDEX_VANDALS);

--- a/ctp2_data/default/gamedata/script.slc
+++ b/ctp2_data/default/gamedata/script.slc
@@ -785,6 +785,7 @@ messagebox '41UnitDisbandedOnGovChange' {
 messagebox '42UnitExpelled' {
 	MessageType("MILITARY");
 	Text(ID_UNIT_EXPELLED);
+	EyePoint(location[0]);
 }
 
 messagebox '44WonderStarted' {


### PR DESCRIPTION
Currently when conquering a city and choosing "Liberate" the conquering units are stuck in the then vandal/barbarian city. 

![ss_2019-10-20_01:00:35](https://user-images.githubusercontent.com/21012234/67152484-900a5f00-f2d7-11e9-8a70-b185cfedce88.png)

They cannot be moved out (due to ZOC?) and are killed over the next turn. This PR tries to solve this by either giving the units over to the barbarians or by sending them home (like when expelled).