### PR TITLE
Ensure city's shield-store cannot become negative

### DIFF
--- a/ctp2_code/gs/gameobj/CityData.cpp
+++ b/ctp2_code/gs/gameobj/CityData.cpp
@@ -2373,7 +2373,10 @@ void CityData::AddShieldsToBuilding()
 		m_net_production = 0;
 	}
 
-	SetShieldstore(m_shieldstore + m_net_production);
+	// Do not add shields to the store when the build-queue is empty.
+	if (m_build_queue.GetHead() != NULL) {
+		SetShieldstore(m_shieldstore + m_net_production);
+	}
 }
 
 #if !defined(NEW_RESOURCE_PROCESS)

--- a/ctp2_code/gs/gameobj/bldque.cpp
+++ b/ctp2_code/gs/gameobj/bldque.cpp
@@ -625,8 +625,6 @@ bool BuildQueue::BuildFront(sint32 &shieldstore, CityData *cd, const MapPoint &p
 			// Cities with empty queues lose the same switch penalty % of their shield store
 			// each turn they are empty.
 
-			shieldstore -= cd->GetNetCityProduction();// Remove shields given at beginturn.
-
 			if (shieldstore > 0)
 			{
 				sint32 s = 0;
@@ -643,6 +641,7 @@ bool BuildQueue::BuildFront(sint32 &shieldstore, CityData *cd, const MapPoint &p
 				DPRINTF(k_DBG_GAMESTATE, ("Deducting %i shields for empty queue in city of %lx\n", s, m_city.m_id));
 				shieldstore = s;
 			}
+			assert(shieldstore >= 0);
 		}
 		return false;
 	}

--- a/ctp2_code/gs/gameobj/bldque.cpp
+++ b/ctp2_code/gs/gameobj/bldque.cpp
@@ -616,33 +616,19 @@ bool BuildQueue::BuildFront(sint32 &shieldstore, CityData *cd, const MapPoint &p
 
 		return true;
 	} else {
-
-		DPRINTF(k_DBG_GAMESTATE, ("BuildFront: City %lx building nothing\n",
-								  m_city.m_id));
-
-		if (!Player::IsThisPlayerARobot(m_owner) ||
-			(g_network.IsClient() && g_network.IsLocalPlayer(m_owner))) {
-			// Cities with empty queues lose the same switch penalty % of their shield store
-			// each turn they are empty.
-
-			if (shieldstore > 0)
-			{
-				sint32 s = 0;
-				double penalty =
+		// Cities with empty queues lose the same switch penalty % of their shield store each turn they are empty.
+		DPRINTF(k_DBG_GAMESTATE, ("BuildFront: City %lx building nothing\n", m_city.m_id));
+		if (shieldstore > 0)
+		{
+			double penalty =
 					static_cast<double>(g_theConstDB->Get(0)->GetChangeCurrentlyBuildingItemPenalty());
+			penalty = std::min<double>(1.0, std::max<double>(0.0, 1.0 - penalty * 0.01));
+			sint32 s = static_cast<sint32>(static_cast<double>(shieldstore) * penalty);
+			DPRINTF(k_DBG_GAMESTATE, ("Decreased shields to %d for empty queue in city of %lx\n", s, m_city.m_id));
 
-				penalty = std::min<double>
-								  (
-								   1.0,
-								   std::max<double>(0.0, 1.0 - penalty * 0.01)
-								  );
-
-				s = static_cast<sint32>(static_cast<double>(shieldstore) * penalty);
-				DPRINTF(k_DBG_GAMESTATE, ("Deducting %i shields for empty queue in city of %lx\n", s, m_city.m_id));
-				shieldstore = s;
-			}
-			Assert(shieldstore >= 0);
+			shieldstore = s;
 		}
+		Assert(shieldstore >= 0);
 		return false;
 	}
 }

--- a/ctp2_code/gs/gameobj/bldque.cpp
+++ b/ctp2_code/gs/gameobj/bldque.cpp
@@ -641,7 +641,7 @@ bool BuildQueue::BuildFront(sint32 &shieldstore, CityData *cd, const MapPoint &p
 				DPRINTF(k_DBG_GAMESTATE, ("Deducting %i shields for empty queue in city of %lx\n", s, m_city.m_id));
 				shieldstore = s;
 			}
-			assert(shieldstore >= 0);
+			Assert(shieldstore >= 0);
 		}
 		return false;
 	}

