### PR TITLE
[linux] Fix ESC key behavior

### DIFF
--- a/ctp2_code/ui/aui_common/aui_control.cpp
+++ b/ctp2_code/ui/aui_common/aui_control.cpp
@@ -186,7 +186,7 @@ AUI_ERRCODE aui_Control::InitCommonLdl(
 			else
 				m_actionKey = '^';
 		} else if(stricmp(shortcut, "ESC") == 0) {
-			m_actionKey = VK_ESCAPE;
+			SetActionKeyToESC();
 		} else {
 			m_actionKey = shortcut[0];
 		}

--- a/ctp2_code/ui/aui_common/aui_control.cpp
+++ b/ctp2_code/ui/aui_common/aui_control.cpp
@@ -186,11 +186,7 @@ AUI_ERRCODE aui_Control::InitCommonLdl(
 			else
 				m_actionKey = '^';
 		} else if(stricmp(shortcut, "ESC") == 0) {
-#ifdef WIN32
 			m_actionKey = VK_ESCAPE;
-#else
-			m_actionKey = AUI_KEYBOARD_KEY_ESCAPE;
-#endif
 		} else {
 			m_actionKey = shortcut[0];
 		}

--- a/ctp2_code/ui/aui_common/aui_control.h
+++ b/ctp2_code/ui/aui_common/aui_control.h
@@ -211,6 +211,8 @@ public:
 	virtual aui_Control	*SetKeyboardFocus( void );
 	virtual AUI_ERRCODE	ReleaseKeyboardFocus( void );
 
+	void SetActionKeyToESC( void ) { m_actionKey = VK_ESCAPE; }
+
 	virtual AUI_ERRCODE Draw(
 		aui_Surface *surface = NULL,
 		sint32 x = 0,

--- a/ctp2_code/ui/aui_ctp2/keypress.cpp
+++ b/ctp2_code/ui/aui_ctp2/keypress.cpp
@@ -335,11 +335,10 @@ sint32 ui_HandleKeypress(WPARAM wParam, LPARAM lParam)
 	}
 #endif
 
