### PR TITLE
Increase MaxRadius and MaxNeeded for power satellite

### DIFF
--- a/ctp2_data/default/gamedata/EndGameObjects.txt
+++ b/ctp2_data/default/gamedata/EndGameObjects.txt
@@ -15,7 +15,7 @@ ENDGAME_POWER_SATELLITE {
     Building IMPROVE_POWER_SATELLITE
 	
 	MinNeeded 10
-	MaxNeeded 20
+	MaxNeeded 40
 }
 
 ENDGAME_PROCESSING_TOWER {
@@ -29,7 +29,7 @@ ENDGAME_PROCESSING_TOWER {
 	MinRadius 5
 
 	// use max radius when max power sources are built
-	MaxRadius 8
+	MaxRadius 16
 
 	// need to have 60% of the map area covered
 	MinCoverage 0.6


### PR DESCRIPTION
This way the science victory (SV) can be achieved with less agression because the oblelisk range can be further increased by building more power sats:
https://github.com/civctp2/civctp2/blob/bf9a81223e9c1ec266364807555fe9ffc7b75b60/ctp2_code/gs/gameobj/gaiacontroller.cpp#L760-L769
This is particularly a problem when playing with huge or gigantic maps.
Before:
![ss_2020-01-01_21:32:20](https://user-images.githubusercontent.com/21012234/71748540-2da31280-2e73-11ea-9049-a16922ee291c.png)
with the PR:
![ss_2020-01-01_22:22:32](https://user-images.githubusercontent.com/21012234/71748549-31cf3000-2e73-11ea-98a5-871b4703bc54.png)