--- a/ctp2_code/ui/aui_common/aui_image.cpp
+++ b/ctp2_code/ui/aui_common/aui_image.cpp
@@ -24,7 +24,7 @@
 // Modifications from the original Activision code:
 //
 // - Crash prevented.
-// - Initialized local variables. (Sep 9th 2005 Martin G�hmann)
+// - Initialized local variables. (Sep 9th 2005 Martin Gühmann)
 //
 //----------------------------------------------------------------------------
 
@@ -314,8 +314,8 @@ AUI_ERRCODE aui_BmpImageFormat::Load(MBCHAR const * filename, aui_Image *image )
 
 	return retcode;
 #elif defined(__AUI_USE_SDL__)
-        fprintf(stderr, "%s L%d: image %s!\n", __FILE__, __LINE__, filename); //is this ever called?
-	assert(0);
+	fprintf(stderr, "%s L%d: image %s!\n", __FILE__, __LINE__, filename); //is this ever called?
+	Assert(0);
 	SDL_Surface *bmp = SDL_LoadBMP(filename);
 	SDL_Surface *surf = NULL;
 	SDL_PixelFormat fmt = { 0 };

--- a/ctp2_code/ui/aui_ctp2/c3blitter.cpp
+++ b/ctp2_code/ui/aui_ctp2/c3blitter.cpp
@@ -24,8 +24,8 @@
 //
 // Modifications from the original Activision code:
 //
-// - Initialized local variables. (Sep 9th 2005 Martin G�hmann)
-// - Standartized code (May 21st 2006 Martin G�hmann)
+// - Initialized local variables. (Sep 9th 2005 Martin Gühmann)
+// - Standartized code (May 21st 2006 Martin Gühmann)
 //
 //----------------------------------------------------------------------------
 
@@ -129,7 +129,7 @@ AUI_ERRCODE C3Blitter::Blt16To16Fast(
 {
 	AUI_ERRCODE     retcode         = AUI_ERRCODE_OK;
 #ifdef __arm__
-	assert(0);
+	Assert(0);
 #else
 	const sint32    destPitch       = destSurf->Pitch() / 2;
 	const sint32    srcPitch        = srcSurf->Pitch() / 2;
@@ -213,7 +213,7 @@ L1:
 L2:
 					}
 #else // _MSC_VER
-					assert(0);
+                    Assert(0);
 #endif // _MSC_VER
 				} while ( (srcBuf += srcPitch) != stop );
 			}
