### PR TITLE
Reduce trade route value for domestic trade

### DIFF
--- a/ctp2_code/gs/gameobj/tradeutil.cpp
+++ b/ctp2_code/gs/gameobj/tradeutil.cpp
@@ -58,10 +58,12 @@ sint32 tradeutil_GetTradeValue(const sint32 owner, const Unit & destination, sin
 	return 0;
 
     double baseValue = g_theWorld->GetGoodValue(resource); // good value varies between a min and a map depening on its frequency on the map
-    double distance = static_cast<double>(destination.GetCityData()->GetDistanceToGood(resource));
-    sint32 totalValue = sint32(baseValue * distance);
 
     PLAYER_INDEX const  tradePartner = destination.GetOwner();
+
+    sint32 totalValue= sint32( // do not count distance to good in case of domestic trade (good is within territory then)
+	(owner != tradePartner) ? baseValue * destination.GetCityData()->GetDistanceToGood(resource) : baseValue
+	);
 
     if ((owner != tradePartner)	&& AgreementMatrix::s_agreements.HasAgreement(owner, tradePartner, PROPOSAL_TREATY_TRADE_PACT))
 	{

--- a/ctp2_code/gs/gameobj/tradeutil.cpp
+++ b/ctp2_code/gs/gameobj/tradeutil.cpp
@@ -62,7 +62,9 @@ sint32 tradeutil_GetTradeValue(const sint32 owner, const Unit & destination, sin
     PLAYER_INDEX const  tradePartner = destination.GetOwner();
 
     sint32 totalValue= sint32( // do not count distance to good in case of domestic trade (good is within territory then)
-	(owner != tradePartner) ? baseValue * destination.GetCityData()->GetDistanceToGood(resource) : baseValue
+	(owner != tradePartner) ?
+	baseValue * destination.GetCityData()->GetDistanceToGood(resource) :
+	baseValue * destination.GetCityData()->GetDistanceToGood(resource) * g_theConstDB->Get(0)->GetDomesticTradeReduction()
 	);
 
     if ((owner != tradePartner)	&& AgreementMatrix::s_agreements.HasAgreement(owner, tradePartner, PROPOSAL_TREATY_TRADE_PACT))

--- a/ctp2_code/gs/gameobj/tradeutil.cpp
+++ b/ctp2_code/gs/gameobj/tradeutil.cpp
@@ -69,7 +69,7 @@ sint32 tradeutil_GetTradeValue(const sint32 owner, const Unit & destination, sin
 
     if ((owner != tradePartner)	&& AgreementMatrix::s_agreements.HasAgreement(owner, tradePartner, PROPOSAL_TREATY_TRADE_PACT))
 	{
-	totalValue = (sint32) (totalValue * 1.05); //- shouldn't trade pact values be set in the ConstDB instead of 1.05? - E 6.13.2007
+	totalValue = (sint32) (totalValue * g_theConstDB->Get(0)->GetTradePactCoef());
 	}
 
     return static_cast<sint32>(std::max<double>(totalValue, 1.0)); // ensure that the trade value is >= 1

--- a/ctp2_code/gs/gameobj/tradeutil.cpp
+++ b/ctp2_code/gs/gameobj/tradeutil.cpp
@@ -72,7 +72,7 @@ sint32 tradeutil_GetTradeValue(const sint32 owner, const Unit & destination, sin
 	totalValue = (sint32) (totalValue * 1.05); //- shouldn't trade pact values be set in the ConstDB instead of 1.05? - E 6.13.2007
 	}
 
-    return totalValue;
+    return static_cast<sint32>(std::max<double>(totalValue, 1.0)); // ensure that the trade value is >= 1
     }
 
 sint32 tradeutil_GetAccurateTradeDistance(const Unit &source, const Unit &destination)

--- a/ctp2_code/gs/newdb/Const.cdb
+++ b/ctp2_code/gs/newdb/Const.cdb
@@ -326,6 +326,7 @@ Const : alsire {
 	Int    BaseStarvationProtection               aka BASE_STARVATION_PROTECTION
 
 	Float  CaravanCoef                            aka CARAVAN_COEF
+	Float  DomesticTradeReduction                 aka DOMESTIC_TRADE_COEF
 
 	Int    PollutionCausedByNuke                  aka POLLUTION_CAUSED_BY_NUKE
 

--- a/ctp2_code/gs/newdb/Const.cdb
+++ b/ctp2_code/gs/newdb/Const.cdb
@@ -327,6 +327,7 @@ Const : alsire {
 
 	Float  CaravanCoef                            aka CARAVAN_COEF
 	Float  DomesticTradeReduction                 aka DOMESTIC_TRADE_COEF
+	Float  TradePactCoef                          aka PACT_TRADE_COEF
 
 	Int    PollutionCausedByNuke                  aka POLLUTION_CAUSED_BY_NUKE
 

--- a/ctp2_data/default/gamedata/Const.txt
+++ b/ctp2_data/default/gamedata/Const.txt
@@ -392,4 +392,4 @@ CAPTURED_CITY_KILL_POP   1  # when a city is captured this number of the populat
 COMBAT_ELITE_CHANCE 0.00 
 COMBAT_LEADER_CHANCE 0.00 
 CITY_ON_TRADE_ROUTE_BONUS  0.3   # if a trade route passes through a city and the desination and source is not the same as the city owner then you get this percentage of the trade route value
-DOMESTIC_TRADE_COEF 1.0 # coefficient for the reduction of trade route value in case of domestic trade (value < 1.0 promotes foreign trade)
+DOMESTIC_TRADE_COEF 0.5 # coefficient for the reduction of trade route value in case of domestic trade (value < 1.0 promotes foreign trade)

--- a/ctp2_data/default/gamedata/Const.txt
+++ b/ctp2_data/default/gamedata/Const.txt
@@ -393,3 +393,4 @@ COMBAT_ELITE_CHANCE 0.00
 COMBAT_LEADER_CHANCE 0.00 
 CITY_ON_TRADE_ROUTE_BONUS  0.3   # if a trade route passes through a city and the desination and source is not the same as the city owner then you get this percentage of the trade route value
 DOMESTIC_TRADE_COEF 0.5 # coefficient for the reduction of trade route value in case of domestic trade (value < 1.0 promotes foreign trade)
+PACT_TRADE_COEF  1.05  # surplus in trade route values in case of a standing trade pact

--- a/ctp2_data/default/gamedata/Const.txt
+++ b/ctp2_data/default/gamedata/Const.txt
@@ -392,3 +392,4 @@ CAPTURED_CITY_KILL_POP   1  # when a city is captured this number of the populat
 COMBAT_ELITE_CHANCE 0.00 
 COMBAT_LEADER_CHANCE 0.00 
 CITY_ON_TRADE_ROUTE_BONUS  0.3   # if a trade route passes through a city and the desination and source is not the same as the city owner then you get this percentage of the trade route value
+DOMESTIC_TRADE_COEF 1.0 # coefficient for the reduction of trade route value in case of domestic trade (value < 1.0 promotes foreign trade)


### PR DESCRIPTION
PR replacing #251, reducing the trade profit (gold) for domestic trade routes. Apparently, no gold was given for domestic trade in CTP1
https://github.com/civctp2/civctp2/blob/71571fc29255a13215a289e00668ad055e776f46/ctp2_code/gs/gameobj/CityData.cpp#L4460-L4475
but in CTP2:
https://github.com/civctp2/civctp2/blob/71571fc29255a13215a289e00668ad055e776f46/ctp2_code/gs/gameobj/CityData.cpp#L4513-L4541
This is fine in general, but with #254 currently leads to more domestic trade routes than before. This PR tries to counter act this by reducing the value of domestic trade by not taking the distance to a good into account in case of domestic trade, since the good is within the territory.