### PR TITLE
For pull fixes only

### DIFF
--- a/ctp2_code/ai/CityManagement/governor.cpp
+++ b/ctp2_code/ai/CityManagement/governor.cpp
@@ -3696,7 +3696,7 @@ void Governor::ComputeDesiredUnits()
 			{
 				m_buildUnitList[list_num].m_maximumCount = 0;
 				m_buildUnitList[list_num].m_desiredCount = 0;
-				DPRINTF(k_DBG_AI, ("// No settler units: needed: %d, max: %d, current: %d\n", m_buildUnitList[list_num].m_desiredCount, m_buildUnitList[list_num].m_maximumCount, m_currentUnitCount[best_unit_type]));
+				DPRINTF(k_DBG_AI, ("// No settler units: needed: %d, max: %d, current: %d\n", m_buildUnitList[list_num].m_desiredCount, m_buildUnitList[list_num].m_maximumCount, 0));
 			}
 
 		case BUILD_UNIT_LIST_SLAVERY:

--- a/ctp2_code/ai/diplomacy/nproposalevent.cpp
+++ b/ctp2_code/ai/diplomacy/nproposalevent.cpp
@@ -713,7 +713,7 @@ STDEHANDLER(TradePact_NewProposalEvent)
 	if (!args->GetInt(0, desireType))
 		return GEV_HD_Continue;
 
-	if ((MOTIVATION_TYPE) desireType != MOTIVATION_DESIRE_MAKE_FRIEND ||
+	if ((MOTIVATION_TYPE) desireType != MOTIVATION_DESIRE_MAKE_FRIEND &&
 		(MOTIVATION_TYPE) desireType != MOTIVATION_DESIRE_GOLD)
 		return GEV_HD_Continue;
 
@@ -870,7 +870,7 @@ STDEHANDLER(MilitaryPact_NewProposalEvent)
 		if (!args->GetInt(0, desireType))
 			return GEV_HD_Continue;
 
-		if ((MOTIVATION_TYPE) desireType != MOTIVATION_DESIRE_MAKE_FRIEND ||
+		if ((MOTIVATION_TYPE) desireType != MOTIVATION_DESIRE_MAKE_FRIEND &&
 			(MOTIVATION_TYPE) desireType != MOTIVATION_DESIRE_ENLIST_FRIEND)
 			return GEV_HD_Continue;
 	}

--- a/ctp2_code/ai/strategy/goals/Goal.cpp
+++ b/ctp2_code/ai/strategy/goals/Goal.cpp
@@ -862,13 +862,8 @@ void Goal::Rollback_Emptied_Transporters()
 	if(m_agents.size() == 0)
 		return;
 
-	Agent_List::iterator agent_iter;
-	for
-	(
-	      agent_iter  = m_agents.begin();
-	      agent_iter != m_agents.end();
-	    ++agent_iter
-	)
+	Agent_List::iterator agent_iter = m_agents.begin();
+	while (agent_iter != m_agents.end())
 	{
 		Agent_ptr agent_ptr = *agent_iter;
 		const MapPoint pos     = agent_ptr->Get_Target_Pos();
@@ -887,9 +882,10 @@ void Goal::Rollback_Emptied_Transporters()
 					("\t\tTransporter (%s) not needed anymore, removing from goal\n", g_theUnitDB->GetNameStr(agent_ptr->Get_Army()->Get(0)->GetType())));
 
 				Rollback_Agent(agent_iter); // increases the agent iterator
-				--agent_iter;
+				continue;
 			}
 		}
+		++agent_iter;
 	}
 }
 

--- a/ctp2_code/ai/strategy/scheduler/scheduler.cpp
+++ b/ctp2_code/ai/strategy/scheduler/scheduler.cpp
@@ -632,12 +632,9 @@ void Scheduler::Match_Resources(const bool move_armies)
 	sint32 committed_agents = 0;
 	sint32 total_agents     = m_agents.size();
 
