### PR TITLE
Make the game only load the ldl files from the default directory

### DIFF
--- a/ctp2_code/gs/fileio/CivPaths.cpp
+++ b/ctp2_code/gs/fileio/CivPaths.cpp
@@ -515,7 +515,7 @@ MBCHAR *CivPaths::FindFile(C3DIR dir, const MBCHAR *filename, MBCHAR *path,
 
 	if (check_prjfile &&
 	    ((dir == C3DIR_PATTERNS) ||
-			(dir == C3DIR_PICTURES)))
+	     (dir == C3DIR_PICTURES)))
 	{
 		uint32 len = strlen(filename);
 

--- a/ctp2_code/gs/fileio/CivPaths.cpp
+++ b/ctp2_code/gs/fileio/CivPaths.cpp
@@ -415,7 +415,7 @@ MBCHAR *CivPaths::MakeAssetPath
 }
 
 MBCHAR *CivPaths::FindFile(C3DIR dir, const MBCHAR *filename, MBCHAR *path,
-                           bool silent, bool check_prjfile, bool checkScenario)
+                           bool silent, bool check_prjfile, bool checkScenario, bool checkLocalizedPath)
 {
 	MBCHAR			fullPath[_MAX_PATH];
 
@@ -437,7 +437,7 @@ MBCHAR *CivPaths::FindFile(C3DIR dir, const MBCHAR *filename, MBCHAR *path,
 		if (m_curScenarioPath)
 		{
 			sprintf(fullPath, "%s%s%s%s%s%s%s", m_curScenarioPath, FILE_SEP, m_localizedPath, FILE_SEP, m_assetPaths[dir], FILE_SEP, filename);
-			if (c3files_PathIsValid(fullPath))
+			if (checkLocalizedPath && c3files_PathIsValid(fullPath))
 			{
 				strcpy(path, fullPath);
 				return path;
@@ -454,7 +454,7 @@ MBCHAR *CivPaths::FindFile(C3DIR dir, const MBCHAR *filename, MBCHAR *path,
 		if (m_curScenarioPackPath)
 		{
 			sprintf(fullPath, "%s%s%s%s%s%s%s", m_curScenarioPackPath, FILE_SEP, m_localizedPath, FILE_SEP, m_assetPaths[dir], FILE_SEP, filename);
-			if (c3files_PathIsValid(fullPath))
+			if (checkLocalizedPath && c3files_PathIsValid(fullPath))
 			{
 				strcpy(path, fullPath);
 				return path;
@@ -478,8 +478,8 @@ MBCHAR *CivPaths::FindFile(C3DIR dir, const MBCHAR *filename, MBCHAR *path,
 	)
 	{
 		MBCHAR const *	l_dataPath	= *p;
-		if (MakeAssetPath(fullPath, m_hdPath, l_dataPath, m_localizedPath, m_assetPaths[dir], filename) ||
-		    MakeAssetPath(fullPath, m_hdPath, l_dataPath, m_defaultPath,   m_assetPaths[dir], filename)
+		if (checkLocalizedPath && MakeAssetPath(fullPath, m_hdPath, l_dataPath, m_localizedPath, m_assetPaths[dir], filename) ||
+		                          MakeAssetPath(fullPath, m_hdPath, l_dataPath, m_defaultPath,   m_assetPaths[dir], filename)
 		   )
 		{
 			strcpy(path, fullPath);
@@ -488,7 +488,7 @@ MBCHAR *CivPaths::FindFile(C3DIR dir, const MBCHAR *filename, MBCHAR *path,
 	}
 
 	// When not found in the new data, try the original directories
-	if (MakeAssetPath(fullPath, m_hdPath, m_dataPath, m_localizedPath, m_assetPaths[dir], filename))
+	if (checkLocalizedPath && MakeAssetPath(fullPath, m_hdPath, m_dataPath, m_localizedPath, m_assetPaths[dir], filename))
 	{
 		strcpy(path, fullPath);
 		return path;
@@ -501,7 +501,7 @@ MBCHAR *CivPaths::FindFile(C3DIR dir, const MBCHAR *filename, MBCHAR *path,
 	}
 
 	// The CD will only have the original content
-	if (MakeAssetPath(fullPath, m_cdPath, m_dataPath, m_localizedPath, m_assetPaths[dir], filename))
+	if (checkLocalizedPath && MakeAssetPath(fullPath, m_cdPath, m_dataPath, m_localizedPath, m_assetPaths[dir], filename))
 	{
 		strcpy(path, fullPath);
 		return path;

--- a/ctp2_code/gs/fileio/CivPaths.h
+++ b/ctp2_code/gs/fileio/CivPaths.h
@@ -40,13 +40,6 @@
 #include "c3files.h"
 #include <vector>	// list did not work: crashes on begin() for empty list
 
-
-
-
-
-
-
-
 class CivPaths {
 private:
 	MBCHAR *m_hdPath;
@@ -87,11 +80,8 @@ public:
 
 	MBCHAR *GetSavePath(C3SAVEDIR dir, MBCHAR *path);
 
-
-
-
 	MBCHAR *FindFile(C3DIR dir, const MBCHAR *filename, MBCHAR *path,
-                     bool silent = false, bool check_prjfile = true, bool checkScenario = true, bool checkLocalizedPath = true);
+	                 bool silent = false, bool check_prjfile = true, bool checkScenario = true, bool checkLocalizedPath = true);
 
 	MBCHAR *GetSpecificPath(C3DIR dir, MBCHAR *path, BOOL local);
 
@@ -103,67 +93,42 @@ public:
 
 	void	ClearCurScenarioPath(void);
 
-
-
-
 	void	SetCurScenarioPackPath(const MBCHAR *path);
 
 	MBCHAR	* GetCurScenarioPackPath(void);
 
 	void	ClearCurScenarioPackPath(void);
 
-
-
-
-
-
-
-
-
-
-
-    bool        FindPath(C3DIR dir, int num, MBCHAR *path);
+	bool        FindPath(C3DIR dir, int num, MBCHAR *path);
 
 	MBCHAR *    GetSavePathString(void) const { return m_savePath; }
 
 	MBCHAR *    GetDesktopPath(void);
 
 	std::vector<MBCHAR const *> const &
-                GetExtraDataPaths(void) const;
-	void	    InsertExtraDataPath(MBCHAR const * path);
-	void	    ResetExtraDataPaths(void);
-	void 		ReplaceFileSeperator(MBCHAR* path);
+	            GetExtraDataPaths(void) const;
+	void        InsertExtraDataPath(MBCHAR const * path);
+	void        ResetExtraDataPaths(void);
+	void        ReplaceFileSeperator(MBCHAR* path);
 
 protected:
 
 	MBCHAR *    MakeAssetPath
-    (
-        MBCHAR *        fullPath,
-        MBCHAR const *  s1,
-        MBCHAR const *  s2,
-        MBCHAR const *  s3,
-        MBCHAR const *  s4,
-        MBCHAR const *  s5
-    ) const;
+	(
+	    MBCHAR *        fullPath,
+	    MBCHAR const *  s1,
+	    MBCHAR const *  s2,
+	    MBCHAR const *  s3,
+	    MBCHAR const *  s4,
+	    MBCHAR const *  s5
+	) const;
 
 	MBCHAR *    MakeSavePath(MBCHAR *fullPath, MBCHAR *s1, MBCHAR *s2, MBCHAR *s3);
 };
 
-
-
-
-
-
-
 void CivPaths_InitCivPaths();
 
-
 void CivPaths_CleanupCivPaths();
-
-
-
-
-
 
 extern CivPaths *g_civPaths;
 

--- a/ctp2_code/gs/fileio/CivPaths.h
+++ b/ctp2_code/gs/fileio/CivPaths.h
@@ -91,7 +91,7 @@ public:
 
 
 	MBCHAR *FindFile(C3DIR dir, const MBCHAR *filename, MBCHAR *path,
-                     bool silent = false, bool check_prjfile = true, bool checkScenario = true);
+                     bool silent = false, bool check_prjfile = true, bool checkScenario = true, bool checkLocalizedPath = true);
 
 	MBCHAR *GetSpecificPath(C3DIR dir, MBCHAR *path, BOOL local);
 

--- a/ctp2_code/ui/ldl/ldl.l
+++ b/ctp2_code/ui/ldl/ldl.l
@@ -36,6 +36,8 @@ name		[a-zA-Z]+[a-zA-Z0-9_]*
 
 %x incl
 %x fname
+%x inclL
+%x fnameL
 
 %%
 
@@ -80,6 +82,49 @@ name		[a-zA-Z]+[a-zA-Z0-9_]*
 				    ldl_parse_error = LDL_ERROR_INCLUDE;
 				    yyterminate();
 				}
+
+^importLoc	{ BEGIN(inclL); }
+<inclL>[ \t\r]* {}
+<inclL>\"    { BEGIN(fnameL); }
+<fnameL>[a-zA-Z0-9_.\\]+\" { /* Got the include file name */
+  			if ( ldl_include_stack_ptr >= MAX_INCLUDE_DEPTH ) {
+				ldl_parse_error = LDL_ERROR_INCLUDE;
+				yyterminate();
+            } else {
+
+				char buf[MAX_PATH];
+				char filename[MAX_PATH];
+				strcpy(filename, yytext);
+				filename[strlen(filename)-1] = 0; /* Strip trailing quote */
+				if(!ldlif_find_localized_file(filename, buf)) {
+					ldl_parse_error = LDL_ERROR_CANT_OPEN_FILE;
+					yyterminate();
+				}
+				ldl_include_line_number_stack[ldl_include_stack_ptr] = g_ldlLineNumber;
+			    ldl_include_stack[ldl_include_stack_ptr++] =
+						YY_CURRENT_BUFFER;
+				ldl_include_filename_stack[ldl_include_stack_ptr] = malloc(strlen(buf)+1);
+				strcpy(ldl_include_filename_stack[ldl_include_stack_ptr],
+					   buf);
+			    yyin = fopen( buf, "r" );
+
+			    if ( ! yyin ) {
+				    ldl_parse_error = LDL_ERROR_CANT_OPEN_FILE;
+					yyterminate();
+				} else {
+					yy_switch_to_buffer(
+						yy_create_buffer( yyin, YY_BUF_SIZE ) );
+
+					g_ldlLineNumber = 1;
+					BEGIN(INITIAL);
+				}
+			}
+		}
+<fnameL>.		{
+				    ldl_parse_error = LDL_ERROR_INCLUDE;
+				    yyterminate();
+				}
+
 <<EOF>> {
 			if ( --ldl_include_stack_ptr < 0 ) {
 				if(ldl_include_stack_ptr == -1) {

--- a/ctp2_code/ui/ldl/ldl.l
+++ b/ctp2_code/ui/ldl/ldl.l
@@ -31,7 +31,7 @@ extern int ldl_parse_error;
 
 %}
 
-string 		\"[^\"\n]*[\"\r\n]
+string		\"[^\"\n]*[\"\r\n]
 name		[a-zA-Z]+[a-zA-Z0-9_]*
 
 %x incl
@@ -45,10 +45,10 @@ name		[a-zA-Z]+[a-zA-Z0-9_]*
 <incl>[ \t\r]* {}
 <incl>\"    { BEGIN(fname); }
 <fname>[a-zA-Z0-9_.\\]+\" { /* Got the include file name */
-  			if ( ldl_include_stack_ptr >= MAX_INCLUDE_DEPTH ) {
+			if ( ldl_include_stack_ptr >= MAX_INCLUDE_DEPTH ) {
 				ldl_parse_error = LDL_ERROR_INCLUDE;
 				yyterminate();
-            } else {
+			} else {
 
 				char buf[MAX_PATH];
 				char filename[MAX_PATH];
@@ -59,15 +59,15 @@ name		[a-zA-Z]+[a-zA-Z0-9_]*
 					yyterminate();
 				}
 				ldl_include_line_number_stack[ldl_include_stack_ptr] = g_ldlLineNumber;
-			    ldl_include_stack[ldl_include_stack_ptr++] =
+				ldl_include_stack[ldl_include_stack_ptr++] =
 						YY_CURRENT_BUFFER;
 				ldl_include_filename_stack[ldl_include_stack_ptr] = malloc(strlen(buf)+1);
 				strcpy(ldl_include_filename_stack[ldl_include_stack_ptr],
-					   buf);
-			    yyin = fopen( buf, "r" );
+				       buf);
+				yyin = fopen( buf, "r" );
 
-			    if ( ! yyin ) {
-				    ldl_parse_error = LDL_ERROR_CANT_OPEN_FILE;
+				if ( ! yyin ) {
+					ldl_parse_error = LDL_ERROR_CANT_OPEN_FILE;
 					yyterminate();
 				} else {
 					yy_switch_to_buffer(
@@ -79,18 +79,18 @@ name		[a-zA-Z]+[a-zA-Z0-9_]*
 			}
 		}
 <fname>.		{
-				    ldl_parse_error = LDL_ERROR_INCLUDE;
-				    yyterminate();
+					ldl_parse_error = LDL_ERROR_INCLUDE;
+					yyterminate();
 				}
 
 ^importLoc	{ BEGIN(inclL); }
 <inclL>[ \t\r]* {}
 <inclL>\"    { BEGIN(fnameL); }
 <fnameL>[a-zA-Z0-9_.\\]+\" { /* Got the include file name */
-  			if ( ldl_include_stack_ptr >= MAX_INCLUDE_DEPTH ) {
+			if ( ldl_include_stack_ptr >= MAX_INCLUDE_DEPTH ) {
 				ldl_parse_error = LDL_ERROR_INCLUDE;
 				yyterminate();
-            } else {
+			} else {
 
 				char buf[MAX_PATH];
 				char filename[MAX_PATH];
@@ -101,15 +101,15 @@ name		[a-zA-Z]+[a-zA-Z0-9_]*
 					yyterminate();
 				}
 				ldl_include_line_number_stack[ldl_include_stack_ptr] = g_ldlLineNumber;
-			    ldl_include_stack[ldl_include_stack_ptr++] =
+				ldl_include_stack[ldl_include_stack_ptr++] =
 						YY_CURRENT_BUFFER;
 				ldl_include_filename_stack[ldl_include_stack_ptr] = malloc(strlen(buf)+1);
 				strcpy(ldl_include_filename_stack[ldl_include_stack_ptr],
-					   buf);
-			    yyin = fopen( buf, "r" );
+				       buf);
+				yyin = fopen( buf, "r" );
 
-			    if ( ! yyin ) {
-				    ldl_parse_error = LDL_ERROR_CANT_OPEN_FILE;
+				if ( ! yyin ) {
+					ldl_parse_error = LDL_ERROR_CANT_OPEN_FILE;
 					yyterminate();
 				} else {
 					yy_switch_to_buffer(
@@ -121,8 +121,8 @@ name		[a-zA-Z]+[a-zA-Z0-9_]*
 			}
 		}
 <fnameL>.		{
-				    ldl_parse_error = LDL_ERROR_INCLUDE;
-				    yyterminate();
+					ldl_parse_error = LDL_ERROR_INCLUDE;
+					yyterminate();
 				}
 
 <<EOF>> {
@@ -132,15 +132,15 @@ name		[a-zA-Z]+[a-zA-Z0-9_]*
 				}
 				yyterminate();
 			} else {
-                fclose(yyin);
-                yyin = 0;
+				fclose(yyin);
+				yyin = 0;
 				yy_delete_buffer( YY_CURRENT_BUFFER );
 				free(ldl_include_filename_stack[ldl_include_stack_ptr + 1]);
 				yy_switch_to_buffer(
 					ldl_include_stack[ldl_include_stack_ptr] );
 				g_ldlLineNumber = ldl_include_line_number_stack[ldl_include_stack_ptr];
 			}
-        }
+		}
 
 template		{ }
 int				{
@@ -155,8 +155,8 @@ bool			{
 string			{
 					return TSTRING;
 				}
-true            { return VTRUE; }
-false           { return VFALSE; }
+true			{ return VTRUE; }
+false			{ return VFALSE; }
 {name}			{
 					yylval.nameval = ldlif_getnameptr(yytext);
 					return VNAME;
@@ -166,7 +166,7 @@ false           { return VFALSE; }
 					return VINT;
 				}
 -?[0-9]*\.[0-9]+ {
-				    yylval.floatval = atof(yytext);
+					yylval.floatval = atof(yytext);
 					return VFLOAT;
 				}
 {string}		{
@@ -174,10 +174,10 @@ false           { return VFALSE; }
 					yylval.stringval = ldlif_getstringptr(&yytext[1]);
 					return VSTRING;
 				}
-#.*\n             { g_ldlLineNumber++; }
+#.*\n			{ g_ldlLineNumber++; }
 [ \t\r]			{ }
 \n				{ g_ldlLineNumber++; }
-\$              { }
+\$				{ }
 .				{ return yytext[0]; }
 
 %%

--- a/ctp2_code/ui/ldl/ldl.y
+++ b/ctp2_code/ui/ldl/ldl.y
@@ -44,22 +44,22 @@ blocks: blocks block
 
 block: blocknames '{' { ldlif_start_block($1.names); } attributes '}' { $$.block = ldlif_end_block($1.names); }
      | blocknames '{' '}' { $$.block = ldlif_add_empty_block($1.names); }
-	   ;
+       ;
 
 blocknames: VNAME ':' blocknames { ldlif_add_name(&$$.names, $1.nameval, $3.names); }
           | VNAME { ldlif_add_name(&$$.names, $1.nameval, NULL); }
-		  ;
+          ;
 
 attributes: attributes attribute
-			| attribute
-			;
+            | attribute
+            ;
 
 attribute: block
            | TBOOL VNAME bool { ldlif_add_bool_attribute($2.nameval, $3.intval); }
-		   | TINT VNAME VINT { ldlif_add_int_attribute($2.nameval, $3.intval); }
-		   | TDOUBLE VNAME VFLOAT { ldlif_add_float_attribute($2.nameval, $3.floatval); }
-		   | TSTRING VNAME VSTRING { ldlif_add_string_attribute($2.nameval, $3.stringval); }
-		   ;
+           | TINT VNAME VINT { ldlif_add_int_attribute($2.nameval, $3.intval); }
+           | TDOUBLE VNAME VFLOAT { ldlif_add_float_attribute($2.nameval, $3.floatval); }
+           | TSTRING VNAME VSTRING { ldlif_add_string_attribute($2.nameval, $3.stringval); }
+           ;
 
 bool: VTRUE { $$.intval = 1; } | VFALSE { $$.intval = 0; } ;
 

--- a/ctp2_code/ui/ldl/ldl_data.cpp
+++ b/ctp2_code/ui/ldl/ldl_data.cpp
@@ -8,7 +8,7 @@
 
 ldl_datablock::ldl_datablock(PointerList<char> *templateNames)
 :
-	m_templates     (),
+    m_templates     (),
     m_children      (),
     m_attributes    (),
     m_parent        (NULL),
@@ -34,7 +34,7 @@ ldl_datablock::ldl_datablock(PointerList<char> *templateNames)
 
 ldl_datablock::ldl_datablock(ldl_datablock *copy)
 :
-	m_templates     (),
+    m_templates     (),
     m_children      (),
     m_attributes    (),
     m_parent        (NULL),
@@ -42,12 +42,12 @@ ldl_datablock::ldl_datablock(ldl_datablock *copy)
     m_hash          (0)
 {
 	for
-    (
-        ldl_attribute * attr = copy->m_attributes.GetHead();
-        attr;
-        attr = copy->m_attributes.GetNext(attr)
-    )
-    {
+	(
+	    ldl_attribute * attr = copy->m_attributes.GetHead();
+	    attr;
+	    attr = copy->m_attributes.GetNext(attr)
+	)
+	{
 		m_attributes.AddTail(attr->GetCopy());
 	}
 
@@ -63,7 +63,7 @@ ldl_datablock::ldl_datablock(ldl_datablock *copy)
 
 ldl_datablock::ldl_datablock(sint32 hash)
 :
-	m_templates     (),
+    m_templates     (),
     m_children      (),
     m_attributes    (),
     m_parent        (NULL),
@@ -73,7 +73,7 @@ ldl_datablock::ldl_datablock(sint32 hash)
 
 ldl_datablock::ldl_datablock(ldl *theLdl, char const * name)
 :
-	m_templates     (),
+    m_templates     (),
     m_children      (),
     m_attributes    (),
     m_parent        (NULL),
@@ -93,13 +93,13 @@ ldl_datablock::~ldl_datablock()
 char *ldl_datablock::GetFullName(char *output)
 {
 	if (m_parent)
-    {
+	{
 		m_parent->GetFullName(output);
 		strcat(output, ".");
 		strcat(output, m_name);
 	}
-    else
-    {
+	else
+	{
 		strcpy(output, m_name);
 	}
 
@@ -126,14 +126,14 @@ ldl_attribute *ldl_datablock::GetAttribute( const char *szName )
 	char * strPtr = ldlif_getnameptr(szName);
 
 	for
-    (
-        ldl_attribute * atr = m_attributes.GetHead();
-        atr;
-        atr = m_attributes.GetNext(atr)
-    )
-    {
+	(
+	    ldl_attribute * atr = m_attributes.GetHead();
+	    atr;
+	    atr = m_attributes.GetNext(atr)
+	)
+	{
 		if (atr->GetName() == strPtr)
-        {
+		{
 			return atr;
 		}
 	}
@@ -209,7 +209,6 @@ void ldl_datablock::AddTemplateChildren()
 
 void ldl_datablock::AddTemplateChildrenTo(ldl_datablock *block)
 {
-
 	PointerList<ldl_datablock>::Walker bwalk;
 	for(bwalk.SetList(&m_children); bwalk.IsValid(); bwalk.Next()) {
 

--- a/ctp2_code/ui/ldl/ldl_data.hpp
+++ b/ctp2_code/ui/ldl/ldl_data.hpp
@@ -121,7 +121,7 @@ public:
 	double  GetDouble(const char *szName = "double");
 	bool    GetBool(const char *szName = "bool");
 //	RECT GetRect(const char *x1 = "rect_x1", const char *y1 = "rect_y1",
-//				 const char *x2 = "rect_x2", const char *y2 = "rect_y2");
+//	             const char *x2 = "rect_x2", const char *y2 = "rect_y2");
 //	POINT GetPoint(const char *x1 = "point_x", const char *y1 = "point_y");
 	char *  GetString(const char *szName);
 };

--- a/ctp2_code/ui/ldl/ldl_data_info.cpp
+++ b/ctp2_code/ui/ldl/ldl_data_info.cpp
@@ -8,7 +8,8 @@ int ldl_datablock::GetInt( const char *szName )
 {
 	ldl_attribute *atr = GetAttribute(szName);
 
-	if(atr) {
+	if(atr)
+	{
 		if(atr->GetType() == ATTRIBUTE_TYPE_INT)
 			return ((ldl_attributeValue<int> *)atr)->GetValue();
 		else if(atr->GetType() == ATTRIBUTE_TYPE_DOUBLE)
@@ -32,7 +33,8 @@ char *ldl_datablock::GetString( const char *szName )
 {
 	ldl_attribute *atr = GetAttribute(szName);
 
-	if(atr) {
+	if(atr)
+	{
 		if(atr->GetType() == ATTRIBUTE_TYPE_STRING)
 			return ((ldl_attributeValue<char *> *)atr)->GetValue();
 	}
@@ -45,7 +47,7 @@ bool ldl_datablock::GetBool( const char *szName )
 	ldl_attribute * atr = GetAttribute(szName);
 
 	if (atr && (atr->GetType() == ATTRIBUTE_TYPE_BOOL))
-    {
+	{
 		return ((ldl_attributeValue<bool> *)atr)->GetValue();
 	}
 

--- a/ctp2_code/ui/ldl/ldlif.cpp
+++ b/ctp2_code/ui/ldl/ldlif.cpp
@@ -193,15 +193,6 @@ void *ldlif_end_block(void *names)
 
 	block->AddTemplateChildren();
 
-
-
-
-
-
-
-
-
-
 	if(!s_blockStack->GetTail()) {
 		s_topLevelList->AddTail(block);
 
@@ -209,7 +200,6 @@ void *ldlif_end_block(void *names)
 
 	delete namelist;
 	return block;
-
 }
 
 void *ldlif_add_empty_block(void *names)
@@ -264,5 +254,4 @@ void ldlif_deallocate_stuff()
 
 	delete s_blockTree;
 	s_blockTree = NULL;
-
 }

--- a/ctp2_code/ui/ldl/ldlif.cpp
+++ b/ctp2_code/ui/ldl/ldlif.cpp
@@ -54,10 +54,18 @@ ldl_datablock *ldlif_find_block(char const * name)
 
 int ldlif_find_file(const char *filename, char *fullpath)
 {
-	if(!g_civPaths->FindFile(C3DIR_LAYOUT, filename, fullpath))
+	if(!g_civPaths->FindFile(C3DIR_LAYOUT, filename, fullpath, false, true, true, false))
 		return 0;
 	return 1;
 }
+
+int ldlif_find_localized_file(const char *filename, char * fullpath)
+{
+	if (!g_civPaths->FindFile(C3DIR_LAYOUT, filename, fullpath))
+		return 0;
+	return 1;
+}
+
 
 char *ldlif_getnameptr(const char *name)
 {

--- a/ctp2_code/ui/ldl/ldlif.h
+++ b/ctp2_code/ui/ldl/ldlif.h
@@ -20,10 +20,10 @@ extern "C" {
 
 extern int g_ldlLineNumber;
 
-int ldlif_open_first_file(char *file);
 const char *ldlif_current_file();
 
 int ldlif_find_file(const char *filename, char *buf);
+int ldlif_find_localized_file(const char *filename, char *buf);
 
 char *ldlif_getnameptr(const char *name);
 char *ldlif_getstringptr(const char *text);


### PR DESCRIPTION
With this pull request CTP2 only loads the ldl files from the default directory. However, there is now a new keword "importLoc" to load ldl files from the language specific localized directories.

This way we can have have ldl files in the default folder without caring about any ldl files in the localized folders from the original CD.

This pull request replaces pull request #277 and fixes issues #262 and #269. 