### PR TITLE
WIP: Gold given even for domestic trade routes

### DIFF
--- a/ctp2_code/gs/gameobj/CityData.cpp
+++ b/ctp2_code/gs/gameobj/CityData.cpp
@@ -4473,6 +4473,9 @@ void CityData::CalculateTradeRoutes(bool projectedOnly)
 					g_player[route.GetSource().GetOwner()]->AddGold(route.GetGoldInReturn());
 				}
 			}
+			else{ // gold even for domestic trade route (e.g. paid by the citizens from their wages)
+			    g_player[m_owner]->AddGold(route.GetGoldInReturn());
+			    }
 
 			if(!route.IsActive())
 			{


### PR DESCRIPTION
In conjunction to https://github.com/civctp2/civctp2/issues/192#issuecomment-570700310, this PR enables receiving gold even for domestic trade routes, e.g. paid by the citizens from their wages.
Currently, domestic trade does not yield any gold
https://github.com/civctp2/civctp2/blob/bf9a81223e9c1ec266364807555fe9ffc7b75b60/ctp2_code/gs/gameobj/CityData.cpp#L4463-L4475
Therefore, before #188, domestic trade routes did not make any sense at all. Now with #188 the destination at least gets the bonus, and with #249 this bonus is lost when the route is pirated. The pirating civ so far does not get the bonus but the gold the route is worth.
It can be argued that the sending city gets the gold from the receiving city, and belonging to the same civ for domestic trade routes, not yielding any net gold to the civ. However, giving the civ some gold (not removed from another player in case of domestic trade) would have the positive effect that the AI (establishing many domestic trade routes) would gain more gold in regard to #223.

Suggestions and other ideas on this are welcome.