-	for
-	(
-	    Goal_List::iterator goal_iter  = m_goals.begin();
-	                        goal_iter != m_goals.end();
-	                      ++goal_iter
-	)
+	//It is best not to iterate using a for loop, as items may be erased as we go through
+	Goal_List::iterator goal_iter = m_goals.begin();
+	while(goal_iter != m_goals.end())
 	{
 		if(committed_agents >= total_agents)
 		{
@@ -686,7 +683,7 @@ void Scheduler::Match_Resources(const bool move_armies)
 
 			// Actually should be checked in the next cycle, but there still seems to be something wrong.
 			Goal_List::iterator tmp_goal_iter = goal_iter;
-			--goal_iter;
+			goal_iter++;
 			m_goals.erase(tmp_goal_iter);
 
 			/*
@@ -723,6 +720,7 @@ void Scheduler::Match_Resources(const bool move_armies)
 					--goal_iter;
 					goal_ptr->Rollback_All_Agents(); // Just roll back but don't report to the build list
 					Reprioritize_Goal(tmp_goal_iter);
+					goal_iter++;
 					continue;
 				}
 			}
@@ -745,6 +743,7 @@ void Scheduler::Match_Resources(const bool move_armies)
 					("\t\tGOAL_FAILED Not enough transporters (goal: %x)\n", goal_ptr));
 
 				Rollback_Matches_For_Goal(goal_ptr);
+				goal_iter++;
 				continue;
 			}
 		}
@@ -756,6 +755,7 @@ void Scheduler::Match_Resources(const bool move_armies)
 			AI_DPRINTF(k_DBG_SCHEDULER, m_playerId, goal_ptr->Get_Goal_Type(), -1,
 					("\t\tGOAL (goal: %x) -- No agents were committed, maybe next time. Continuing...\n",
 						goal_ptr));
+			goal_iter++;
 			continue;
 		}
 
@@ -865,6 +865,7 @@ void Scheduler::Match_Resources(const bool move_armies)
 				break;
 			}
 		}
+		goal_iter++;
 	}
 
 #if defined(_DEBUG)

--- a/ctp2_code/ai/strategy/scheduler/scheduler.cpp
+++ b/ctp2_code/ai/strategy/scheduler/scheduler.cpp
@@ -632,10 +632,18 @@ void Scheduler::Match_Resources(const bool move_armies)
 	sint32 committed_agents = 0;
 	sint32 total_agents     = m_agents.size();
 
+#if defined(_DEBUG)
+	int loopCount = 0;
+	int loopCountBadUtility = -1;
+#endif
+
 	//It is best not to iterate using a for loop, as items may be erased as we go through
 	Goal_List::iterator goal_iter = m_goals.begin();
 	while(goal_iter != m_goals.end())
 	{
+#if defined(_DEBUG)
+		loopCount++;
+#endif
 		if(committed_agents >= total_agents)
 		{
 			Assert(committed_agents == total_agents);
@@ -664,6 +672,9 @@ void Scheduler::Match_Resources(const bool move_armies)
 
 			AI_DPRINTF(k_DBG_SCHEDULER, m_playerId, goal_ptr->Get_Goal_Type(), -1, ("\n"));
 			AI_DPRINTF(k_DBG_SCHEDULER, m_playerId, goal_ptr->Get_Goal_Type(), -1, ("\n"));
+#if defined(_DEBUG)
+			loopCountBadUtility = loopCount;
+#endif
 			// Assuming that the list is still sorted,
 			// and the following has only Goal::BAD_UTILITY
 			break;
@@ -864,7 +875,7 @@ void Scheduler::Match_Resources(const bool move_armies)
 
 #if defined(_DEBUG)
 	sint32 committed_agents_test = 0;
-
+      loopCount = 0;
 	for
 	(
 	    Goal_List::iterator goal_iter2  = m_goals.begin();
@@ -872,6 +883,9 @@ void Scheduler::Match_Resources(const bool move_armies)
 	                      ++goal_iter2
 	)
 	{
+		loopCount++;
+		if (loopCount == loopCountBadUtility)
+			break;
 		Goal_ptr goal_ptr        = static_cast<Goal_ptr>(*goal_iter2);
 		committed_agents_test   += goal_ptr->Get_Agent_Count();
 	}

--- a/ctp2_code/ai/strategy/scheduler/scheduler.cpp
+++ b/ctp2_code/ai/strategy/scheduler/scheduler.cpp
@@ -682,9 +682,7 @@ void Scheduler::Match_Resources(const bool move_armies)
 			goal_ptr->Rollback_All_Agents(); // Just roll back but don't report to the build list
 
 			// Actually should be checked in the next cycle, but there still seems to be something wrong.
-			Goal_List::iterator tmp_goal_iter = goal_iter;
-			goal_iter++;
-			m_goals.erase(tmp_goal_iter);
+			m_goals.erase(goal_iter);
 
 			/*
 			// Move to the end
@@ -716,11 +714,8 @@ void Scheduler::Match_Resources(const bool move_armies)
 					// http://www.cplusplus.com/reference/stl/list/splice.html
 					//or use a decrement
 					// Sort the goal list, move iterator increment herein back
-					tmp_goal_iter = goal_iter;
-					--goal_iter;
 					goal_ptr->Rollback_All_Agents(); // Just roll back but don't report to the build list
-					Reprioritize_Goal(tmp_goal_iter);
-					goal_iter++;
+					Reprioritize_Goal(goal_iter);
 					continue;
 				}
 			}
@@ -822,10 +817,9 @@ void Scheduler::Match_Resources(const bool move_armies)
 					{
 						AI_DPRINTF(k_DBG_SCHEDULER, m_playerId, goal_ptr->Get_Goal_Type(), -1,
 							("\t\t Transporters found.\n"));
-						--goal_iter;
 						committed_agents -= goal_ptr->Get_Agent_Count();
 						goal_ptr->Rollback_All_Agents(); // No we don't want to report this to the build list
-						break;
+						continue;
 					}
 				} // if out_of_transports is true, we just fail like in the original code
 			}

--- a/ctp2_code/gfx/spritesys/FacedSpriteWshadow.cpp
+++ b/ctp2_code/gfx/spritesys/FacedSpriteWshadow.cpp
@@ -599,7 +599,7 @@ void FacedSpriteWshadow::SetFrameData(uint16 facing, uint16 frame, Pixel16 *data
 	Assert(m_frames[facing] != NULL);
 	Assert(m_framesSizes[facing] != NULL);
 #ifdef _WINDOWS
-	Assert((((data == NULL) && (size = 0)) || ((data != NULL) && (_msize(data) == size))));
+	Assert((((data == NULL) && (size == 0)) || ((data != NULL) && (_msize(data) == size))));
 #endif
 	m_frames[facing][frame] = data;
 	m_framesSizes[facing][frame] = size;
@@ -612,7 +612,7 @@ void FacedSpriteWshadow::SetMiniFrameData(uint16 facing, uint16 frame, Pixel16 *
 	Assert(m_miniframes[facing] != NULL);
 	Assert(m_miniframesSizes[facing] != NULL);
 #ifdef _WINDOWS
-	Assert((((data == NULL) && (size = 0)) || ((data != NULL) && (_msize(data) == size))));
+	Assert((((data == NULL) && (size == 0)) || ((data != NULL) && (_msize(data) == size))));
 #endif
 
 	m_miniframes[facing][frame] = data;
@@ -672,7 +672,7 @@ void FacedSpriteWshadow::SetShadowFrameData(uint16 facing, uint16 frame, Pixel16
 	Assert(m_shadowFrames[facing] != NULL);
 	Assert(m_shadowFramesSizes[facing] != NULL);
 #ifdef _WINDOWS
-	Assert((((data == NULL) && (size = 0)) || ((data != NULL) && (_msize(data) == size))));
+	Assert((((data == NULL) && (size == 0)) || ((data != NULL) && (_msize(data) == size))));
 #endif
 	m_shadowFrames[facing][frame] = data;
 	m_shadowFramesSizes[facing][frame] = size;
@@ -685,7 +685,7 @@ void FacedSpriteWshadow::SetMiniShadowFrameData(uint16 facing, uint16 frame, Pix
 	Assert(m_miniShadowFrames[facing] != NULL);
 	Assert(m_miniShadowFramesSizes[facing] != NULL);
 #ifdef _WINDOWS
-	Assert((((data == NULL) && (size = 0)) || ((data != NULL) && (_msize(data) == size))));
+	Assert((((data == NULL) && (size == 0)) || ((data != NULL) && (_msize(data) == size))));
 #endif
 	m_miniShadowFrames[facing][frame] = data;
 	m_miniShadowFramesSizes[facing][frame] = size;

--- a/ctp2_code/gs/database/StrDB.cpp
+++ b/ctp2_code/gs/database/StrDB.cpp
@@ -668,5 +668,5 @@ void StringDB::Export(MBCHAR * file)
 	}
 
 	c3files_fclose(fout);
-	delete path;
+	delete[] path;
 }

--- a/ctp2_code/ui/aui_common/aui_listbox.h
+++ b/ctp2_code/ui/aui_common/aui_listbox.h
@@ -152,12 +152,9 @@ public:
 
 		if ( column == -1 ) return AUI_ERRCODE_OK;
 
-		if ( column != -2 )
-		{
-			Assert( 0 <= column && column < m_numColumns );
-			if ( 0 > column || column >= m_numColumns )
-					return AUI_ERRCODE_INVALIDPARAM;
-		}
+		Assert( 0 <= column && column < m_numColumns );
+		if ( 0 > column || column >= m_numColumns )
+			return AUI_ERRCODE_INVALIDPARAM;
 
 		m_sortColumn = column;
 		m_sortAscending = ascending;

--- a/ctp2_code/ui/aui_common/aui_pixel.cpp
+++ b/ctp2_code/ui/aui_common/aui_pixel.cpp
@@ -34,62 +34,6 @@ uint16 aui_Pixel::Get16BitRGB( uint8 red, uint8 green, uint8 blue )
     }
 }
 
-uint8 aui_Pixel::GetPaletteIndexedColor(uint8 red, uint8 green, uint8 blue, HPALETTE *hpal)
-{
-#ifdef __AUI_USE_DIRECTX__
-	PALETTEENTRY *  pe              = new PALETTEENTRY[256];
-	size_t const    paletteCount    =
-        static_cast<size_t>(GetPaletteEntries(*hpal, 0, 256, pe));
-    Assert(paletteCount == 256);
-
-	uint16          valMain         = ColorCode555(red, green, blue);
-	uint8           color           = 0;
-	sint32          diff            = INT_MAX;
-
-	for (uint8 i = 0; i < static_cast<uint8>(paletteCount); ++i)
-    {
-		uint16  valCompare = ColorCode555(pe[i].peRed, pe[i].peGreen, pe[i].peBlue);
-
-		if (abs(valCompare - valMain) < diff )
-        {
-			color   = i;
-			diff    = abs(valCompare - valMain);
-			if (diff == 0) break;
-		}
-	}
-
-	delete [] pe;
-	return color;
-#else
-	// TODO: 8bit modes wanted?
-	Assert(0);
-	return 0;
-#endif
-}
-
-uint8 aui_Pixel::GetPaletteIndexedColor( uint8 red, uint8 green, uint8 blue, RGBQUAD *rgbq )
-{
-	uint8   color   = 0;
-	sint32  diff    = INT_MAX;
-	uint16  valMain = ColorCode555(red, green, blue);
-
-	for (uint8 i = 0; i < 256; i++)
-    {
-		uint16  valCompare = ColorCode555(rgbq[i].rgbRed, rgbq[i].rgbGreen, rgbq[i].rgbBlue);
-
-		if (abs(valCompare - valMain) < diff)
-        {
-			color   = i;
-			diff    = abs(valCompare - valMain);
-
-			if (diff == 0) break;
-		}
-	}
-
-	return color;
-
-}
-
 AUI_ERRCODE aui_Pixel::Convert24To16Dither(
 							 uint16 *buf16,
 							 uint8 *buf24,

--- a/ctp2_code/ui/aui_common/aui_pixel.cpp
+++ b/ctp2_code/ui/aui_common/aui_pixel.cpp
@@ -111,12 +111,12 @@ AUI_ERRCODE aui_Pixel::Convert24To16Dither(
 	if (!thisrerr || !thisgerr || !thisberr ||
 		!nextrerr || !nextgerr || !nextberr)
     {
-		delete thisrerr;
-		delete thisgerr;
-		delete thisberr;
-		delete nextrerr;
-		delete nextgerr;
-		delete nextberr;
+		delete[] thisrerr;
+		delete[] thisgerr;
+		delete[] thisberr;
+		delete[] nextrerr;
+		delete[] nextgerr;
+		delete[] nextberr;
 		return AUI_ERRCODE_LOADFAILED;
 	}
 
@@ -248,12 +248,12 @@ AUI_ERRCODE aui_Pixel::Convert24To16Dither(
 	    fs_direction = ! fs_direction;
 	}
 
-    delete thisrerr;
-    delete thisgerr;
-    delete thisberr;
-    delete nextrerr;
-    delete nextgerr;
-    delete nextberr;
+    delete[] thisrerr;
+    delete[] thisgerr;
+    delete[] thisberr;
+    delete[] nextrerr;
+    delete[] nextgerr;
+    delete[] nextberr;
 
     Free2D(m_edge);
 

--- a/ctp2_code/ui/aui_common/aui_pixel.h
+++ b/ctp2_code/ui/aui_common/aui_pixel.h
@@ -34,8 +34,6 @@ public:
 		uint32 srcPitch,
 		RGBQUAD *rgbq );
 	static uint16 Get16BitRGB( uint8 red, uint8 green, uint8 blue );
-	static uint8 GetPaletteIndexedColor( uint8 red, uint8 green, uint8 blue, RGBQUAD *rgbq );
-	static uint8 GetPaletteIndexedColor( uint8 red, uint8 green, uint8 blue, HPALETTE *hpal );
 
 protected:
 

--- a/ctp2_code/ui/aui_ctp2/c3_listbox.cpp
+++ b/ctp2_code/ui/aui_ctp2/c3_listbox.cpp
@@ -336,11 +336,8 @@ AUI_ERRCODE c3_ListBox::SortByColumn(
 
 	if ( column == -1 ) return AUI_ERRCODE_OK;
 
-	if ( column != -2 )
-	{
-		Assert( 0 <= column && column < m_numColumns );
-		if ( 0 > column || column >= m_numColumns ) return AUI_ERRCODE_INVALIDPARAM;
-	}
+	Assert( 0 <= column && column < m_numColumns );
+	if ( 0 > column || column >= m_numColumns ) return AUI_ERRCODE_INVALIDPARAM;
 
 	m_sortColumn = column;
 	m_sortAscending = ascending;

--- a/ctp2_code/ui/aui_ctp2/c3_utilitydialogbox.cpp
+++ b/ctp2_code/ui/aui_ctp2/c3_utilitydialogbox.cpp
@@ -201,7 +201,7 @@ void C3UtilityTextFieldButtonActionCallback( aui_Control *control, uint32 action
 		if (!strlen(resultText))
 		{
 
-			delete resultText;
+			delete[] resultText;
 			resultText = NULL;
 			if(popup->m_wantEmpties) {
 				popup->m_callback(resultText, TRUE, popup->GetData());

--- a/ctp2_code/ui/aui_ctp2/ctp2_listbox.cpp
+++ b/ctp2_code/ui/aui_ctp2/ctp2_listbox.cpp
@@ -332,11 +332,8 @@ AUI_ERRCODE ctp2_ListBox::SortByColumn(
 {
 	if ( column == -1 ) return AUI_ERRCODE_OK;
 
-	if ( column != -2 )
-	{
-		Assert( 0 <= column && column < m_numColumns );
-		if ( 0 > column || column >= m_numColumns ) return AUI_ERRCODE_INVALIDPARAM;
-	}
+	Assert( 0 <= column && column < m_numColumns );
+	if ( 0 > column || column >= m_numColumns ) return AUI_ERRCODE_INVALIDPARAM;
 
 	m_sortColumn = column;
 	m_sortAscending = ascending;

--- a/ctp2_code/ui/aui_ctp2/videowindow.cpp
+++ b/ctp2_code/ui/aui_ctp2/videowindow.cpp
@@ -90,7 +90,7 @@ AUI_ERRCODE VideoWindow::CreateVideoSurface(MBCHAR *name, BOOL modal)
 
 	g_civPaths->FindFile(C3DIR_VIDEOS, name, fname);
 	hr = m_video->OpenStream(fname);
-	Assert(!hr);
+	Assert(FAILED(hr));
 	if (hr != 0) {
 
 		c3errors_ErrorDialog("Video", "Error opening DirectMovie Indeo 5 video stream.  Be sure that DirectMovie and Indeo 5 are installed.");

--- a/ctp2_code/ui/aui_directx/aui_directblitter.cpp
+++ b/ctp2_code/ui/aui_directx/aui_directblitter.cpp
@@ -33,7 +33,7 @@ AUI_ERRCODE aui_DirectBlitter::Blt16To16(
 			}
 			if(((aui_DirectSurface *) destSurf)->BUFFER()->IsLost() != DD_OK)
 			{
-				if(((aui_DirectSurface *) destSurf)->BUFFER()->Restore())
+				if(SUCCEEDED(((aui_DirectSurface *) destSurf)->BUFFER()->Restore()))
 					return AUI_ERRCODE_NOSURFACE;
 			}
 

--- a/ctp2_code/ui/interface/StatusBar.cpp
+++ b/ctp2_code/ui/interface/StatusBar.cpp
@@ -44,7 +44,7 @@ void StatusBar::SetText(const MBCHAR *text, const aui_Control *owner)
 {
 	if(m_text && (unsigned) m_allocatedLen < strlen(text) + 1) {
 
-		delete m_text;
+		delete[] m_text;
 		m_text = NULL;
 	}
 

--- a/ctp2_code/ui/interface/hotseatlist.cpp
+++ b/ctp2_code/ui/interface/hotseatlist.cpp
@@ -541,7 +541,7 @@ void HotseatListItem::EnterEmail()
 
 void hotseatlist_ClearOptions(void)
 {
-	delete s_legalCivList;
+	delete[] s_legalCivList;
 	s_legalCivList = new bool[g_theCivilisationDB->NumRecords()];
 
 	std::fill(s_hotseatCivList, s_hotseatCivList + k_MAX_PLAYERS, 0);

--- a/ctp2_code/ui/interface/loadsavewindow.cpp
+++ b/ctp2_code/ui/interface/loadsavewindow.cpp
@@ -72,8 +72,6 @@
 extern C3UI							*g_c3ui;
 extern sint32						g_is565Format;
 
-#define k_LOADSAVE_AUTOSORT_COL		-2
-
 LoadSaveWindow::LoadSaveWindow(AUI_ERRCODE *retval, uint32 id,
 		const MBCHAR *ldlBlock, sint32 bpp, AUI_WINDOW_TYPE type, bool bevel)
 :
@@ -1099,14 +1097,5 @@ LSSavesListItem::~LSSavesListItem()
 
 sint32 LSSavesListItem::Compare(c3_ListItem *item2, uint32 column)
 {
-	LSSavesListItem *item = (LSSavesListItem *)item2;
-
-	switch (column) {
-	case k_LOADSAVE_AUTOSORT_COL:
-
-		return strcmp(this->GetText(), item->GetText());
-		break;
-	}
-
 	return 0;
 }


### PR DESCRIPTION
Fix a number of issues that were causing compilation or crash problems for me.
The AI changes seem to make sense, but there was some guess-work about intent involved.

This series contains the following changes:

    - fix some uses of delete where delete[] is required

    - fix a compile error on Ubuntu 20.04 caused by comparing an int8 to 256

    - fix a buggy implementation of Match_Resources when removing goals

    - fix use of this != something or this != something else, which will always be true. && was presumably intended

    - fix some assert statements that were performing an assign of zero to size

    - fix some DEBUG print statements that would crash when there was no best unit
 
