### PR TITLE
Adjustments for general GL-CI runners

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -7,6 +7,7 @@ if [ -z ${XVFBtmp+x} ]; then
     xauth nlist $DISPLAY < /dev/null | sed -e 's/^..../ffff/' | xauth -f $XAUTH nmerge -
 
     DOCKERARGS="--volume $XSOCK:$XSOCK:rw --volume $XAUTH:$XAUTH:rw --env XAUTHORITY=$XAUTH"
+    DOCKERARGS="${DOCKERARGS} --device /dev/dri:/dev/dri --device /dev/snd:/dev/snd --env ALSA_CARD=0 "
 else
     DOCKERARGS="--volume $XVFBtmp:$XSOCK:rw"
 fi
@@ -25,9 +26,6 @@ fi
 docker run \
        --rm \
        $DOCKERARGS \
-       --device /dev/dri:/dev/dri \
-       --device /dev/snd:/dev/snd \
-       --env "ALSA_CARD=0" \
        --env "DISPLAY" \
        -v $HOME/.civctp2/userprofile.txt:/opt/ctp2/ctp2_program/ctp/userprofile.txt \
        -v $HOME/.civctp2/userkeymap.txt:/opt/ctp2/ctp2_program/ctp/userkeymap.txt \


### PR DESCRIPTION
Regression for #241, which apparently does not work as is for all of the available GL-CI runners. As devices are not needed for Xvfb (at least not as long as screen casting from Xvfb does not work) nor guaranteed to be available on every shared runner by default, they are now move to the docker parameters when used with X11.