### PR TITLE
Speedup trade route cost evaluation

### DIFF
--- a/ctp2_code/ai/CityManagement/governor.cpp
+++ b/ctp2_code/ai/CityManagement/governor.cpp
@@ -5136,10 +5136,8 @@ void Governor::ManageGoodsTradeRoutes()
 
 						const sint32 price = tradeutil_GetTradeValue(m_playerId, destCity, g); // # of gold
 						const sint32 cost = tradeutil_GetTradeDistance(city, destCity); // # of caravans
-						const sint32 cost2 = tradeutil_GetAccurateTradeDistance(city, destCity); // # of caravans
 						const double valuePerCaravan = static_cast<double>(price) / cost; // cost = tradeutil_GetAccurateTradeDistance returns > 1.0
-						fprintf(stderr, "%s L%d: GetAccurateTradeDistance - GetTradeDistance: %d, valuePerCaravan: %f (%f)\n", __FILE__, __LINE__, cost2 - cost, valuePerCaravan, static_cast<double>(price) / cost2);
-						
+
 						if (valuePerCaravan > bestValuePerCaravan) // determine best offer (and its cost) that would be available, to set goal for # of caravans (m_neededFreight)
 						{
 							maxNeededFreight = cost;

--- a/ctp2_code/ai/CityManagement/governor.cpp
+++ b/ctp2_code/ai/CityManagement/governor.cpp
@@ -5089,7 +5089,7 @@ void Governor::ManageGoodsTradeRoutes()
 				{
 					sellingCost = curDestRoute->GetCost();
 					sellingVPC = static_cast<double>(tradeutil_GetTradeValue(m_playerId, curDestRoute->GetDestination(), g))
-					    / sellingCost; // tradeutil_GetAccurateTradeDistance returns > 1.0
+					    / sellingCost; // tradeutil_GetTradeDistance returns > 1.0
 				}
 				else
 				{

--- a/ctp2_code/ai/CityManagement/governor.cpp
+++ b/ctp2_code/ai/CityManagement/governor.cpp
@@ -5135,7 +5135,7 @@ void Governor::ManageGoodsTradeRoutes()
 							continue;
 
 						const sint32 price = tradeutil_GetTradeValue(m_playerId, destCity, g); // # of gold
-						const sint32 cost = tradeutil_GetAccurateTradeDistance(city, destCity); // # of caravans
+						const sint32 cost = tradeutil_GetTradeDistance(city, destCity); // # of caravans
 						const double valuePerCaravan = static_cast<double>(price) / cost; // cost = tradeutil_GetAccurateTradeDistance returns > 1.0
 
 						if (valuePerCaravan > bestValuePerCaravan) // determine best offer (and its cost) that would be available, to set goal for # of caravans (m_neededFreight)

--- a/ctp2_code/ai/CityManagement/governor.cpp
+++ b/ctp2_code/ai/CityManagement/governor.cpp
@@ -5136,8 +5136,10 @@ void Governor::ManageGoodsTradeRoutes()
 
 						const sint32 price = tradeutil_GetTradeValue(m_playerId, destCity, g); // # of gold
 						const sint32 cost = tradeutil_GetTradeDistance(city, destCity); // # of caravans
+						const sint32 cost2 = tradeutil_GetAccurateTradeDistance(city, destCity); // # of caravans
 						const double valuePerCaravan = static_cast<double>(price) / cost; // cost = tradeutil_GetAccurateTradeDistance returns > 1.0
-
+						fprintf(stderr, "%s L%d: GetAccurateTradeDistance - GetTradeDistance: %d, valuePerCaravan: %f (%f)\n", __FILE__, __LINE__, cost2 - cost, valuePerCaravan, static_cast<double>(price) / cost2);
+						
 						if (valuePerCaravan > bestValuePerCaravan) // determine best offer (and its cost) that would be available, to set goal for # of caravans (m_neededFreight)
 						{
 							maxNeededFreight = cost;

--- a/ctp2_code/gs/gameobj/TradeRouteData.cpp
+++ b/ctp2_code/gs/gameobj/TradeRouteData.cpp
@@ -107,6 +107,7 @@ TradeRouteData::TradeRouteData
 			 sPos.x, sPos.y, dPos.x, dPos.y));
 
 	m_valid = GeneratePath(); // determins cost of trade-units
+	m_transportCost = tradeutil_GetTradeDistance(m_sourceCity, m_destinationCity); // overwrite transport cost from GeneratePath with that from tradeutil_GetTradeDistance to conform with all other cost estimations before creation, namely in governor.cpp (AI) and trademanager (human), which use tradeutil_GetTradeDistance due to significant speed-up
 
 	DPRINTF(k_DBG_GAMESTATE, ("Created Trade Route from %s to %s, cost=%d, valid=%i\n",
 	                          m_sourceCity->GetCityData()->GetName(),

--- a/ctp2_code/gs/gameobj/tradeutil.cpp
+++ b/ctp2_code/gs/gameobj/tradeutil.cpp
@@ -77,6 +77,7 @@ sint32 tradeutil_GetTradeValue(const sint32 owner, const Unit & destination, sin
     return static_cast<sint32>(std::max<double>(totalValue, 1.0)); // ensure that the trade value is >= 1
     }
 
+/* deprecated (in favor of tradeutil_GetTradeDistance) because result can differ significantly, though exact takes much longer to compute due to use of astar
 sint32 tradeutil_GetAccurateTradeDistance(const Unit &source, const Unit &destination)
 {
 	Path    path;
@@ -91,6 +92,7 @@ sint32 tradeutil_GetAccurateTradeDistance(const Unit &source, const Unit &destin
 
 	return DISTANCE_UNKNOWN;
 }
+*/
 
 sint32 tradeutil_GetTradeDistance(Unit &source, Unit &destination)
 {

--- a/ctp2_code/gs/gameobj/tradeutil.cpp
+++ b/ctp2_code/gs/gameobj/tradeutil.cpp
@@ -92,7 +92,6 @@ sint32 tradeutil_GetAccurateTradeDistance(const Unit &source, const Unit &destin
 	return DISTANCE_UNKNOWN;
 }
 
-/* deprecated (in favor of tradeutil_GetAccurateTradeDistance) because result can differ significantly
 sint32 tradeutil_GetTradeDistance(Unit &source, Unit &destination)
 {
 	double cost = g_theWorld->CalcTerrainFreightCost(source.RetPos()) *
@@ -101,7 +100,6 @@ sint32 tradeutil_GetTradeDistance(Unit &source, Unit &destination)
 
 	return static_cast<sint32>(std::max<double>(tradeutil_GetNetTradeCosts(cost), 1.0));
 }
-*/
 
 // Maybe move the following to worldutils
 

--- a/ctp2_code/gs/gameobj/tradeutil.h
+++ b/ctp2_code/gs/gameobj/tradeutil.h
@@ -42,7 +42,7 @@ sint32 const    DISTANCE_UNKNOWN    = 10000;
 
 sint32 tradeutil_GetTradeValue(const sint32 owner, const Unit & destination, sint32 resource);
 sint32 tradeutil_GetAccurateTradeDistance(const Unit &source, const Unit &destination);
-// sint32 tradeutil_GetTradeDistance(Unit &source, Unit &destination); // deprecated (in favor of tradeutil_GetAccurateTradeDistance) because result can differ significantly
+sint32 tradeutil_GetTradeDistance(Unit &source, Unit &destination);
 double inline tradeutil_GetNetTradeCosts(double costs){return(costs * g_theConstDB->Get(0)->GetCaravanCoef() * 0.1) + 0.5;}
 
 void constutil_y2meridian(const sint32 y, sint32 &k);

--- a/ctp2_code/gs/gameobj/tradeutil.h
+++ b/ctp2_code/gs/gameobj/tradeutil.h
@@ -41,7 +41,7 @@
 sint32 const    DISTANCE_UNKNOWN    = 10000;
 
 sint32 tradeutil_GetTradeValue(const sint32 owner, const Unit & destination, sint32 resource);
-sint32 tradeutil_GetAccurateTradeDistance(const Unit &source, const Unit &destination);
+//sint32 tradeutil_GetAccurateTradeDistance(const Unit &source, const Unit &destination); deprecated because result can differ significantly, though exact takes much longer to compute due to use of astar
 sint32 tradeutil_GetTradeDistance(Unit &source, Unit &destination);
 double inline tradeutil_GetNetTradeCosts(double costs){return(costs * g_theConstDB->Get(0)->GetCaravanCoef() * 0.1) + 0.5;}
 

--- a/ctp2_code/ui/interface/trademanager.cpp
+++ b/ctp2_code/ui/interface/trademanager.cpp
@@ -421,7 +421,7 @@ void TradeManager::UpdateCreateList(const PLAYER_INDEX & player_id)
 						data->m_resource = g;
 						data->m_destination = maxCity[i];
 						data->m_price = maxPrice[i];
-						data->m_caravans = tradeutil_GetAccurateTradeDistance(city, maxCity[i]);
+						data->m_caravans = tradeutil_GetTradeDistance(city, maxCity[i]);
 						data->m_curDestination.m_id = curDestCity.m_id;
 
 						m_createData.AddTail(data);


### PR DESCRIPTION
The use of astar for the exact cost evaluation of a trade route as in
https://github.com/civctp2/civctp2/blob/b2aaae74c063d8e86b281ffb826d252fe30a8c55/ctp2_code/gs/gameobj/tradeutil.cpp#L80-L93
is significantly more time consuming than the approximation by
https://github.com/civctp2/civctp2/blob/b2aaae74c063d8e86b281ffb826d252fe30a8c55/ctp2_code/gs/gameobj/tradeutil.cpp#L96-L103
which was used in
https://github.com/civctp2/civctp2/blob/ea3274c3d43176670ac71f6bc75703fac18a226e/ctp2_code/ai/CityManagement/governor.cpp#L5137
before db7b3e0861a90f464d1cf502ed81c494f3bdc38f of #252.
This was not noticeable until about 500AD and later (see also https://github.com/civctp2/civctp2/pull/263#issuecomment-595757346), because the AI had not many trade routes to evaluate. In later games after about 300 turns this becomes noticeable as finishing a turn for a single AI player can take up to a minute then when a few 100 possibly a few 1000 trade route combinations are checked for their value.

Just reverting db7b3e0861a90f464d1cf502ed81c494f3bdc38f leads again to the problem that the AI trade route creation gets unstable because then the fast estimate of the cost of a trade route in general differs to that of the exact cost as used during creation so the AI cancels routes in the expectation that it can create better ones that then turn out to be as bad or even worse than the former ones.

So this PR instead deprecates the accurate cost evaluation and only makes use of the estimate. For that to work the accurate cost evaluated during creation must be overwritten by the estimate used everywhere else
https://github.com/LynxAbraxas/civctp2/blob/df0db714a420071439de8bfd81de901ae847cec2/ctp2_code/gs/gameobj/TradeRouteData.cpp#L110

While this leads to consistent trade route costs and stable trade routes from the AI, it is not as nice as a speed up of the accurate trade cost evaluation. However that would need a significant speed up of the astar implementation, which would effect many aspects of the code and could easily lead to the introduction of critical new bugs. So this PR represents a workaround for the time being.


