### PR TITLE
Build the Linux executable in the correct folder

### DIFF
--- a/GNUmakefile.am
+++ b/GNUmakefile.am
@@ -19,3 +19,9 @@ all-local:
 install-data-hook:
 	nm --demangle --defined-only --numeric-sort $(DESTDIR)$(bindir)/ctp2 > $(DESTDIR)$(bindir)/ctp2linux.map
 endif
+
+clean-local:
+	rm -f $(top_srcdir)/ctp2_code/ctp/ctp2linux.map
+
+uninstall-local:
+	rm -f $(DESTDIR)$(bindir)/ctp2linux.map

--- a/GNUmakefile.am
+++ b/GNUmakefile.am
@@ -13,6 +13,9 @@ bootstrap bootstrap-anet doc local playtest: $(top_srcdir)/Makefile
 .PHONY: purge bootstrap doc local playtest
 
 if DEBUG
+all-local:
+	nm --demangle --defined-only --numeric-sort $(top_srcdir)/ctp2_code/ctp/ctp2 > $(top_srcdir)/ctp2_code/ctp/ctp2linux.map
+
 install-data-hook:
 	nm --demangle --defined-only --numeric-sort $(DESTDIR)$(bindir)/ctp2 > $(DESTDIR)$(bindir)/ctp2linux.map
 endif

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ You will probably need GCC 5.x or later to build. The code doesn't seem to build
 
 You will need SDL 1.2, SDL_Mixer, SDL_Image and the GTK 2.0 libraries.
 You will also need `byacc`
-On debian and friends, use `sudo apt install libsdl1.2-dev libsdl-mixer1.2-dev libsdl-image1.2-dev byacc gtk2.0-dev` to install them all.
+On debian and friends, use `sudo apt install libsdl1.2-dev libsdl-mixer1.2-dev libsdl-image1.2-dev byacc gtk2.0-dev flex` to install them all.
 
 The build itself is pretty classing and straight forward:
 

--- a/ctp2_code/Makefile.am
+++ b/ctp2_code/Makefile.am
@@ -10,7 +10,7 @@ SUBDIRS = \
 	libs \
 	sound
 
-bin_PROGRAMS = ctp2
+bin_PROGRAMS = ctp/ctp2
 # This hack shortens include path list,
 # but prohibits using a separate build dir
 #ctp2_code=..
@@ -38,7 +38,7 @@ CTP2_ANET_INC=-I$(ctp2_code)/libs/anet/h
 
 include $(ctp2_code)/os/autoconf/Makefile.common
 
-ctp2_LDADD = \
+ctp_ctp2_LDADD = \
 	gfx/gfx_utils/libgfxgfx_utils.la \
 	gfx/layers/libgfxlayers.la \
 	gfx/spritesys/libgfxspritesys.la \
@@ -57,10 +57,10 @@ ctp2_LDADD = \
 	$(CTP2_LIBOSNOWIN32_LDADD) \
 	$(CTP2_LIBTTF_LDADD)
 
-ctp2_LDFLAGS = \
+ctp_ctp2_LDFLAGS = \
 	$(CTP2_LDFLAGS)
 
-ctp2_SOURCES = \
+ctp_ctp2_SOURCES = \
 	ctp/ctp2_utils/appstrings.cpp \
 	ctp/ctp2_utils/c3cmdline.cpp \
 	ctp/ctp2_utils/c3cpu.cpp \


### PR DESCRIPTION
This pull request changes the following on Linux:

- The executable is built in same folder as the Windows executable ctp2_code/ctp/
- The file ctp2linux.map is created on build
- When cleaning and uninstalling ctp2linux.map is now deleted, too
- The readme now also mentions that you also have to install flex