### PR TITLE
Use/test run.sh in GL-CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -85,11 +85,7 @@ debug:
     - echo $DOCKER_PARAMS
     - echo $CTP_PARAMS
     - mkdir -p $(pwd)/logs/ && chmod a+rw $(pwd)/logs/ # needs to be rw for diUser
-    - docker run
-             --env DISPLAY
-             -v ${SHARED_PATH}/.X11-unix/:/tmp/.X11-unix/
-             -v $(pwd)/.civctp2/save/:/opt/ctp2/ctp2_program/ctp/save/
-             -v $(pwd)/logs/:/opt/ctp2/ctp2_program/ctp/logs/
+    - XVFBtmp=${SHARED_PATH}/.X11-unix/ ./run.sh
              $DOCKER_PARAMS
              $IMAGE_TAG:${CI_JOB_STAGE}-${BTYP}
              ./ctp2 $CTP_PARAMS &

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -85,7 +85,7 @@ debug:
     - echo $DOCKER_PARAMS
     - echo $CTP_PARAMS
     - mkdir -p $(pwd)/logs/ && chmod a+rw $(pwd)/logs/ # needs to be rw for diUser
-    - XVFBtmp=${SHARED_PATH}/.X11-unix/ ./run.sh
+    - XVFBtmp=${SHARED_PATH}/.X11-unix/ HOME=$(pwd) ./run.sh
              $DOCKER_PARAMS
              $IMAGE_TAG:${CI_JOB_STAGE}-${BTYP}
              ./ctp2 $CTP_PARAMS &

--- a/run.sh
+++ b/run.sh
@@ -1,9 +1,15 @@
-#!/bin/bash
+#!/bin/sh
 
 XSOCK=/tmp/.X11-unix
-XAUTH=/tmp/.docker.xauth
-touch $XAUTH
-xauth nlist $DISPLAY < /dev/null | sed -e 's/^..../ffff/' | xauth -f $XAUTH nmerge -
+if [ -z ${XVFBtmp+x} ]; then 
+    XAUTH=/tmp/.docker.xauth
+    touch $XAUTH
+    xauth nlist $DISPLAY < /dev/null | sed -e 's/^..../ffff/' | xauth -f $XAUTH nmerge -
+
+    DOCKERARGS="--volume $XSOCK:$XSOCK:rw --volume $XAUTH:$XAUTH:rw --env XAUTHORITY=$XAUTH"
+else
+    DOCKERARGS="--volume $XVFBtmp:$XSOCK:rw"
+fi
 
 mkdir -p $HOME/.civctp2/save/
 mkdir -p $HOME/.civctp2/logs/ # if not existent created by docker then owned by root
@@ -18,14 +24,11 @@ fi
 ## ./run.sh -v $HOME/ctp2CD/ctp2_program/ctp/music/:/opt/ctp2/ctp2_program/ctp/music/:ro registry.gitlab.com/civctp2/civctp2/master:latest ./ctp2 fullscreen
 docker run \
        --rm \
-       --volume $XSOCK:$XSOCK:rw \
-       --volume $XAUTH:$XAUTH:rw \
+       $DOCKERARGS \
        --device /dev/dri:/dev/dri \
        --device /dev/snd:/dev/snd \
        --env "ALSA_CARD=0" \
-       --env "XAUTHORITY=${XAUTH}" \
        --env "DISPLAY" \
-       --user "diUser" \
        -v $HOME/.civctp2/userprofile.txt:/opt/ctp2/ctp2_program/ctp/userprofile.txt \
        -v $HOME/.civctp2/userkeymap.txt:/opt/ctp2/ctp2_program/ctp/userkeymap.txt \
        $CON \
@@ -33,4 +36,6 @@ docker run \
        -v $HOME/.civctp2/logs/:/opt/ctp2/ctp2_program/ctp/logs \
        $@
 
-rm $XAUTH # remove to avoid accumulation of xauth settings
+if [ -z ${XVFBtmp+x} ]; then 
+    rm $XAUTH # remove to avoid accumulation of xauth settings
+fi

--- a/run.sh
+++ b/run.sh
@@ -9,7 +9,11 @@ mkdir -p $HOME/.civctp2/save/
 mkdir -p $HOME/.civctp2/logs/ # if not existent created by docker then owned by root
 touch $HOME/.civctp2/userprofile.txt # file must exist for docker file-vol
 touch $HOME/.civctp2/userkeymap.txt # file must exist for docker file-vol
-touch $HOME/.civctp2/Const.txt # file must exist for docker file-vol
+
+if test -s $HOME/.civctp2/Const.txt # file must exist for docker file-vol
+then CON="-v $HOME/.civctp2/Const.txt:/opt/ctp2/ctp2_program/ctp/Const.txt"
+fi     
+
 ## use -v to specify the folder with OGGs (TrackXX.ogg) for the game music, e.g.:
 ## ./run.sh -v $HOME/ctp2CD/ctp2_program/ctp/music/:/opt/ctp2/ctp2_program/ctp/music/:ro registry.gitlab.com/civctp2/civctp2/master:latest ./ctp2 fullscreen
 docker run \
@@ -24,7 +28,7 @@ docker run \
        --user "diUser" \
        -v $HOME/.civctp2/userprofile.txt:/opt/ctp2/ctp2_program/ctp/userprofile.txt \
        -v $HOME/.civctp2/userkeymap.txt:/opt/ctp2/ctp2_program/ctp/userkeymap.txt \
-       -v $HOME/.civctp2/Const.txt:/opt/ctp2/ctp2_program/ctp/Const.txt \
+       $CON \
        -v $HOME/.civctp2/save/:/opt/ctp2/ctp2_program/ctp/save \
        -v $HOME/.civctp2/logs/:/opt/ctp2/ctp2_program/ctp/logs \
        $@


### PR DESCRIPTION
So far `run.sh` is well tested to work for running CTP2 through the GL-DI (docker image). Even though GL-CI testing uses the GL-DI, commands from `run.sh` are used (doublicated) in `.gitlab-ci.yml` because Xorg and Xvfb need different settings.
This PR is meant for making use of `run.sh` in GL-CI in order to avoid dublication and to test  `run.sh` in the scope of GL-CI.