### PR TITLE
Technical: fix memory leak (sort of) while saving game

### DIFF
--- a/ctp2_code/gs/world/UnseenCell.cpp
+++ b/ctp2_code/gs/world/UnseenCell.cpp
@@ -25,18 +25,18 @@
 // Modifications from the original Activision code:
 //
 // - Finished tile improvements are now stored as well in the improvements
-//   list to be able to draw or access them later. - Dec. 21st 2004 Martin Gühmann
+//   list to be able to draw or access them later. - Dec. 21st 2004 Martin GÃ¼hmann
 // - Added new functions to calculate the food, shields and gold values produced
-//   at the storing time of this UnseenCell. - Dec. 22nd 2004 Martin Gühmann
+//   at the storing time of this UnseenCell. - Dec. 22nd 2004 Martin GÃ¼hmann
 // - Modified constructors and serialize method to support the new
-//   m_visibleCityOwner member. - Dec. 26th 2004 - Martin Gühmann
+//   m_visibleCityOwner member. - Dec. 26th 2004 - Martin GÃ¼hmann
 // - When an UnseenCell object is created and the according cell contains a
 //   city the owner is now taken from the CityData instead of the Unit
 //   itsself this allows to get the right owner info when a city changes
-//   hands. - Mar. 4th 2005 Martin Gühmann
+//   hands. - Mar. 4th 2005 Martin GÃ¼hmann
 // - Moved Peter's good's fix to the according Get*FromTerrain functions.
-//   - April 13th 2005 Martin Gühmann
-// - Fix retrieval of good boni. - May 18th 2005 Martin Gühmann
+//   - April 13th 2005 Martin GÃ¼hmann
+// - Fix retrieval of good boni. - May 18th 2005 Martin GÃ¼hmann
 // - Added isCapitol
 //
 //----------------------------------------------------------------------------
@@ -866,6 +866,8 @@ void UnseenCell::Serialize(CivArchive &archive)
 				archive.Store((uint8*)walk.GetObj(), sizeof(UnseenInstallationInfo));
 				walk.Next();
 			}
+			UnseenInstallationInfo * storedCityOwner = m_installations->RemoveTail();
+			delete storedCityOwner;
 		}
 
 		{


### PR DESCRIPTION
During saving the game an extra UnseenInstallationInfo-record was added to every unseen cell to store the city owner. This record was not removed.

This caused additional memory to be allocated after every save game (cumulative). (Re-)loading the game removed this additional memory. As the record was stored in a list it was correctly deleted when quitting the game.

This was most noticeable due to auto-save and playing for a long time without reloading or quitting the game.

A side-effect was that the save-game size increased as well (cumulative). This was also resetted when the game was reloaded and saved again.

As in bigger games the number of unseen-cells can be significant (my game had around ~100k unseen cells) the amount of allocated memory grew also significantly ~4Mb per turn.