### PR TITLE
make Emphatic Diplomats un-expelleable

### DIFF
--- a/ctp2_data/default/gamedata/Units.txt
+++ b/ctp2_data/default/gamedata/Units.txt
@@ -1504,7 +1504,6 @@ UNIT_EMPATHIC_DIPLOMAT {
    MaxFuel 0
    IgnoreZOC
    NoZoc
-   CanBeExpelled
    CantCaptureCity
    EstablishEmbassy
    ThrowParty


### PR DESCRIPTION
missing from 6b68e4ae:
![ss_2019-12-31_00:11:46](https://user-images.githubusercontent.com/21012234/71752089-0d2c8580-2e7e-11ea-82f4-ad3b2cf3cb01.png)
