### PR TITLE
Don't show city capture options for cities with 1 pop

### DIFF
--- a/ctp2_code/gs/gameobj/CityEvent.cpp
+++ b/ctp2_code/gs/gameobj/CityEvent.cpp
@@ -201,7 +201,7 @@ STDEHANDLER(CaptureCityEvent)
 		if (
 			(g_theProfileDB->IsCityCaptureOptions())
 			//(g_theProfileDB->GetValueByName("CityCaptureOptions"))
-		&& (city.GetData()->GetCityData()->PopCount() > 0)
+		&& (city.GetData()->GetCityData()->PopCount() > 1)
 		){
 //EMOD Capture city options
             /// @todo Check impact: this could be considered a human cheat.


### PR DESCRIPTION
When capturing a city with population of 1, it is automatically razed yet
the City Capture Options dialog is still shown. The dialog buttons can be
clicked but it has no effect, since city is already destroyed.

Note: the observed behavior is with AE Mod scernario. I haven't played vanilla
for decades, so I'm not entirely sure that cities lose population after being
captured in vanilla game.