### PR TITLE
Correct trade route deletion

### DIFF
--- a/ctp2_code/gs/gameobj/CityData.cpp
+++ b/ctp2_code/gs/gameobj/CityData.cpp
@@ -575,8 +575,10 @@ CityData::~CityData()
 	if (!m_home_city.IsValid() || m_home_city.CD() == this)
 	{
 		//DPRINTF(k_DBG_GAMESTATE, ("Killing City %lx\n", uint32(m_home_city)));
-		sint32 i;
 
+		//// all trade routes now killed in PrepareToRemove where owner can still be determined to remove SeenByBit
+	        //// left just in case PrepareToRemove was not called before
+		sint32 i;
 		for(i = 0; i < m_tradeSourceList.Num(); i++)
 		{
 			m_tradeSourceList[i].Kill(CAUSE_KILL_TRADE_ROUTE_CITY_DIED);
@@ -1579,6 +1581,8 @@ void CityData::PrepareToRemove(const CAUSE_REMOVE_ARMY cause,
 		if(it.Pos() == m_home_city.RetPos()) continue;
 		g_theWorld->GetCell(it.Pos())->SetCityOwner(Unit());
 	}
+
+	KillAllTradeRoutes(); // to ensure RemoveSeenByBit is executed before city owner cannot be determined any more
 
 	// Change influence of neighbor cities
 }

--- a/ctp2_code/gs/gameobj/TradeRoute.cpp
+++ b/ctp2_code/gs/gameobj/TradeRoute.cpp
@@ -109,8 +109,10 @@ void TradeRoute::KillRoute(CAUSE_KILL_TRADE_ROUTE cause) // Mapped to TradeRoute
 
 	TradeRoute tmp(*this);
 	tmp.Deactivate();                       // Deactivate route => if a tile of the path is seen again the route will not be drawn any more
-	tmp.RemoveSeenByBit(source.GetOwner()); // Owner should not see it any more instantly
-	tmp.RemoveSeenByBit(dest.GetOwner());   // Receiver should not see it any more instantly
+	if(g_theUnitPool->IsValid(source)) // can be gone in case city is destroyed
+	    tmp.RemoveSeenByBit(source.GetOwner()); // Owner should not see it any more instantly
+	if(g_theUnitPool->IsValid(dest)) // can be gone in case city is destroyed
+	    tmp.RemoveSeenByBit(dest.GetOwner());   // Receiver should not see it any more instantly
 	tmp.RevealTradeRouteStateIfInVision();  // Reveal trade route state to players where route is in vision, must be after Deactivate()
 }
 


### PR DESCRIPTION
Changes missing from #256: In case a city is destroyed its trade routes must be killed before the CityData destructor is called because then it is not possible any more to determine the owner to remove the SeenByBit.