-
-
-
-
-
+	// If a tooltip is shown, close it to prevent keyboard events being sent to it.
+	if (g_c3ui->TopWindow() && g_c3ui->TopWindow()->Type() == AUI_WINDOW_TYPE_TIP) {
+		g_ui->RemoveWindow(g_c3ui->TopWindow()->Id());
+	}
 
 	if (wParam == VK_ESCAPE) {
 

--- a/ctp2_code/ui/aui_ctp2/keypress.cpp
+++ b/ctp2_code/ui/aui_ctp2/keypress.cpp
@@ -134,6 +134,7 @@
 #include "MainControlPanel.h"
 #include "UnitControlPanel.h"
 #include "segmentlist.h"
+#include "helptile.h"
 
 extern C3UI			*g_c3ui;
 extern BOOL			gSuspended;
@@ -345,7 +346,7 @@ sint32 ui_HandleKeypress(WPARAM wParam, LPARAM lParam)
 		extern OptionsWindow *g_optionsWindow;
 
 		if(g_c3ui->TopWindow() && g_c3ui->TopWindow() == DipWizard::GetWindow()) {
-
+			// Nothing
 		} else if(g_keyboardHandlers.GetTail()) {
 			g_keyboardHandlers.GetTail()->kh_Close();
 		} else if (g_civApp->IsGameLoaded()) {
@@ -354,7 +355,6 @@ sint32 ui_HandleKeypress(WPARAM wParam, LPARAM lParam)
 			   (g_theMessagePool->IsValid(*g_currentMessageWindow->GetMessage()))) {
 				g_currentMessageWindow->GetMessage()->Minimize();
 			} else if(g_modalMessage) {
-
 				Message *msg = g_modalMessage->GetMessage();
 				if(msg && g_theMessagePool->IsValid(*msg)) {
 					Assert(msg->IsAlertBox());
@@ -365,15 +365,15 @@ sint32 ui_HandleKeypress(WPARAM wParam, LPARAM lParam)
 				}
 			} else if (g_chatBox->IsActive()) {
 				g_chatBox->SetActive(false);
+			} else if (helptile_isShown()) {
+				helptile_closeWindow();
 			} else if (g_optionsWindow && g_c3ui->GetWindow(g_optionsWindow->Id())) {
-
 				optionsscreen_removeMyWindow(AUI_BUTTON_ACTION_EXECUTE);
-			} else if(g_c3ui->TopWindow() && g_c3ui->TopWindow()->HandleKey(wParam)) {
-
-			} else if(g_battleViewWindow) {
-				battleview_ExitButtonActionCallback( NULL, AUI_BUTTON_ACTION_EXECUTE, 0, NULL);
+			} else if (g_c3ui->TopWindow() && g_c3ui->TopWindow()->HandleKey(wParam)) {
+				// Nothing
+			} else if (g_battleViewWindow) {
+				battleview_ExitButtonActionCallback(NULL, AUI_BUTTON_ACTION_EXECUTE, 0, NULL);
 			} else {
-
 				optionsscreen_Initialize();
 				optionsscreen_displayMyWindow(1);
 			}

--- a/ctp2_code/ui/aui_ctp2/keypress.cpp
+++ b/ctp2_code/ui/aui_ctp2/keypress.cpp
@@ -346,7 +346,7 @@ sint32 ui_HandleKeypress(WPARAM wParam, LPARAM lParam)
 		extern OptionsWindow *g_optionsWindow;
 
 		if(g_c3ui->TopWindow() && g_c3ui->TopWindow() == DipWizard::GetWindow()) {
-			// Nothing
+			DipWizard::Hide();
 		} else if(g_keyboardHandlers.GetTail()) {
 			g_keyboardHandlers.GetTail()->kh_Close();
 		} else if (g_civApp->IsGameLoaded()) {

--- a/ctp2_code/ui/interface/MessageBoxDialog.cpp
+++ b/ctp2_code/ui/interface/MessageBoxDialog.cpp
@@ -140,6 +140,10 @@ m_userData(userData)
 		m_rightButton->SetText(g_theStringDB->GetNameStr(okText));
 	}
 
+	// Right button is always visible and acts like Cancel in a two-button query
+	// dialog or like OK in a one-button informational dialog.
+	m_rightButton->SetActionKeyToESC();
+
 	m_leftButton->SetActionFuncAndCookie(
 		LeftButtonActionCallback, this);
 	m_rightButton->SetActionFuncAndCookie(

--- a/ctp2_code/ui/interface/helptile.cpp
+++ b/ctp2_code/ui/interface/helptile.cpp
@@ -92,7 +92,8 @@ static c3_Static			*s_tileSaleV		= NULL;
 static c3_Static			*s_tileGold			= NULL;
 static c3_Static			*s_tileGoldV		= NULL;
 
-static aui_StringTable		*s_stringTable		= NULL;
+static aui_StringTable		*s_stringTable	= NULL;
+static bool s_helptileIsShown = false;
 
 enum { STR_SALE_VALUE=0,STR_NONE=1 };
 
@@ -369,6 +370,8 @@ void helptile_displayData(const MapPoint &p)
 	{
 		g_c3ui->AddWindow(g_helpTileWindow);
 	}
+
+	s_helptileIsShown = true;
 }
 
 void helptile_setPosition(const MapPoint& p)
@@ -383,9 +386,22 @@ void helptile_setPosition(const MapPoint& p)
 	g_helpTileWindow->Move(x,y);
 }
 
-static
-void bExitPress( aui_Control *control, uint32 action, uint32 data, void *cookie )
+bool helptile_isShown(void) { return s_helptileIsShown; }
+
+void helptile_closeWindow(void)
 {
+	Assert(s_helptileIsShown);
+
+  AUI_ERRCODE auiErr;
+  auiErr = g_c3ui->RemoveWindow(g_helpTileWindow->Id());
+  Assert(auiErr == AUI_ERRCODE_OK);
+
+  s_helptileIsShown = false;
+}
+
+static
+void bExitPress(aui_Control *control, uint32 action, uint32 data,
+											 void *cookie) {
 	removeMyWindow(action);
 }
 
@@ -394,13 +410,7 @@ sint32 removeMyWindow(uint32 action)
 {
 	if ( action != (uint32)AUI_BUTTON_ACTION_EXECUTE ) return 0;
 
-	AUI_ERRCODE auiErr;
-#if 1
-	auiErr = g_c3ui->RemoveWindow( g_helpTileWindow->Id() );
-	Assert( auiErr == AUI_ERRCODE_OK );
-#else
-	sint32 initialplayscreen_removeMyWindow(uint32);
-	initialplayscreen_removeMyWindow(action);
-#endif
+	helptile_closeWindow();
+
 	return 1;
 }

--- a/ctp2_code/ui/interface/helptile.h
+++ b/ctp2_code/ui/interface/helptile.h
@@ -11,6 +11,8 @@ sint32 helptile_Initialize();
 void helptile_Cleanup( void );
 void helptile_displayData(const MapPoint&);
 void helptile_setPosition(const MapPoint&);
+bool helptile_isShown(void);
+void helptile_closeWindow(void);
 
 #include "c3_listitem.h"
 


### PR DESCRIPTION
Make ESC key close City Manager and similar windows, before popping the game
Options window.

fixes #271