### PR TITLE
Show tooltip when idling mouse over panel button (SDL2-regression)

### DIFF
--- a/ctp2_code/ui/aui_sdl/aui_sdlmouse.cpp
+++ b/ctp2_code/ui/aui_sdl/aui_sdlmouse.cpp
@@ -154,6 +154,7 @@ sint32 aui_SDLMouse::ManipulateInputs(aui_MouseEvent *data, BOOL add) {
 		if (currentFrameTick > m_lastFrameTick + TICKS_PER_FRAME) {
 			m_lastFrameTick = currentFrameTick;
 			data[0] = m_data;
+			data[0].time = currentFrameTick;
 			numberEvents = 1;
 		}
 	}


### PR DESCRIPTION
This will fix the issue that a tool-tip was not shown any more when idling the mouse over a panel button; per example unit-actions such as `Pillage`.