### PR TITLE
Update Readme with info on preparing the GOG version data

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,11 @@ First, you need the original game files of CTP2.
 If you have the CD version, it's better to install it on a Windows machine / using Wine and copy over the files. You need the folders `ctp2_data`, `ctp2_program` and `Scenarios`.
 
 If you have the GoG version, use `innoextract` to extract all the required files (you can `sudo apt install innoextract` if you need) from the `setup_call_to_power2_2.0.0.13.exe` windows installer.
-For example `innoextract -m -I app  setup_call_to_power2_2.0.0.13.exe` will extract the `app`folder that contains all the game files, which are in the same subfolders as in the CD version: `ctp2_data`, `ctp2_program` and `Scenarios`.
+For example `innoextract -m -I app  setup_call_to_power2_2.0.0.13.exe` will extract the `app` folder that contains all the game files, which are in the same subfolders as in the CD version: `ctp2_data`, `ctp2_program` and `Scenarios`. GOG' version of `ctp2_data` folder needs some files deleted to be fully compatible with AE:
+```bash
+rm ctp2_data/default/aidata/{AdvanceLists,BuildListSequences,UnitBuildLists}.txt
+rm ctp2_data/english/uidata/layouts/*
+```
 
 Put those folder in you `home` path or anywhere else, for example `~/ctp2`
 


### PR DESCRIPTION
fixes #267 and #268

This is alternative solution for #268 without modifying or renaming anything (except Readme) on our side. @LynxAbraxas  after I realized that #276 will mess with CI build, since `ctp2CD` directory contains files in lower case, I think that giving instructions in Readme is better than messing with file names in the repo. If you agree, you can just close #276 without merging and merge this PR instead.