### PR TITLE
[linux] Partial fix for permanent 100% CPU usage

### DIFF
--- a/ctp2_code/ctp/civ3_main.cpp
+++ b/ctp2_code/ctp/civ3_main.cpp
@@ -1698,12 +1698,16 @@ int WINAPI CivMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PSTR szCmdLine,
 #ifdef __AUI_USE_SDL__
 		SDL_Event event;
 		while (!g_letUIProcess) { // There are breaks, too ;)
-			SDL_PumpEvents();
-			int n = SDL_PeepEvents(&event, 1, SDL_GETEVENT,
+			// Throttle the loop a bit to prevent 100% CPU usage in idle state.
+			// FIXME: implement blocking loop with SDL_WaitEvent().
+			if (!SDL_PollEvent(NULL)) {
+				SDL_Delay(30);
+				break;
+			}
 
+			int n = SDL_PeepEvents(&event, 1, SDL_GETEVENT,
                      ~(SDL_EVENTMASK(SDL_MOUSEMOTION) | SDL_EVENTMASK(SDL_MOUSEBUTTONDOWN) | SDL_EVENTMASK(SDL_MOUSEBUTTONUP)));
 			if (0 > n) {
-                            //fprintf(stderr, "[CivMain] PeepEvents failed: %s\n", SDL_GetError());
                             fprintf(stderr, "%s L%d: SDL_PeepEvents: Still events stored! Error?: %s\n", __FILE__, __LINE__, SDL_GetError());
 
 				break;


### PR DESCRIPTION
The event loop throttling for 30 msec implemented by this path reduced the game
CPU load on my laptop (Thinkpad X220 i7 2.7 Ghz) from 100% to around 50% in menu
and 55% while in-game. Not ideal solution, but it prevents the CPU cooler noise
from overheat at 100%.

The proper solution would be to rework the event loop to the blocking mode with
SDL_WaitEvent(). Yet the current hack is still better than nothing.

fixes #272