### PR TITLE
Fix incorrect assertion

### DIFF
--- a/ctp2_code/ui/aui_common/aui_resource.h
+++ b/ctp2_code/ui/aui_common/aui_resource.h
@@ -162,8 +162,8 @@ aui_Resource<T>::aui_Resource()
 template<class T>
 aui_Resource<T>::~aui_Resource()
 {
-	Assert(!m_resourceList);
-// diabled because SetPointSize needed in linux debug version before m_surfaceList is populated	Assert((m_resourceList->L() == 0));
+	// disabled because SetPointSize needed in linux debug version before m_surfaceList is populated
+	// Assert(!m_resourceList || (m_resourceList->L() == 0));
 	delete m_resourceList;
 	m_resourceList = NULL;
 


### PR DESCRIPTION
The assertion tested that m_resourceList was always NULL which is most likely not the case as the member is initialized in the constructor.