### PR TITLE
[linux] Fix empty scenario selection window on New Game

### DIFF
--- a/ctp2_code/gs/fileio/civscenarios.cpp
+++ b/ctp2_code/gs/fileio/civscenarios.cpp
@@ -244,7 +244,7 @@ void CivScenarios::LoadData(void)
 		if (!dent)
 			continue;
 		snprintf(path, sizeof(path), "%s%s%s", rootPath, FILE_SEP, dent->d_name);
-		if (!stat(path, &tmpstat))
+		if (stat(path, &tmpstat) == -1)
 			continue;
 
 		if (S_ISDIR(tmpstat.st_mode)) {


### PR DESCRIPTION
stat(2) returns 0 on success and -1 on error, so the condition was wrong in this
case.

fixes #270