@@ -283,7 +283,7 @@ AUI_ERRCODE C3Blitter::Blt16To16FastMMX(
 {
 	AUI_ERRCODE     retcode         = AUI_ERRCODE_OK;
 #ifdef __arm__
-	assert(0);
+	Assert(0);
 #else
 	const sint32    destPitch       = destSurf->Pitch() / 2;
 	const sint32    srcPitch        = srcSurf->Pitch() / 2;
@@ -374,7 +374,7 @@ AUI_ERRCODE C3Blitter::Blt16To16FastMMX(
 	   					rep movsw
 					}
 #else // _MSCVER
-//					assert(0);
+//					Assert(0);
                     //fprintf(stderr, "%s L%d: Using Blt16To16FastMMX!\n", __FILE__, __LINE__);
                     __asm__ (
                         //"movl $scanWidth, %eax       \n\t"
@@ -475,7 +475,7 @@ AUI_ERRCODE C3Blitter::Blt16To16FastFPU(
 {
 	AUI_ERRCODE     retcode         = AUI_ERRCODE_OK;
 #ifdef __arm__
-	assert(0);
+	Assert(0);
 #else
 	const sint32    destPitch       = destSurf->Pitch() / 2;
 	const sint32    srcPitch        = srcSurf->Pitch() / 2;
@@ -559,7 +559,7 @@ AUI_ERRCODE C3Blitter::Blt16To16FastFPU(
 					   	rep movsw
 					}
 #else // _MSC_VER
-					assert(0);
+					Assert(0);
 #endif // _MSC_VER
 				} while ( (srcBuf += srcPitch) != stop );
 			}
@@ -708,7 +708,7 @@ End:	add		ecx, eax
 	rep movsb
 	}
 #else // _MSC_VER
-	assert(0);
+	Assert(0);
 #endif // _MSC_VER
 #endif
 }

--- a/ctp2_code/ui/aui_sdl/aui_sdlblitter.cpp
+++ b/ctp2_code/ui/aui_sdl/aui_sdlblitter.cpp
@@ -184,8 +184,8 @@ static AUI_ERRCODE SimpleHVStretch(SDL_Surface* src, SDL_Rect* rsrc,
 		// put a pixel in column dx while the level is non-negative
 		while (lx >= 0 && dx < edx && sx < esx) {
 		    // write source pixel sx
-		    assert(src->format->BytesPerPixel == 2);
-		    assert(dst->format->BytesPerPixel == 2);
+		    Assert(src->format->BytesPerPixel == 2);
+		    Assert(dst->format->BytesPerPixel == 2);
 		    dptr[dx] = sptr[sx];
 		    lx -= rsrc->w-1;
 		    ++dx;

--- a/ctp2_code/ui/aui_sdl/aui_sdlui.cpp
+++ b/ctp2_code/ui/aui_sdl/aui_sdlui.cpp
@@ -136,7 +136,6 @@ AUI_ERRCODE aui_SDLUI::CreateNativeScreen( BOOL useExclusiveMode )
 {
 	AUI_ERRCODE errcode = aui_SDL::InitCommon( useExclusiveMode );
 	Assert( AUI_SUCCESS(errcode) );
-	assert( AUI_SUCCESS(errcode) );
 	if ( !AUI_SUCCESS(errcode) ) return errcode;
 
 	m_pixelFormat = aui_Surface::TransformBppToSurfacePixelFormat(m_bpp);
@@ -159,13 +158,11 @@ AUI_ERRCODE aui_SDLUI::CreateNativeScreen( BOOL useExclusiveMode )
 
 	m_primary = new aui_SDLSurface(&errcode, m_width, m_height, m_bpp, NULL, TRUE);
 	Assert( AUI_NEWOK(m_primary,errcode) );
-	assert( AUI_NEWOK(m_primary,errcode) );
 	if ( !AUI_NEWOK(m_primary,errcode) ) return AUI_ERRCODE_MEMALLOCFAILED;
 
 	if(!m_secondary) {
 		m_secondary = new aui_SDLSurface(&errcode, m_width, m_height, m_bpp, NULL, FALSE);
 		Assert( AUI_NEWOK(m_secondary,errcode) );
-		assert( AUI_NEWOK(m_secondary,errcode) );
 		if ( !AUI_NEWOK(m_secondary,errcode) ) return AUI_ERRCODE_MEMALLOCFAILED;
 	}
 
@@ -258,7 +255,7 @@ AUI_ERRCODE aui_SDLUI::RestoreMouse(void)
 
 AUI_ERRCODE aui_SDLUI::AltTabOut( void )
 {
-	assert(0);
+	Assert(0);
 
 	if(m_keyboard) m_keyboard->Unacquire();
 	if ( m_joystick ) m_joystick->Unacquire();
@@ -301,7 +298,7 @@ AUI_ERRCODE aui_SDLUI::AltTabOut( void )
 
 AUI_ERRCODE aui_SDLUI::AltTabIn( void )
 {
-	assert(0);
+	Assert(0);
 
 	if ( !m_primary ) CreateNativeScreen( m_exclusiveMode );
 

--- a/ctp2_code/ui/interface/loadsavescreen.cpp
+++ b/ctp2_code/ui/interface/loadsavescreen.cpp
@@ -1142,7 +1142,7 @@ void loadsavescreen_delete( void )
 		}
 		sprintf(path, "%s", gameInfo->path);
 		int retval=_rmdir(path);
-		assert(!retval);
+		Assert(!retval);
 		g_loadsaveWindow->FillListTwo(NULL);
 		g_loadsaveWindow->SetType(g_loadsaveWindow->GetType());
 #endif // WIN32

--- a/ctp2_code/ui/netshell/netfunc.h
+++ b/ctp2_code/ui/netshell/netfunc.h
@@ -30,7 +30,7 @@
 //
 // - Added SDL support.
 // - Make the Linux version loading and producing Windows compatible
-//   savegames. (16-Jan-2019 Martin Gühmann)
+//   savegames. (16-Jan-2019 Martin GÃ¼hmann)
 //
 //----------------------------------------------------------------------------
 
@@ -419,7 +419,7 @@ public:
 	}
 
 	void Grow(size_t s) {
-		assert((size + s) <= nf_MAX_PACKETSIZE);
+		Assert((size + s) <= nf_MAX_PACKETSIZE);
         size = static_cast<SizeT>(size + s);
 	}
 


### PR DESCRIPTION
Changed functionality of 'removing added shields when the queue is empty' to not 'adding shields in case queue is empty'. The number of shields that were removed was bigger than the number of shields added which may result in negative number of shields in the store. It was bigger as it was not corrected for military and material shields that were already removed.