### PR TITLE
allow non-complete paths in _fullname (linux)

### DIFF
--- a/ctp2_code/gs/fileio/CivPaths.cpp
+++ b/ctp2_code/gs/fileio/CivPaths.cpp
@@ -215,17 +215,17 @@ void CivPaths::CreateSaveFolders(const MBCHAR *path)
 	c3files_CreateDirectory(path);
 
 	sprintf(subFolderPath, "%s%s%s", path, FILE_SEP, m_saveGamePath);
-	c3files_CreateDirectory(path);
+	c3files_CreateDirectory(subFolderPath);
 	sprintf(subFolderPath, "%s%s%s", path, FILE_SEP, m_saveQueuePath);
-	c3files_CreateDirectory(path);
+	c3files_CreateDirectory(subFolderPath);
 	sprintf(subFolderPath, "%s%s%s", path, FILE_SEP, m_saveMPPath);
-	c3files_CreateDirectory(path);
+	c3files_CreateDirectory(subFolderPath);
 	sprintf(subFolderPath, "%s%s%s", path, FILE_SEP, m_saveSCENPath);
-	c3files_CreateDirectory(path);
+	c3files_CreateDirectory(subFolderPath);
 	sprintf(subFolderPath, "%s%s%s", path, FILE_SEP, m_saveMapPath);
-	c3files_CreateDirectory(path);
+	c3files_CreateDirectory(subFolderPath);
 	sprintf(subFolderPath, "%s%s%s", path, FILE_SEP, m_saveClipsPath);
-	c3files_CreateDirectory(path);
+	c3files_CreateDirectory(subFolderPath);
 }
 
 void CivPaths::InitCDPath(void)

--- a/ctp2_code/ui/aui_common/aui_resource.h
+++ b/ctp2_code/ui/aui_common/aui_resource.h
@@ -162,8 +162,8 @@ aui_Resource<T>::aui_Resource()
 template<class T>
 aui_Resource<T>::~aui_Resource()
 {
-	Assert(!m_resourceList);
-// diabled because SetPointSize needed in linux debug version before m_surfaceList is populated	Assert((m_resourceList->L() == 0));
+	// disabled because SetPointSize needed in linux debug version before m_surfaceList is populated
+	// Assert(!m_resourceList || (m_resourceList->L() == 0));
 	delete m_resourceList;
 	m_resourceList = NULL;
 


### PR DESCRIPTION
To minimize the impact I only do the extra work on splitting the path in dirname and basename when canonicalize_file_name returns NULL. It could also be always done. This partly fixes #290. Another PR will be created for the creation of the save-subdirectories.