### PR TITLE
Save known CityWall and ForceField 

### DIFF
--- a/ctp2_code/gfx/spritesys/UnitActor.cpp
+++ b/ctp2_code/gfx/spritesys/UnitActor.cpp
@@ -338,11 +338,6 @@ void UnitActor::Initialize(void)
 
 	m_hidden = FALSE;
 
-	m_isFortifying = FALSE;
-	m_isFortified = FALSE;
-	m_hasCityWalls = FALSE;
-	m_hasForceField = FALSE;
-
 	m_shieldFlashOnTime = 0;
 	m_shieldFlashOffTime = 0;
 

--- a/ctp2_code/gfx/spritesys/UnitActor.cpp
+++ b/ctp2_code/gfx/spritesys/UnitActor.cpp
@@ -2323,10 +2323,10 @@ void UnitActor::Serialize(CivArchive &archive)
 		}
 
 		archive << m_facing;
-		archive.PutUINT8((uint8)m_isFortified);
-		archive.PutUINT8((uint8)m_isFortifying);
-		archive.PutUINT8((uint8)m_hasCityWalls);
-		archive.PutUINT8((uint8)m_hasForceField);
+		archive.PutUINT8((uint8)m_isFortified); // was not saved before #244 and is only saved here to fill the fromer 4 bytes, i.e. slot could be reused
+		archive.PutUINT8((uint8)m_isFortifying); // was not saved before #244 and is only saved here to fill the fromer 4 bytes, i.e. slot could be reused
+		archive.PutUINT8((uint8)m_hasCityWalls); // without saving, known city walls are not drawn after a game reload (bad for sending armies, slavers)
+		archive.PutUINT8((uint8)m_hasForceField); // without saving, known force fields are not drawn after a game reload (bad for sending armies)
 		archive << m_size;
 		archive.PutUINT8((uint8)m_isUnseenCellActor);
 

--- a/ctp2_code/gfx/spritesys/UnitActor.cpp
+++ b/ctp2_code/gfx/spritesys/UnitActor.cpp
@@ -2328,7 +2328,10 @@ void UnitActor::Serialize(CivArchive &archive)
 		}
 
 		archive << m_facing;
-		archive << m_lastMoveFacing;
+		archive.PutUINT8((uint8)m_isFortified);
+		archive.PutUINT8((uint8)m_isFortifying);
+		archive.PutUINT8((uint8)m_hasCityWalls);
+		archive.PutUINT8((uint8)m_hasForceField);
 		archive << m_size;
 		archive.PutUINT8((uint8)m_isUnseenCellActor);
 
@@ -2354,7 +2357,10 @@ void UnitActor::Serialize(CivArchive &archive)
 	else
 	{
 		archive >> m_facing;
-		archive >> m_lastMoveFacing;
+		m_isFortified = (BOOL)archive.GetUINT8();
+		m_isFortifying = (BOOL)archive.GetUINT8();
+		m_hasCityWalls = (BOOL)archive.GetUINT8();
+		m_hasForceField = (BOOL)archive.GetUINT8();
 		archive >> m_size;
 
 		m_isUnseenCellActor = (BOOL)archive.GetUINT8();

--- a/ctp2_code/gfx/spritesys/UnitActor.h
+++ b/ctp2_code/gfx/spritesys/UnitActor.h
@@ -264,7 +264,7 @@ protected:
 	LOADTYPE			m_loadType;
 
 	sint32				m_facing;
-	sint32				m_lastMoveFacing;
+	sint32				m_lastMoveFacing; // purpose unclear since there is also m_facing, not saved any more since #244
 	sint32				m_frame;
 	uint16				m_transparency;
 


### PR DESCRIPTION
So far it seems that known City-Walls and Force-Fields are not saved such that when re-loading a game cities in FOW are always drawn without City-Walls/ Force-Fields. 
Force-Field seen and saved in unseen cell:
![ss_2020-01-11_21:55:08](https://user-images.githubusercontent.com/21012234/72211230-fa423280-34c7-11ea-92ba-4fd9cb3d4054.png)
After a save (quick or normal) and a re-load the force field is not drawn any more:
![ss_2020-01-11_22:01:45](https://user-images.githubusercontent.com/21012234/72211231-03cb9a80-34c8-11ea-8082-8b436d46287a.png)

