### PR TITLE
Corrections to unit dependencies

### DIFF
--- a/bin/deprecateAdv.awk
+++ b/bin/deprecateAdv.awk
@@ -1,16 +1,16 @@
 # read a Great_Library.txt
 # when a  UNIT_.*_PREREQ is found use the info to extract ObsoleteAdvance from Units.txt into variable OA
-# insert that info 2 lines after "Requires:"
+# insert that info 1 lines after "L:DATABASE_ADVANCES,ADVANCE_" (which is language indep.)
 
 match($0, /.*(UNIT_.*)_PREREQ.*/, s) {
     cmd = sprintf("awk -v var=%s '/{/ {a=$1}; /ObsoleteAdvance/ { if ( a ~ var ) print $2}' ./ctp2_data/default/gamedata/Units.txt", s[1])
     cmd | getline OA
     close(cmd)
     }
-/Requires:/ {
+/L:DATABASE_ADVANCES,ADVANCE_/ {
     found=1
     }
-(found++) == 3 && OA {
+(found++) == 2 && OA {
     printf("Obsolete:\n<L:DATABASE_ADVANCES,%s>%s<e>\n", OA, OA)
     OA=0
     } 1

--- a/bin/deprecateAdv.awk
+++ b/bin/deprecateAdv.awk
@@ -3,7 +3,7 @@
 # insert that info 1 lines after "L:DATABASE_ADVANCES,ADVANCE_" (which is language indep.)
 
 match($0, /.*(UNIT_.*)_PREREQ.*/, s) {
-    cmd = sprintf("awk -v var=%s '/{/ {a=$1}; /ObsoleteAdvance/ { if ( a ~ var ) print $2}' ./ctp2_data/default/gamedata/Units.txt", s[1])
+    cmd = sprintf("awk -v var=%s '/{/ {a=$1}; /ObsoleteAdvance/ { if ( a ~ var ) print $2}' ../../default/gamedata/Units.txt", s[1])
     cmd | getline OA
     close(cmd)
     }
@@ -11,9 +11,10 @@ match($0, /.*(UNIT_.*)_PREREQ.*/, s) {
     found=1
     }
 (found++) == 2 && OA {
-    oa=OA
-    gsub(/ADVANCE_/, "", oa)
-    gsub(/_/, " ", oa)
-    printf("Obsolete:\n<L:DATABASE_ADVANCES,%s>%s<e>\n", OA, tolower(oa))
+    cmd = sprintf("awk -v var=%s -v FPAT='([^ \t]+)|(\"[^\"]+\")' ' $1 ~ var { print $2 }' gl_str.txt", OA)
+    cmd | getline oa
+    close(cmd)
+    gsub("\"","", oa) # remove quotes around quoted fields
+    printf("Obsolete:\n<L:DATABASE_ADVANCES,%s>%s<e>\n", OA, oa)
     OA=0
     } 1

--- a/bin/deprecateAdv.awk
+++ b/bin/deprecateAdv.awk
@@ -6,12 +6,13 @@ match($0, /.*(UNIT_.*)_PREREQ.*/, s) {
     cmd = sprintf("awk -v var=%s '/{/ {a=$1}; /ObsoleteAdvance/ { if ( a ~ var ) print $2}' ../../default/gamedata/Units.txt", s[1])
     cmd | getline OA
     close(cmd)
+    gsub("\r","", OA) # remove CR
     }
 /L:DATABASE_ADVANCES,ADVANCE_/ {
     found=1
     }
 (found++) == 2 && OA {
-    cmd = sprintf("awk -v var=%s -v FPAT='([^ \t]+)|(\"[^\"]+\")' ' $1 ~ var { print $2 }' gl_str.txt", OA)
+    cmd = sprintf("awk -v var=%s -v FPAT='([^ \t]+)|(\"[^\"]+\")' ' $1 ~ var { print $2 }' gl_str.txt", OA) # OA must not contain CR for matching!
     cmd | getline oa
     close(cmd)
     gsub("\"","", oa) # remove quotes around quoted fields

--- a/bin/deprecateAdv.awk
+++ b/bin/deprecateAdv.awk
@@ -1,17 +1,16 @@
 # read a Great_Library.txt
 # when a  UNIT_.*_PREREQ is found use the info to extract ObsoleteAdvance from Units.txt into variable OA
-# insert that info after "Requires:" before "[END]"
+# insert that info 2 lines after "Requires:"
 
 match($0, /.*(UNIT_.*)_PREREQ.*/, s) {
     cmd = sprintf("awk -v var=%s '/{/ {a=$1}; /ObsoleteAdvance/ { if ( a ~ var ) print $2}' ./ctp2_data/default/gamedata/Units.txt", s[1])
     cmd | getline OA
     close(cmd)
     }
-/Requires:/ && OA {
+/Requires:/ {
     found=1
     }
-/\[END\]/ && found == 1 {
+(found++) == 3 && OA {
     printf("Obsolete:\n<L:DATABASE_ADVANCES,%s>%s<e>\n", OA, OA)
     OA=0
-    found=0
     } 1

--- a/bin/deprecateAdv.awk
+++ b/bin/deprecateAdv.awk
@@ -11,6 +11,9 @@ match($0, /.*(UNIT_.*)_PREREQ.*/, s) {
     found=1
     }
 (found++) == 2 && OA {
-    printf("Obsolete:\n<L:DATABASE_ADVANCES,%s>%s<e>\n", OA, OA)
+    oa=OA
+    gsub(/ADVANCE_/, "", oa)
+    gsub(/_/, " ", oa)
+    printf("Obsolete:\n<L:DATABASE_ADVANCES,%s>%s<e>\n", OA, tolower(oa))
     OA=0
     } 1

--- a/bin/deprecateAdv.awk
+++ b/bin/deprecateAdv.awk
@@ -1,0 +1,17 @@
+# read a Great_Library.txt
+# when a  UNIT_.*_PREREQ is found use the info to extract ObsoleteAdvance from Units.txt into variable OA
+# insert that info after "Requires:" before "[END]"
+
+match($0, /.*(UNIT_.*)_PREREQ.*/, s) {
+    cmd = sprintf("awk -v var=%s '/{/ {a=$1}; /ObsoleteAdvance/ { if ( a ~ var ) print $2}' ./ctp2_data/default/gamedata/Units.txt", s[1])
+    cmd | getline OA
+    close(cmd)
+    }
+/Requires:/ && OA {
+    found=1
+    }
+/\[END\]/ && found == 1 {
+    printf("Obsolete:\n<L:DATABASE_ADVANCES,%s>%s<e>\n", OA, OA)
+    OA=0
+    found=0
+    } 1

--- a/bin/deprecateAdv.sh
+++ b/bin/deprecateAdv.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+d=$(dirname $1)
+f=$(basename $1)
+pwd=$(pwd)
+echo "$d $f"
+
+cd $d
+awk -i inplace -f $pwd/bin/deprecateAdv.awk $f
+sed -i 's/\r//g' $f

--- a/ctp2_data/default/gamedata/Units.txt
+++ b/ctp2_data/default/gamedata/Units.txt
@@ -2378,7 +2378,7 @@ UNIT_LEVIATHON {
    FoodHunger 0
    MaxMovePoints 10
    VisionRange 3
-   EnableAdvance ADVANCE_UNIFIED_PHYSICS
+   EnableAdvance ADVANCE_PLASMA_WEAPONRY
    BombRounds 5
    BombardRange 1
    CanCounterBombard

--- a/ctp2_data/default/gamedata/Units.txt
+++ b/ctp2_data/default/gamedata/Units.txt
@@ -766,7 +766,7 @@ UNIT_CAVALRY {
    MaxMovePoints 400
    VisionRange 2
    EnableAdvance ADVANCE_CAVALRY_TACTICS
-   ObsoleteAdvance ADVANCE_FUSION
+   ObsoleteAdvance ADVANCE_TANK_WARFARE
    UpgradeTo	UNIT_TANK
    UpgradeTo	UNIT_FUSION_TANK
    ActiveDefenseRange 0

--- a/ctp2_data/default/gamedata/Units.txt
+++ b/ctp2_data/default/gamedata/Units.txt
@@ -3955,7 +3955,7 @@ UNIT_TANK {
    MaxMovePoints 600
    VisionRange 3
    EnableAdvance ADVANCE_TANK_WARFARE
-   ObsoleteAdvance ADVANCE_UNIFIED_PHYSICS
+   ObsoleteAdvance ADVANCE_FUSION
    UpgradeTo	UNIT_FUSION_TANK
    ActiveDefenseRange 0
    LossMoveToDmgNone

--- a/ctp2_data/english/gamedata/Great_Library.txt
+++ b/ctp2_data/english/gamedata/Great_Library.txt
@@ -7355,7 +7355,7 @@ The catapult was the one of the most effective siege weapons used in ancient and
 Requires:
 <L:DATABASE_ADVANCES,ADVANCE_CAVALRY_TACTICS>Cavalry Tactics<e>
 Obsolete:
-<L:DATABASE_ADVANCES,ADVANCE_FUSION>Fusion<e>
+<L:DATABASE_ADVANCES,ADVANCE_TANK_WARFARE>Tank Warfare<e>
 [END]
 
 [UNIT_CAVALRY_STATISTICS]
@@ -9269,7 +9269,7 @@ Samurai were the warrior class during the feudal period of Japanese history from
 Requires:
 <L:DATABASE_ADVANCES,ADVANCE_TANK_WARFARE>Tank Warfare<e>
 Obsolete:
-<L:DATABASE_ADVANCES,ADVANCE_UNIFIED_PHYSICS>Unified Physics<e>
+<L:DATABASE_ADVANCES,ADVANCE_FUSION>Fusion<e>
 [END]
 
 [UNIT_TANK_STATISTICS]

--- a/ctp2_data/english/gamedata/Great_Library.txt
+++ b/ctp2_data/english/gamedata/Great_Library.txt
@@ -6992,6 +6992,8 @@ In the beginning of World War II, planes dive-bombing and torpedo bombing from c
 [UNIT_ARCHER_PREREQ]
 Requires:
 <L:DATABASE_ADVANCES,ADVANCE_BALLISTICS>Ballistics<e>
+Obsolete:
+<L:DATABASE_ADVANCES,ADVANCE_CANNON_MAKING>Cannon Making<e>
 [END]
 
 [UNIT_ARCHER_STATISTICS]
@@ -7096,6 +7098,8 @@ World War II was the battleship's heyday, when the Washington Treaty of 1922, wh
 [UNIT_BOMBER_PREREQ]
 Requires:
 <L:DATABASE_ADVANCES,ADVANCE_JET_PROPULSION>Jet Propulsion<e>
+Obsolete:
+<L:DATABASE_ADVANCES,ADVANCE_ADVANCED_COMPOSITES>Advanced Composites<e>
 
 Abilities: 
 Can carry 1 <L:DATABASE_UNITS,UNIT_NUKE>Nuke<e> or <L:DATABASE_UNITS,UNIT_CRUISE_MISSILE>Cruise Missile<e>
@@ -7134,6 +7138,8 @@ Although propeller-driven bombers proved their worth many times over in World Wa
 [UNIT_CANNON_PREREQ]
 Requires:
 <L:DATABASE_ADVANCES,ADVANCE_CANNON_MAKING>Cannon Making<e>
+Obsolete:
+<L:DATABASE_ADVANCES,ADVANCE_CYBERNETICS>Cybernetics<e>
 
 Abilities:
 <L:DATABASE_ORDERS,ORDER_BOMBARD>Bombards<e>
@@ -7169,6 +7175,8 @@ As gunpowder revolutionized the world of infantry and melee combat in the 16th c
 [UNIT_CARAVAN_PREREQ]
 Requires:
 <L:DATABASE_ADVANCES,ADVANCE_TRADE>Trade<e>
+Obsolete:
+<L:DATABASE_ADVANCES,ADVANCE_GLOBAL_ECONOMICS>Global Economics<e>
 
 Costs:
 {UnitDB(UnitRecord[0]).ShieldCost} <L:DATABASE_CONCEPTS,CONCEPT_PRODUCTION>Production<e>
@@ -7231,6 +7239,8 @@ Although some military helicopters were primarily designed for ground attack, th
 [UNIT_CARRACK_PREREQ]
 Requires:
 <L:DATABASE_ADVANCES,ADVANCE_OCEAN_FARING>Ocean Faring<e>
+Obsolete:
+<L:DATABASE_ADVANCES,ADVANCE_INTERNAL_COMBUSTION>Internal Combustion<e>
 
 Abilities:
 Can <L:DATABASE_ORDERS,ORDER_BOARD_TRANSPORT>Transport<e> up to three land units
@@ -7270,6 +7280,8 @@ Two of the most famous Carracks were the Santa Maria, one of Christopher Columbu
 [UNIT_CATAMARAN_PREREQ]
 Requires:
 <L:DATABASE_ADVANCES,ADVANCE_SHIP_BUILDING>Shipbuilding<e>
+Obsolete:
+<L:DATABASE_ADVANCES,ADVANCE_HULL_MAKING>Hullmaking<e>
 
 Abilities:
 Can <L:DATABASE_ORDERS,ORDER_BOARD_TRANSPORT>Transport<e> one land units
@@ -7305,6 +7317,8 @@ The Coracle is a boat native to ancient Wales and Ireland.  Some coracles were r
 [UNIT_CATAPULT_PREREQ]
 Requires:
 <L:DATABASE_ADVANCES,ADVANCE_GEOMETRY>Geometry<e>
+Obsolete:
+<L:DATABASE_ADVANCES,ADVANCE_EXPLOSIVES>Explosives<e>
 
 Abilities:
 <L:DATABASE_ORDERS,ORDER_BOMBARD>Bombards<e>
@@ -7340,6 +7354,8 @@ The catapult was the one of the most effective siege weapons used in ancient and
 [UNIT_CAVALRY_PREREQ]
 Requires:
 <L:DATABASE_ADVANCES,ADVANCE_CAVALRY_TACTICS>Cavalry Tactics<e>
+Obsolete:
+<L:DATABASE_ADVANCES,ADVANCE_FUSION>Fusion<e>
 [END]
 
 [UNIT_CAVALRY_STATISTICS]
@@ -7372,6 +7388,8 @@ The early 14th century development of gunpowder and armor-piercing bullets compl
 [UNIT_CLERIC_PREREQ]
 Requires:
 <L:DATABASE_ADVANCES,ADVANCE_THEOLOGY>Theology<e>
+Obsolete:
+<L:DATABASE_ADVANCES,ADVANCE_MASS_MEDIA>Mass Media<e>
 
 Abilities:
 <L:DATABASE_ORDERS,ORDER_CONVERT>Converts Cities<e>
@@ -7566,6 +7584,8 @@ After the military developed an internal neural interface device, they began to 
 [UNIT_DESTROYER_PREREQ]
 Requires:
 <L:DATABASE_ADVANCES,ADVANCE_MASS_PRODUCTION>Mass Production<e>
+Obsolete:
+<L:DATABASE_ADVANCES,ADVANCE_PLASMA_WEAPONRY>Plasma Weaponry<e>
 
 Abilities:
 <L:DATABASE_ORDERS,ORDER_BOMBARD>Bombards<e>
@@ -7605,6 +7625,8 @@ After World War II, the destroyer's dual role of antiaircraft and antisubmarine 
 [UNIT_DIPLOMAT_PREREQ]
 Requires:
 <L:DATABASE_ADVANCES,ADVANCE_BUREAUCRACY>Bureaucracy<e>
+Obsolete:
+<L:DATABASE_ADVANCES,ADVANCE_EUGENICS>Gene Therapy<e>
 
 Abilities:
 <L:DATABASE_ORDERS,ORDER_ESTABLISH_EMBASSY>Establishes Embassies<e>
@@ -7839,6 +7861,8 @@ In April 1925, Adolf Hitler established the Schutzstaffel (German, "Protective E
 [UNIT_FIGHTER_PREREQ]
 Requires:
 <L:DATABASE_ADVANCES,ADVANCE_AERODYNAMICS>Aerodynamics<e>
+Obsolete:
+<L:DATABASE_ADVANCES,ADVANCE_SUPERSONIC_FLIGHT>Supersonic Flight<e>
 
 Abilities:
 Land on <L:DATABASE_UNITS,UNIT_AIRCRAFT_CARRIER>Aircraft Carrier<e>
@@ -7879,6 +7903,8 @@ During World War II, all-metal, propeller-engine fighters were capable of speeds
 [UNIT_FIRE_TRIREME_PREREQ]
 Requires:
 <L:DATABASE_ADVANCES,ADVANCE_ALCHEMY>Alchemy<e>
+Obsolete:
+<L:DATABASE_ADVANCES,ADVANCE_MODERN_METALLURGY>Modern Metallurgy<e>
 [END]
 
 [UNIT_FIRE_TRIREME_STATISTICS]
@@ -7934,6 +7960,8 @@ A standard container size made shipping easier.  A single 8 ft x 8 ft by 20 ft c
 [UNIT_FRIGATE_PREREQ]
 Requires:
 <L:DATABASE_ADVANCES,ADVANCE_MASS_PRODUCTION>Mass Production<e> 
+Obsolete:
+<L:DATABASE_ADVANCES,ADVANCE_PLASMA_WEAPONRY>Plasma Weaponry<e>
 
 Abilities:
 <L:DATABASE_ORDERS,ORDER_BOMBARD>Bombards<e>
@@ -8010,6 +8038,8 @@ The fusion tank could penetrate heavily armored and fortified targets with its h
 [UNIT_HOPLITE_PREREQ]
 Requires:
 <L:DATABASE_ADVANCES,ADVANCE_BRONZE_WORKING>Bronze Working<e>
+Obsolete:
+<L:DATABASE_ADVANCES,ADVANCE_GUNPOWDER>Gunpowder<e>
 [END]
 
 [UNIT_HOPLITE_STATISTICS]
@@ -8074,6 +8104,8 @@ The development of applied chaos theory opened up new opportunities in the realm
 [UNIT_INFANTRYMAN_PREREQ]
 Requires:
 <L:DATABASE_ADVANCES,ADVANCE_GUNPOWDER>Gunpowder<e>
+Obsolete:
+<L:DATABASE_ADVANCES,ADVANCE_ADV_INFANTRY_TACTICS>Adv. Infantry Tactics<e>
 [END]
 
 [UNIT_INFANTRYMAN_STATISTICS]
@@ -8149,6 +8181,8 @@ Although biological warfare was an ever-looming threat in the late 20th century,
 [UNIT_INTERCEPTOR_PREREQ]
 Requires:
 <L:DATABASE_ADVANCES,ADVANCE_SUPERSONIC_FLIGHT>Supersonic Flight<e>
+Obsolete:
+<L:DATABASE_ADVANCES,ADVANCE_AI_SURVEILLANCE>AI Surveillance<e>
 
 Abilities:
 <L:DATABASE_CONCEPTS,CONCEPT_ACTIVE_DEFENSE>Anti-Air Active Defense<e>
@@ -8187,6 +8221,8 @@ The interceptor's extreme speeds and operational altitudes made targeting, strik
 [UNIT_IRONCLAD_PREREQ]
 Requires:
 <L:DATABASE_ADVANCES,ADVANCE_MODERN_METALLURGY>Modern Metallurgy<e>
+Obsolete:
+<L:DATABASE_ADVANCES,ADVANCE_ADV_NAVAL_TACTICS>Adv. Naval Tactics<e>
 
 Abilities:
 <L:DATABASE_ORDERS,ORDER_BOMBARD>Bombards<e>
@@ -8224,6 +8260,8 @@ When, early in the Civil War, Union forces abandoned the Norfolk Navy Yard at Po
 [UNIT_KNIGHT_PREREQ]
 Requires:
 <L:DATABASE_ADVANCES,ADVANCE_FEUDALISM>Feudalism<e>
+Obsolete:
+<L:DATABASE_ADVANCES,ADVANCE_INDUSTRIAL_REVOLUTION>Industrial Revolution<e>
 
 Abilities:
 <L:DATABASE_CONCEPTS,CONCEPT_SPECIAL_FORCES>Special Forces<e>
@@ -8374,6 +8412,8 @@ Conceived by military strategists as the most effective defensive military craft
 [UNIT_LONGSHIP_PREREQ]
 Requires:
 <L:DATABASE_ADVANCES,ADVANCE_HULL_MAKING>Hull Making<e>
+Obsolete:
+<L:DATABASE_ADVANCES,ADVANCE_INTERNAL_COMBUSTION>Internal Combustion<e>
 
 Abilities: 
 Can <L:DATABASE_ORDERS,ORDER_BOARD_TRANSPORT>Transport<e> up to 2 land units
@@ -8409,6 +8449,8 @@ The Viking longship was one of the first seafaring vessels that employed a clink
 [UNIT_MACHINE_GUNNER_PREREQ]
 Requires:
 <L:DATABASE_ADVANCES,ADVANCE_INDUSTRIAL_REVOLUTION>Industrial Revolution<e>
+Obsolete:
+<L:DATABASE_ADVANCES,ADVANCE_CHAOS_THEORY>Chaos Theory<e>
 [END]
 
 [UNIT_MACHINE_GUNNER_STATISTICS]
@@ -8550,6 +8592,8 @@ The first military application of organic systems design culminated in the devel
 [UNIT_MOUNTED_ARCHER_PREREQ]
 Requires:
 <L:DATABASE_ADVANCES,ADVANCE_HORSE_RIDING>Horse Riding<e>
+Obsolete:
+<L:DATABASE_ADVANCES,ADVANCE_INDUSTRIAL_REVOLUTION>Industrial Revolution<e>
 [END]
 
 [UNIT_MOUNTED_ARCHER_STATISTICS]
@@ -8582,6 +8626,8 @@ The earliest armies of the ancient age used chariots to conduct high-speed attac
 [UNIT_NUCLEAR_SUBMARINE_PREREQ]
 Requires:
 <L:DATABASE_ADVANCES,ADVANCE_NUCLEAR_POWER>Nuclear Power<e>
+Obsolete:
+<L:DATABASE_ADVANCES,ADVANCE_GENETIC_TAILORING>Genetic Tailoring<e>
 
 Abilities:
 Can carry up to 2 <L:DATABASE_UNITS,UNIT_CRUISE_MISSILE>Cruise Missiles<e> or <L:DATABASE_UNITS,UNIT_NUKE>Nukes<e>
@@ -8699,6 +8745,8 @@ During World War II, military forces deployed parachute-equipped infantrymen cal
 [UNIT_PIKEMEN_PREREQ]
 Requires:
 <L:DATABASE_ADVANCES,ADVANCE_FEUDALISM>Feudalism<e>
+Obsolete:
+<L:DATABASE_ADVANCES,ADVANCE_FASCISM>Fascism<e>
 
 Abilities:
 Defensive bonus vs. mounted units
@@ -8878,6 +8926,8 @@ Since prehistoric times, people often lived a nomadic lifestyle, traveling from 
 [UNIT_SHIP_OF_THE_LINE_PREREQ]
 Requires:
 <L:DATABASE_ADVANCES,ADVANCE_NAVAL_TACTICS>Naval Tactics<e>
+Obsolete:
+<L:DATABASE_ADVANCES,ADVANCE_MASS_PRODUCTION>Mass Production<e>
 
 Abilities:
 <L:DATABASE_ORDERS,ORDER_BOMBARD>Bombards<e>
@@ -8988,6 +9038,8 @@ In 2047, scientists at the National Aeronautical and Space Administration launch
 [UNIT_SPY_PREREQ]
 Requires:
 <L:DATABASE_ADVANCES,ADVANCE_NATIONALISM>Nationalism<e>
+Obsolete:
+<L:DATABASE_ADVANCES,ADVANCE_NEURAL_INTERFACE>Neural Interface<e>
 Abilities:
 <L:DATABASE_ORDERS,ORDER_INCITE_REVOLUTION>Incites Revolutions<e>
 <L:DATABASE_ORDERS,ORDER_INVESTIGATE_CITY>Spies<e>
@@ -9140,6 +9192,8 @@ Stealth technology was not without its costs.  The first stealth fighter, the Un
 [UNIT_SUBMARINE_PREREQ]
 Requires:
 <L:DATABASE_ADVANCES,ADVANCE_OIL_REFINING>Oil Refining<e>
+Obsolete:
+<L:DATABASE_ADVANCES,ADVANCE_NUCLEAR_POWER>Nuclear Power<e>
 
 Abilities:
 Bombards 
@@ -9177,6 +9231,8 @@ The first submarines, developed and tested by both navies of the American Civil 
 [UNIT_SWORDSMAN_PREREQ]
 Requires:
 <L:DATABASE_ADVANCES,ADVANCE_IRON_WORKING>Iron Working<e>
+Obsolete:
+<L:DATABASE_ADVANCES,ADVANCE_INDUSTRIAL_REVOLUTION>Industrial Revolution<e>
 
 Abilities:
 <L:DATABASE_CONCEPTS,CONCEPT_SPECIAL_FORCES>Special Forces<e>
@@ -9212,6 +9268,8 @@ Samurai were the warrior class during the feudal period of Japanese history from
 [UNIT_TANK_PREREQ]
 Requires:
 <L:DATABASE_ADVANCES,ADVANCE_TANK_WARFARE>Tank Warfare<e>
+Obsolete:
+<L:DATABASE_ADVANCES,ADVANCE_UNIFIED_PHYSICS>Unified Physics<e>
 [END]
 
 [UNIT_TANK_STATISTICS]
@@ -9361,6 +9419,8 @@ By the middle of the 20th century, urban planners experimented with new concepts
 [UNIT_WARRIOR_PREREQ]
 Requires:
 <L:DATABASE_ADVANCES,ADVANCE_TOOLMAKING>Tool Making<e>
+Obsolete:
+<L:DATABASE_ADVANCES,ADVANCE_GUNPOWDER>Gunpowder<e>
 [END]
 
 [UNIT_WARRIOR_STATISTICS]
@@ -11027,6 +11087,8 @@ A player may want to upgrade a unit for a variety of reasons.  Older and obsolet
 [UNIT_LONGBOWMAN_PREREQ]
 Requires:
 <L:DATABASE_ADVANCES,ADVANCE_FEUDALISM><e>
+Obsolete:
+<L:DATABASE_ADVANCES,ADVANCE_CANNON_MAKING>Cannon Making<e>
 [END]
 
 [UNIT_LONGBOWMAN_STATISTICS]

--- a/ctp2_data/french/gamedata/Great_Library.txt
+++ b/ctp2_data/french/gamedata/Great_Library.txt
@@ -5743,6 +5743,8 @@ Au début de deuxième guerre mondiale, les bombardiers et lance-torpilles embarqu
 [UNIT_ARCHER_PREREQ]
 Condition :
 <L:DATABASE_ADVANCES,ADVANCE_BALLISTICS>Balistique<e>
+Obsolete:
+<L:DATABASE_ADVANCES,ADVANCE_CANNON_MAKING>Fabric. canons<e>
 [END]
 
 [UNIT_ARCHER_STATISTICS]
@@ -5835,6 +5837,8 @@ La seconde guerre mondiale est l'âge d'or des cuirassés, après l'abandon du trai
 [UNIT_BOMBER_PREREQ]
 Condition :
 <L:DATABASE_ADVANCES,ADVANCE_JET_PROPULSION>Propulsion à réaction<e>
+Obsolete:
+<L:DATABASE_ADVANCES,ADVANCE_ADVANCED_COMPOSITES>Composites avancés<e>
 
 Capacités :
 Transporter un <L:DATABASE_UNITS,UNIT_NUKE>missile nucléaire<e> ou un <L:DATABASE_UNITS,UNIT_CRUISE_MISSILE>missile de croisère<e>
@@ -5869,6 +5873,8 @@ En dépit de l'impact notable des bombardiers conventionnels sur la deuxième guer
 [UNIT_CANNON_PREREQ]
 Condition :
 <L:DATABASE_ADVANCES,ADVANCE_CANNON_MAKING>Fabrication de canons<e>
+Obsolete:
+<L:DATABASE_ADVANCES,ADVANCE_CYBERNETICS>Cybernétique<e>
 
 Capacités :
 <L:DATABASE_ORDERS,ORDER_BOMBARD>Bombarder<e>
@@ -5900,6 +5906,8 @@ La poudre à canon a révolutionné l'infanterie et le combat rapproché au XVIe siè
 [UNIT_CARAVAN_PREREQ]
 Condition :
 <L:DATABASE_ADVANCES,ADVANCE_TRADE>Echanges<e>
+Obsolete:
+<L:DATABASE_ADVANCES,ADVANCE_GLOBAL_ECONOMICS>Economie mondiale<e>
 
 Coût :
 <L:DATABASE_CONCEPTS,CONCEPT_PRODUCTION>Production<e> : {UnitDB(UnitRecord[0]).ShieldCost}
@@ -5952,6 +5960,8 @@ Bien que certains hélicoptères militaires soient avant tout conçus pour l'attaqu
 [UNIT_CARRACK_PREREQ]
 Condition :
 <L:DATABASE_ADVANCES,ADVANCE_OCEAN_FARING>Exploration maritime<e>
+Obsolete:
+<L:DATABASE_ADVANCES,ADVANCE_INTERNAL_COMBUSTION>Combust. interne<e>
 
 Capacités :
 <L:DATABASE_ORDERS,ORDER_BOARD_TRANSPORT>Transporter<e> jusqu'à trois unités terrestres
@@ -5986,6 +5996,8 @@ Deux des carracks les plus célèbres ont été le Santa Maria, l'un des navires de 
 [UNIT_CATAMARAN_PREREQ]
 Condition :
 <L:DATABASE_ADVANCES,ADVANCE_SHIP_BUILDING>Construction navale<e>
+Obsolete:
+<L:DATABASE_ADVANCES,ADVANCE_HULL_MAKING>Fabr. coques<e>
 
 Capacités :
 Peut <L:DATABASE_ORDERS,ORDER_BOARD_TRANSPORT>transporter<e> une unité terrestre
@@ -6017,6 +6029,8 @@ Le coracle est un bateau originaire du Pays de Galles et d'Irlande. Certains cor
 [UNIT_CATAPULT_PREREQ]
 Condition :
 <L:DATABASE_ADVANCES,ADVANCE_GEOMETRY>Géometrie<e>
+Obsolete:
+<L:DATABASE_ADVANCES,ADVANCE_EXPLOSIVES>Explosifs<e>
 
 Capacités :
 <L:DATABASE_ORDERS,ORDER_BOMBARD>Bombarder<e>
@@ -6048,6 +6062,8 @@ La catapulte est l'une des armes de siège les plus efficaces de l'Antiquité et d
 [UNIT_CAVALRY_PREREQ]
 Condition :
 <L:DATABASE_ADVANCES,ADVANCE_CAVALRY_TACTICS>Tactiques de cavalerie<e>
+Obsolete:
+<L:DATABASE_ADVANCES,ADVANCE_FUSION>Fusion<e>
 [END]
 
 [UNIT_CAVALRY_STATISTICS]
@@ -6076,6 +6092,8 @@ Au début du XIVe siècle, l'arrivée de la poudre à canon et des munitions capable
 [UNIT_CLERIC_PREREQ]
 Condition :
 <L:DATABASE_ADVANCES,ADVANCE_THEOLOGY>Théologie<e>
+Obsolete:
+<L:DATABASE_ADVANCES,ADVANCE_MASS_MEDIA>Médias<e>
 
 Capacités :
 <L:DATABASE_ORDERS,ORDER_CONVERT>Convertir des villes<e>
@@ -6246,6 +6264,8 @@ A la suite de la mise au point d'un appareil interne d'interfaçage neural, les m
 [UNIT_DESTROYER_PREREQ]
 Condition :
 <L:DATABASE_ADVANCES,ADVANCE_MASS_PRODUCTION>Production de masse<e>
+Obsolete:
+<L:DATABASE_ADVANCES,ADVANCE_PLASMA_WEAPONRY>Armes à plasma<e>
 
 Capacités :
 <L:DATABASE_ORDERS,ORDER_BOMBARD>Bombarder<e>
@@ -6282,6 +6302,8 @@ Après la deuxième guerre mondiale, le double rôle du destroyer (défense anti-aér
 [UNIT_DIPLOMAT_PREREQ]
 Condition :
 <L:DATABASE_ADVANCES,ADVANCE_BUREAUCRACY>Bureaucratie<e>
+Obsolete:
+<L:DATABASE_ADVANCES,ADVANCE_EUGENICS>Thérapie génique<e>
 
 Capacités :
 <L:DATABASE_ORDERS,ORDER_ESTABLISH_EMBASSY>Etablir des ambassades<e>
@@ -6495,6 +6517,8 @@ En avril 1925, Adolf Hitler crée le Schutzstaffeln (en allemand, 'unité de prote
 [UNIT_FIGHTER_PREREQ]
 Condition :
 <L:DATABASE_ADVANCES,ADVANCE_AERODYNAMICS>Aérodynamique<e>
+Obsolete:
+<L:DATABASE_ADVANCES,ADVANCE_SUPERSONIC_FLIGHT>Vol supersonique<e>
 
 Capacités :
 Atterrir sur un <L:DATABASE_UNITS,UNIT_AIRCRAFT_CARRIER>porte-avions<e>
@@ -6530,6 +6554,8 @@ Durant la deuxième guerre mondiale, les chasseurs sont construit entièrement en 
 [UNIT_FIRE_TRIREME_PREREQ]
 Condition :
 <L:DATABASE_ADVANCES,ADVANCE_ALCHEMY>Alchimie<e>
+Obsolete:
+<L:DATABASE_ADVANCES,ADVANCE_MODERN_METALLURGY>Métall. moderne<e>
 [END]
 
 [UNIT_FIRE_TRIREME_STATISTICS]
@@ -6581,6 +6607,8 @@ L'utilisation de conteneurs standard facilite l'acheminement du fret. Un camion 
 [UNIT_FRIGATE_PREREQ]
 Condition :
 <L:DATABASE_ADVANCES,ADVANCE_MASS_PRODUCTION>Production de masse<e> 
+Obsolete:
+<L:DATABASE_ADVANCES,ADVANCE_PLASMA_WEAPONRY>Armes à plasma<e>
 
 Capacités :
 <L:DATABASE_ORDERS,ORDER_BOMBARD>Bombarder<e>
@@ -6649,6 +6677,8 @@ Le char à fusion peut perforer les blindages les plus résistants grâce à son can
 [UNIT_HOPLITE_PREREQ]
 Condition :
 <L:DATABASE_ADVANCES,ADVANCE_BRONZE_WORKING>Travail du bronze<e>
+Obsolete:
+<L:DATABASE_ADVANCES,ADVANCE_GUNPOWDER>Poudre à canon<e>
 [END]
 
 [UNIT_HOPLITE_STATISTICS]
@@ -6705,6 +6735,8 @@ Les applications de la théorie du chaos ont ouvert de nouvelles perspectives dan
 [UNIT_INFANTRYMAN_PREREQ]
 Condition :
 <L:DATABASE_ADVANCES,ADVANCE_GUNPOWDER>Poudre à canon<e>
+Obsolete:
+<L:DATABASE_ADVANCES,ADVANCE_ADV_INFANTRY_TACTICS>Infanterie avanc.<e>
 [END]
 
 [UNIT_INFANTRYMAN_STATISTICS]
@@ -6770,6 +6802,8 @@ La menace de la guerre biologique a pesé lourdement sur la fin du XXe siècle, ma
 [UNIT_INTERCEPTOR_PREREQ]
 Condition :
 <L:DATABASE_ADVANCES,ADVANCE_SUPERSONIC_FLIGHT>Vol supersonique<e>
+Obsolete:
+<L:DATABASE_ADVANCES,ADVANCE_AI_SURVEILLANCE>Surveil. infor.<e>
 
 Capacités :
 <L:DATABASE_CONCEPTS,CONCEPT_ACTIVE_DEFENSE>Défense active anti-aérienne<e>
@@ -6802,6 +6836,8 @@ En raison de leur vitesse et de leur altitude de vol, il devient très compliqué 
 [UNIT_IRONCLAD_PREREQ]
 Condition :
 <L:DATABASE_ADVANCES,ADVANCE_MODERN_METALLURGY>Métallurgie moderne<e>
+Obsolete:
+<L:DATABASE_ADVANCES,ADVANCE_ADV_NAVAL_TACTICS>Tact. nav. avanc.<e>
 
 Capacités :
 <L:DATABASE_ORDERS,ORDER_BOMBARD>Bombarder<e>
@@ -6835,6 +6871,8 @@ Lorsque, au début de la guerre de Sécession, l'Union abandonne la base maritime 
 [UNIT_KNIGHT_PREREQ]
 Condition :
 <L:DATABASE_ADVANCES,ADVANCE_FEUDALISM>Féodalisme<e>
+Obsolete:
+<L:DATABASE_ADVANCES,ADVANCE_INDUSTRIAL_REVOLUTION>Rév. industr.<e>
 
 Capacités :
 <L:DATABASE_CONCEPTS,CONCEPT_SPECIAL_FORCES>Forces spéciales<e>
@@ -6969,6 +7007,8 @@ Conçu par les stratèges militaires pour être le véhicule défensif le plus effica
 [UNIT_LONGSHIP_PREREQ]
 Condition :
 <L:DATABASE_ADVANCES,ADVANCE_HULL_MAKING>Fabrication de coques<e>
+Obsolete:
+<L:DATABASE_ADVANCES,ADVANCE_INTERNAL_COMBUSTION>Combust. interne<e>
 
 Capacités : 
 <L:DATABASE_ORDERS,ORDER_BOARD_TRANSPORT>Transporter<e> jusqu'à 2 unités terrestres
@@ -7000,6 +7040,8 @@ Le drakkar viking est l'un des premiers navires de haute mer doté d'une coque fa
 [UNIT_MACHINE_GUNNER_PREREQ]
 Condition :
 <L:DATABASE_ADVANCES,ADVANCE_INDUSTRIAL_REVOLUTION>Révolution industrielle<e>
+Obsolete:
+<L:DATABASE_ADVANCES,ADVANCE_CHAOS_THEORY>Théorie du chaos<e>
 [END]
 
 [UNIT_MACHINE_GUNNER_STATISTICS]
@@ -7126,6 +7168,8 @@ La première application militaire de cette conception des systèmes organiques a 
 [UNIT_MOUNTED_ARCHER_PREREQ]
 Condition :
 <L:DATABASE_ADVANCES,ADVANCE_HORSE_RIDING>Equitation<e>
+Obsolete:
+<L:DATABASE_ADVANCES,ADVANCE_INDUSTRIAL_REVOLUTION>Rév. industr.<e>
 [END]
 
 [UNIT_MOUNTED_ARCHER_STATISTICS]
@@ -7154,6 +7198,8 @@ Les premières armées de l'Antiquité se servaient de chars pour mener des attaque
 [UNIT_NUCLEAR_SUBMARINE_PREREQ]
 Condition :
 <L:DATABASE_ADVANCES,ADVANCE_NUCLEAR_POWER>Energie nucléaire<e>
+Obsolete:
+<L:DATABASE_ADVANCES,ADVANCE_GENETIC_TAILORING>Génie génétique<e>
 
 Capacités :
 Peut transporter jusqu'à 2 <L:DATABASE_UNITS,UNIT_CRUISE_MISSILE>missiles de croisière<e> ou 2 <L:DATABASE_UNITS,UNIT_NUKE>missiles nucléaires<e>
@@ -7253,6 +7299,8 @@ Au cours de la deuxième guerre mondiale, les forces en présence déploient des un
 [UNIT_PIKEMEN_PREREQ]
 Condition :
 <L:DATABASE_ADVANCES,ADVANCE_AGRICULTURAL_REVOLUTION>Révolution agricole<e>
+Obsolete:
+<L:DATABASE_ADVANCES,ADVANCE_FASCISM>Fascisme<e>
 
 Capacités :
 Bonus défensif contre les unités montées
@@ -7412,6 +7460,8 @@ Aux temps les plus reculés, l'être humain vivait en nomade, allant d'un lieu à l
 [UNIT_SHIP_OF_THE_LINE_PREREQ]
 Condition :
 <L:DATABASE_ADVANCES,ADVANCE_NAVAL_TACTICS>Tactiques navales<e>
+Obsolete:
+<L:DATABASE_ADVANCES,ADVANCE_MASS_PRODUCTION>Prod. de masse<e>
 
 Capacités :
 <L:DATABASE_ORDERS,ORDER_BOMBARD>Bombarder<e>
@@ -7508,6 +7558,8 @@ En 2047, les chercheurs de la NASA lancent le premier véhicule de transport orbi
 [UNIT_SPY_PREREQ]
 Condition :
 <L:DATABASE_ADVANCES,ADVANCE_NATIONALISM>Nationalisme<e>
+Obsolete:
+<L:DATABASE_ADVANCES,ADVANCE_NEURAL_INTERFACE>Interface neurale<e>
 
 Capacités :
 <L:DATABASE_ORDERS,ORDER_INCITE_REVOLUTION>Inciter à la révolution<e>
@@ -7643,6 +7695,8 @@ Mais la technologie furtive a un prix élevé. Le premier chasseur furtif, le F-11
 [UNIT_SUBMARINE_PREREQ]
 Condition :
 <L:DATABASE_ADVANCES,ADVANCE_OIL_REFINING>Raffinage de pétrole<e>
+Obsolete:
+<L:DATABASE_ADVANCES,ADVANCE_NUCLEAR_POWER>Energie nucl.<e>
 
 Capacités :
 Bombarder 
@@ -7675,6 +7729,8 @@ Les premiers sous-marins, conçus et testés par les deux camps de la guerre de Sé
 [UNIT_SWORDSMAN_PREREQ]
 Condition :
 <L:DATABASE_ADVANCES,ADVANCE_IRON_WORKING>Travail du fer<e>
+Obsolete:
+<L:DATABASE_ADVANCES,ADVANCE_INDUSTRIAL_REVOLUTION>Rév. industr.<e>
 
 Capacités :
 <L:DATABASE_CONCEPTS,CONCEPT_SPECIAL_FORCES>Forces spéciales<e>
@@ -7706,6 +7762,8 @@ Les samouraïs forment une caste de guerriers qui agit pendant l'époque féodale d
 [UNIT_TANK_PREREQ]
 Condition :
 <L:DATABASE_ADVANCES,ADVANCE_TANK_WARFARE>Guerre de blindés<e>
+Obsolete:
+<L:DATABASE_ADVANCES,ADVANCE_UNIFIED_PHYSICS>Physique unifiée<e>
 [END]
 
 [UNIT_TANK_STATISTICS]
@@ -7841,6 +7899,8 @@ Vers le milieu du XXe siècle, les urbanistes expérimentent de nouveaux concepts 
 [UNIT_WARRIOR_PREREQ]
 Condition :
 <L:DATABASE_ADVANCES,ADVANCE_TOOLMAKING>Fabrication d'outils<e>
+Obsolete:
+<L:DATABASE_ADVANCES,ADVANCE_GUNPOWDER>Poudre à canon<e>
 [END]
 
 [UNIT_WARRIOR_STATISTICS]
@@ -9449,6 +9509,8 @@ A player may want to upgrade a unit for a variety of reasons.  Older and obsolet
 [UNIT_LONGBOWMAN_PREREQ]
 Requires:
 <L:DATABASE_ADVANCES,ADVANCE_FEUDALISM><e>
+Obsolete:
+<L:DATABASE_ADVANCES,ADVANCE_CANNON_MAKING>Fabric. canons<e>
 [END]
 
 [UNIT_LONGBOWMAN_STATISTICS]

--- a/ctp2_data/french/gamedata/Great_Library.txt
+++ b/ctp2_data/french/gamedata/Great_Library.txt
@@ -6063,7 +6063,7 @@ La catapulte est l'une des armes de siège les plus efficaces de l'Antiquité et d
 Condition :
 <L:DATABASE_ADVANCES,ADVANCE_CAVALRY_TACTICS>Tactiques de cavalerie<e>
 Obsolete:
-<L:DATABASE_ADVANCES,ADVANCE_FUSION>Fusion<e>
+<L:DATABASE_ADVANCES,ADVANCE_TANK_WARFARE>Guerre blindés<e>
 [END]
 
 [UNIT_CAVALRY_STATISTICS]
@@ -7763,7 +7763,7 @@ Les samouraïs forment une caste de guerriers qui agit pendant l'époque féodale d
 Condition :
 <L:DATABASE_ADVANCES,ADVANCE_TANK_WARFARE>Guerre de blindés<e>
 Obsolete:
-<L:DATABASE_ADVANCES,ADVANCE_UNIFIED_PHYSICS>Physique unifiée<e>
+<L:DATABASE_ADVANCES,ADVANCE_FUSION>Fusion<e>
 [END]
 
 [UNIT_TANK_STATISTICS]

--- a/ctp2_data/german/gamedata/Great_Library.txt
+++ b/ctp2_data/german/gamedata/Great_Library.txt
@@ -7155,6 +7155,8 @@ Zu Beginn des 2. Weltkrieges besaßen die Tauch- und Torpedobomber, die von Flugz
 [UNIT_ARCHER_PREREQ]
 Voraussetzung:
 <L:DATABASE_ADVANCES,ADVANCE_BALLISTICS>Ballistik<e>
+Veraltet mit:
+<L:DATABASE_ADVANCES,ADVANCE_CANNON_MAKING>Kanonenbau<e>
 [END]
 
 [UNIT_ARCHER_STATISTICS]
@@ -7259,6 +7261,8 @@ Der 2. Weltkrieg sollte die Blütezeit des Schlachtschiffs werden, als das 1922 g
 [UNIT_BOMBER_PREREQ]
 Voraussetzung:
 <L:DATABASE_ADVANCES,ADVANCE_JET_PROPULSION>Düsenantrieb<e>
+Veraltet mit:
+<L:DATABASE_ADVANCES,ADVANCE_ADVANCED_COMPOSITES>Neue Kunststoffe<e>
 
 Fähigkeiten: 
 Transport von 1 <L:DATABASE_UNITS,UNIT_NUKE>Nuklearrakete<e> oder <L:DATABASE_UNITS,UNIT_CRUISE_MISSILE>Cruisemissile<e>
@@ -7297,6 +7301,8 @@ Obwohl sich propellerbetriebene Bomber im 2. Weltkrieg vielfach als sehr nützlic
 [UNIT_CANNON_PREREQ]
 Voraussetzung:
 <L:DATABASE_ADVANCES,ADVANCE_CANNON_MAKING>Kanonenbau<e>
+Veraltet mit:
+<L:DATABASE_ADVANCES,ADVANCE_CYBERNETICS>Kybernetik<e>
 
 Fähigkeit:
 <L:DATABASE_ORDERS,ORDER_BOMBARD>Bombardierung<e>
@@ -7332,6 +7338,8 @@ So wie das Schießpulver im 16. Jahrhundert die Infanterie- und Nahkampftaktiken 
 [UNIT_CARAVAN_PREREQ]
 Voraussetzung:
 <L:DATABASE_ADVANCES,ADVANCE_TRADE>Handel<e>
+Veraltet mit:
+<L:DATABASE_ADVANCES,ADVANCE_GLOBAL_ECONOMICS>Weltwirtschaft<e>
 
 Kosten:
 {UnitDB(UnitRecord[0]).ShieldCost} <L:DATABASE_CONCEPTS,CONCEPT_PRODUCTION>Produktion<e>
@@ -7388,6 +7396,8 @@ Militärhubschrauber waren in erster Linie zur Durchführung von Bodenangriffen ko
 [UNIT_CARRACK_PREREQ]
 Voraussetzung:
 <L:DATABASE_ADVANCES,ADVANCE_OCEAN_FARING>Seefahrt<e>
+Veraltet mit:
+<L:DATABASE_ADVANCES,ADVANCE_INTERNAL_COMBUSTION>Verbr.-Motor<e>
 
 Fähigkeit:
 <L:DATABASE_ORDERS,ORDER_BOARD_TRANSPORT>Transport<e> von maximal 3 Bodeneinheiten 
@@ -7425,6 +7435,8 @@ Ihre hohen Achteraufbauten gewährleisteten eine gute Verteidigung. Darüber hinau
 [UNIT_CATAMARAN_PREREQ]
 Voraussetzung:
 <L:DATABASE_ADVANCES,ADVANCE_SHIP_BUILDING>Schiffbau<e>
+Veraltet mit:
+<L:DATABASE_ADVANCES,ADVANCE_HULL_MAKING>Schiffskonstr.<e>
 
 Fähigkeit:
 <L:DATABASE_ORDERS,ORDER_BOARD_TRANSPORT>Transport<e> von maximal 1 Bodeneinheit 
@@ -7460,6 +7472,8 @@ Die Korvette wurde im Altertum vorrangig in Wales und Irland benutzt. Manche die
 [UNIT_CATAPULT_PREREQ]
 Voraussetzung:
 <L:DATABASE_ADVANCES,ADVANCE_GEOMETRY>Geometrie<e>
+Veraltet mit:
+<L:DATABASE_ADVANCES,ADVANCE_EXPLOSIVES>Sprengstoff<e>
 
 Fähigkeit:
 <L:DATABASE_ORDERS,ORDER_BOMBARD>Bombardierung<e>
@@ -7495,6 +7509,8 @@ Das Katapult gehörte zu den effizientesten Belagerungswaffen der Antike und des 
 [UNIT_CAVALRY_PREREQ]
 Voraussetzung:
 <L:DATABASE_ADVANCES,ADVANCE_CAVALRY_TACTICS>Kavallerietaktiken<e>
+Veraltet mit:
+<L:DATABASE_ADVANCES,ADVANCE_FUSION>Kernfusion<e>
 [END]
 
 [UNIT_CAVALRY_STATISTICS]
@@ -7527,6 +7543,8 @@ Die Entwicklung des Schießpulvers und der panzerdurchschlagenden Patronen im frü
 [UNIT_CLERIC_PREREQ]
 Voraussetzung:
 <L:DATABASE_ADVANCES,ADVANCE_THEOLOGY>Theologie<e>
+Veraltet mit:
+<L:DATABASE_ADVANCES,ADVANCE_MASS_MEDIA>Massenmedien<e>
 
 Fähigkeiten:
 <L:DATABASE_ORDERS,ORDER_CONVERT>Glaubenswechsel<e>
@@ -7722,6 +7740,8 @@ Nachdem das Militär eine interne neurale Schnittstelle entwickelt hatte, wurden 
 [UNIT_DESTROYER_PREREQ]
 Voraussetzung:
 <L:DATABASE_ADVANCES,ADVANCE_MASS_PRODUCTION>Massenproduktion<e>
+Veraltet mit:
+<L:DATABASE_ADVANCES,ADVANCE_PLASMA_WEAPONRY>Plasmawaffen<e>
 
 Fähigkeiten:
 <L:DATABASE_ORDERS,ORDER_BOMBARD>Bombardierung<e> von Land- und Marineeinheiten
@@ -7761,6 +7781,8 @@ Nach dem 2. Weltkrieg wurde die Doppelrolle des Zerstörers als Flug- und U-Boot-
 [UNIT_DIPLOMAT_PREREQ]
 Voraussetzung:
 <L:DATABASE_ADVANCES,ADVANCE_BUREAUCRACY>Bürokratie<e>
+Veraltet mit:
+<L:DATABASE_ADVANCES,ADVANCE_EUGENICS>Gentherapie<e>
 
 Fähigkeiten:
 <L:DATABASE_ORDERS,ORDER_ESTABLISH_EMBASSY>Botschaft errichten<e>
@@ -8002,6 +8024,8 @@ Im April 1925 formierte Adolf Hitler im Rahmen der Neugründung der NSDAP die Sch
 [UNIT_FIGHTER_PREREQ]
 Voraussetzung:
 <L:DATABASE_ADVANCES,ADVANCE_AERODYNAMICS>Aerodynamik<e>
+Veraltet mit:
+<L:DATABASE_ADVANCES,ADVANCE_SUPERSONIC_FLIGHT>Überschallflüge<e>
 
 Fähigkeit:
 Landung auf <L:DATABASE_UNITS,UNIT_AIRCRAFT_CARRIER>Flugzeugträgern<e>
@@ -8042,6 +8066,8 @@ Während des 2. Weltkrieges konnten die metallenen Jagdflieger mit Propellerantri
 [UNIT_FIRE_TRIREME_PREREQ]
 Voraussetzung:
 <L:DATABASE_ADVANCES,ADVANCE_ALCHEMY>Alchimie<e>
+Veraltet mit:
+<L:DATABASE_ADVANCES,ADVANCE_MODERN_METALLURGY>Mod. Metallurgie<e>
 [END]
 
 [UNIT_FIRE_TRIREME_STATISTICS]
@@ -8097,6 +8123,8 @@ Auch die Einführung internationaler Normgrößen für Container trug zur verbessert
 [UNIT_FRIGATE_PREREQ]
 Voraussetzung:
 <L:DATABASE_ADVANCES,ADVANCE_MASS_PRODUCTION>Massenproduktion<e> 
+Veraltet mit:
+<L:DATABASE_ADVANCES,ADVANCE_PLASMA_WEAPONRY>Plasmawaffen<e>
 
 Fähigkeiten:
 <L:DATABASE_ORDERS,ORDER_BOMBARD>Bombardierung<e>
@@ -8173,6 +8201,8 @@ Der Fusionspanzer war in der Lage, mit seiner Hightech-Laserpulskanone selbst sc
 [UNIT_HOPLITE_PREREQ]
 Voraussetzung:
 <L:DATABASE_ADVANCES,ADVANCE_BRONZE_WORKING>Bronzeverarbeitung<e>
+Veraltet mit:
+<L:DATABASE_ADVANCES,ADVANCE_GUNPOWDER>Schießpulver<e>
 [END]
 
 [UNIT_HOPLITE_STATISTICS]
@@ -8237,6 +8267,8 @@ Neue Anwendungsmethoden der Chaostheorie eröffneten ungeahnte physikalische Mögl
 [UNIT_INFANTRYMAN_PREREQ]
 Voraussetzung:
 <L:DATABASE_ADVANCES,ADVANCE_GUNPOWDER>Schießpulver<e>
+Veraltet mit:
+<L:DATABASE_ADVANCES,ADVANCE_ADV_INFANTRY_TACTICS>Geh. Infanteriet.<e>
 [END]
 
 [UNIT_INFANTRYMAN_STATISTICS]
@@ -8309,6 +8341,8 @@ Während die biologische Kriegsführung bereits im späten 20. Jahrhundert eine stä
 [UNIT_INTERCEPTOR_PREREQ]
 Voraussetzung:
 <L:DATABASE_ADVANCES,ADVANCE_SUPERSONIC_FLIGHT>Überschallflüge<e>
+Veraltet mit:
+<L:DATABASE_ADVANCES,ADVANCE_AI_SURVEILLANCE>KI-Überwachung<e>
 
 Fähigkeit:
 <L:DATABASE_CONCEPTS,CONCEPT_ACTIVE_DEFENSE>Aktive Flugabwehr<e>
@@ -8347,6 +8381,8 @@ Die extrem hohen Geschwindigkeiten und Flughöhen des Abfangjägers erschwerten di
 [UNIT_IRONCLAD_PREREQ]
 Voraussetzung:
 <L:DATABASE_ADVANCES,ADVANCE_MODERN_METALLURGY>Moderne Metallurgie<e>
+Veraltet mit:
+<L:DATABASE_ADVANCES,ADVANCE_ADV_NAVAL_TACTICS>Geh. Marinetakt.<e>
 
 Fähigkeit:
 <L:DATABASE_ORDERS,ORDER_BOMBARD>Bombardierung<e>
@@ -8384,6 +8420,8 @@ Nachdem die Unionstruppen zu Beginn des Bürgerkrieges den Norfolk-Marinehafen in
 [UNIT_KNIGHT_PREREQ]
 Voraussetzung:
 <L:DATABASE_ADVANCES,ADVANCE_FEUDALISM>Feudalismus<e>
+Veraltet mit:
+<L:DATABASE_ADVANCES,ADVANCE_INDUSTRIAL_REVOLUTION>Ind. Revolution<e>
 
 Fähigkeit:
 <L:DATABASE_CONCEPTS,CONCEPT_SPECIAL_FORCES>Spezialeinheit<e>
@@ -8534,6 +8572,8 @@ Von Militärstrategen als das effizienteste Verteidigungsfahrzeug der Geschichte 
 [UNIT_LONGSHIP_PREREQ]
 Voraussetzung:
 <L:DATABASE_ADVANCES,ADVANCE_HULL_MAKING>Schiffskonstruktion<e>
+Veraltet mit:
+<L:DATABASE_ADVANCES,ADVANCE_INTERNAL_COMBUSTION>Verbr.-Motor<e>
 
 Fähigkeit: 
 <L:DATABASE_ORDERS,ORDER_BOARD_TRANSPORT>Transport<e> von maximal 2 Bodeneinheiten 
@@ -8569,6 +8609,8 @@ Das Wikinger-Langschiff war eins der ersten Seefahrzeuge, die einen klinkerbepla
 [UNIT_MACHINE_GUNNER_PREREQ]
 Voraussetzung:
 <L:DATABASE_ADVANCES,ADVANCE_INDUSTRIAL_REVOLUTION>Industrielle Revolution<e>
+Veraltet mit:
+<L:DATABASE_ADVANCES,ADVANCE_CHAOS_THEORY>Chaostheorie<e>
 [END]
 
 [UNIT_MACHINE_GUNNER_STATISTICS]
@@ -8710,6 +8752,8 @@ Der Muränengleiter, ein unter strenger Geheimhaltung gebautes Stealth-Unterwasse
 [UNIT_MOUNTED_ARCHER_PREREQ]
 Voraussetzung:
 <L:DATABASE_ADVANCES,ADVANCE_HORSE_RIDING>Rittertum<e>
+Veraltet mit:
+<L:DATABASE_ADVANCES,ADVANCE_INDUSTRIAL_REVOLUTION>Ind. Revolution<e>
 [END]
 
 [UNIT_MOUNTED_ARCHER_STATISTICS]
@@ -8742,6 +8786,8 @@ Um schnelle Angriffe ausführen zu können, setzten die frühen Kampftruppen der An
 [UNIT_NUCLEAR_SUBMARINE_PREREQ]
 Voraussetzung:
 <L:DATABASE_ADVANCES,ADVANCE_NUCLEAR_POWER>Atomenergie<e>
+Veraltet mit:
+<L:DATABASE_ADVANCES,ADVANCE_GENETIC_TAILORING>Genmanipulation<e>
 
 Fähigkeit:
 Transport von maximal 2 <L:DATABASE_UNITS,UNIT_CRUISE_MISSILE>Cruisemissiles<e> oder <L:DATABASE_UNITS,UNIT_NUKE>Nuklearraketen<e>
@@ -8854,6 +8900,8 @@ Während des 2. Weltkrieges gingen die Streitkräfte erstmals dazu über, mit Falls
 [UNIT_PIKEMEN_PREREQ]
 Voraussetzung:
 <L:DATABASE_ADVANCES,ADVANCE_AGRICULTURAL_REVOLUTION>Landwirtschaftliche Revolution<e>
+Veraltet mit:
+<L:DATABASE_ADVANCES,ADVANCE_FASCISM>Faschismus<e>
 
 Abilities:
 Defensivbonus gegen berittene Einheiten
@@ -9031,6 +9079,8 @@ Seit der Frühzeit lebten die Menschen oft als Nomaden, die auf der Suche nach Na
 [UNIT_SHIP_OF_THE_LINE_PREREQ]
 Voraussetzung:
 <L:DATABASE_ADVANCES,ADVANCE_NAVAL_TACTICS>Marinetaktiken<e>
+Veraltet mit:
+<L:DATABASE_ADVANCES,ADVANCE_MASS_PRODUCTION>Massenproduktion<e>
 
 Fähigkeit:
 <L:DATABASE_ORDERS,ORDER_BOMBARD>Bombardierung<e>
@@ -9140,6 +9190,8 @@ Im Jahre 2047 starteten die Wissenschaftler der Nationalen Luft- und Raumfahrtbe
 [UNIT_SPY_PREREQ]
 Voraussetzung:
 <L:DATABASE_ADVANCES,ADVANCE_NATIONALISM>Nationalismus<e>
+Veraltet mit:
+<L:DATABASE_ADVANCES,ADVANCE_NEURAL_INTERFACE>Neur. Schnittst.<e>
 
 Fähigkeiten:
 <L:DATABASE_ORDERS,ORDER_INCITE_REVOLUTION>Revolution auslösen<e>
@@ -9293,6 +9345,8 @@ Die Stealth-Technologie ist jedoch nicht ganz billig. Der erste Stealth-Fighter 
 [UNIT_SUBMARINE_PREREQ]
 Voraussetzung:
 <L:DATABASE_ADVANCES,ADVANCE_OIL_REFINING>Ölraffination<e>
+Veraltet mit:
+<L:DATABASE_ADVANCES,ADVANCE_NUCLEAR_POWER>Atomenergie<e>
 
 Fähigkeit:
 <L:DATABASE_ORDERS,ORDER_BOMBARD>Bombardierung<e>
@@ -9328,6 +9382,8 @@ Die ersten U-Boote, die von beiden am amerikanischen Bürgerkrieg beteiligten Mar
 [UNIT_SWORDSMAN_PREREQ]
 Voraussetzung:
 <L:DATABASE_ADVANCES,ADVANCE_IRON_WORKING>Eisenverarbeitung<e>
+Veraltet mit:
+<L:DATABASE_ADVANCES,ADVANCE_INDUSTRIAL_REVOLUTION>Ind. Revolution<e>
 
 Fähigkeit:
 <L:DATABASE_CONCEPTS,CONCEPT_SPECIAL_FORCES>Spezialeinheit<e>
@@ -9363,6 +9419,8 @@ Die Samurai gehörten im feudalen Japan des 12. Jahrhunderts bis etwa 1871 dem pr
 [UNIT_TANK_PREREQ]
 Voraussetzung:
 <L:DATABASE_ADVANCES,ADVANCE_TANK_WARFARE>Panzereinsatz<e>
+Veraltet mit:
+<L:DATABASE_ADVANCES,ADVANCE_UNIFIED_PHYSICS>Ganzheitstheorie<e>
 [END]
 
 [UNIT_TANK_STATISTICS]
@@ -9510,6 +9568,8 @@ Mitte des 20. Jahrhunderts experimentierten die Stadtplaner mit neuen Planungsko
 [UNIT_WARRIOR_PREREQ]
 Voraussetzung:
 <L:DATABASE_ADVANCES,ADVANCE_TOOLMAKING>Werkzeugbau<e>
+Veraltet mit:
+<L:DATABASE_ADVANCES,ADVANCE_GUNPOWDER>Schießpulver<e>
 [END]
 
 [UNIT_WARRIOR_STATISTICS]
@@ -11086,6 +11146,8 @@ Im späten 20. Jahrhundert war die Gesellschaft der westlichen Welt regelrecht pr
 [UNIT_LONGBOWMAN_PREREQ]
 Requires:
 <L:DATABASE_ADVANCES,ADVANCE_FEUDALISM><e>
+Veraltet mit:
+<L:DATABASE_ADVANCES,ADVANCE_CANNON_MAKING>Kanonenbau<e>
 [END]
 
 [UNIT_LONGBOWMAN_STATISTICS]

--- a/ctp2_data/german/gamedata/Great_Library.txt
+++ b/ctp2_data/german/gamedata/Great_Library.txt
@@ -7510,7 +7510,7 @@ Das Katapult gehörte zu den effizientesten Belagerungswaffen der Antike und des 
 Voraussetzung:
 <L:DATABASE_ADVANCES,ADVANCE_CAVALRY_TACTICS>Kavallerietaktiken<e>
 Veraltet mit:
-<L:DATABASE_ADVANCES,ADVANCE_FUSION>Kernfusion<e>
+<L:DATABASE_ADVANCES,ADVANCE_TANK_WARFARE>Panzereinsatz<e>
 [END]
 
 [UNIT_CAVALRY_STATISTICS]
@@ -9420,7 +9420,7 @@ Die Samurai gehörten im feudalen Japan des 12. Jahrhunderts bis etwa 1871 dem pr
 Voraussetzung:
 <L:DATABASE_ADVANCES,ADVANCE_TANK_WARFARE>Panzereinsatz<e>
 Veraltet mit:
-<L:DATABASE_ADVANCES,ADVANCE_UNIFIED_PHYSICS>Ganzheitstheorie<e>
+<L:DATABASE_ADVANCES,ADVANCE_FUSION>Kernfusion<e>
 [END]
 
 [UNIT_TANK_STATISTICS]

--- a/ctp2_data/italian/gamedata/Great_Library.txt
+++ b/ctp2_data/italian/gamedata/Great_Library.txt
@@ -6010,7 +6010,7 @@ La catapulta era una delle più efficaci armi da assedio utilizzate nei conflitti
 Richiede:
 <L:DATABASE_ADVANCES,ADVANCE_CAVALRY_TACTICS>Tattiche di cavalleria<e>
 Obsolete:
-<L:DATABASE_ADVANCES,ADVANCE_FUSION>Fusione nucleare<e>
+<L:DATABASE_ADVANCES,ADVANCE_TANK_WARFARE>Guerra coi carri armati<e>
 [END]
 
 [UNIT_CAVALRY_STATISTICS]
@@ -7668,7 +7668,7 @@ I samurai erano la classe di guerrieri dell'età feudale giapponese, attivi dal X
 Richiede:
 <L:DATABASE_ADVANCES,ADVANCE_TANK_WARFARE>Guerra coi carri armati<e>
 Obsolete:
-<L:DATABASE_ADVANCES,ADVANCE_UNIFIED_PHYSICS>Fisica unitaria<e>
+<L:DATABASE_ADVANCES,ADVANCE_FUSION>Fusione nucleare<e>
 [END]
 
 [UNIT_TANK_STATISTICS]

--- a/ctp2_data/italian/gamedata/Great_Library.txt
+++ b/ctp2_data/italian/gamedata/Great_Library.txt
@@ -5690,6 +5690,8 @@ All'inizio della Seconda Guerra Mondiale, gli attacchi sferrati con bombe o silu
 [UNIT_ARCHER_PREREQ]
 Richiede:
 <L:DATABASE_ADVANCES,ADVANCE_BALLISTICS>Balistica<e>
+Obsolete:
+<L:DATABASE_ADVANCES,ADVANCE_CANNON_MAKING>Fabbricazione di cannoni<e>
 [END]
 
 [UNIT_ARCHER_STATISTICS]
@@ -5779,6 +5781,8 @@ La Seconda Guerra Mondiale rappresentò l'apogeo della corazzata, allorché il Tra
 [UNIT_BOMBER_PREREQ]
 Richiede:
 <L:DATABASE_ADVANCES,ADVANCE_JET_PROPULSION>Propulsione a reazione<e>
+Obsolete:
+<L:DATABASE_ADVANCES,ADVANCE_ADVANCED_COMPOSITES>Materiali compositi av.<e>
 
 Abilità:
 Può trasportare una <L:DATABASE_UNITS,UNIT_NUKE>bomba atomica<e> o un <L:DATABASE_UNITS,UNIT_CRUISE_MISSILE>missile da crociera<e>
@@ -5811,6 +5815,8 @@ Nonostante i bombardieri a elica avessero più volte dato prova delle proprie pot
 [UNIT_CANNON_PREREQ]
 Richiede:
 <L:DATABASE_ADVANCES,ADVANCE_CANNON_MAKING>Fabbricazione di cannoni<e>
+Obsolete:
+<L:DATABASE_ADVANCES,ADVANCE_CYBERNETICS>Cibernetica<e>
 
 Abilità:
 <L:DATABASE_ORDERS,ORDER_BOMBARD>Bombarda<e>
@@ -5841,6 +5847,8 @@ Dopo aver rivoluzionato il mondo della fanteria e degli scontri ravvicinati nel 
 [UNIT_CARAVAN_PREREQ]
 Richiede:
 <L:DATABASE_ADVANCES,ADVANCE_TRADE>Commercio<e>
+Obsolete:
+<L:DATABASE_ADVANCES,ADVANCE_GLOBAL_ECONOMICS>Economia globale<e>
 
 Costa:
 {UnitDB(UnitRecord[0]).ShieldCost} <L:DATABASE_CONCEPTS,CONCEPT_PRODUCTION>produzione<e>
@@ -5902,6 +5910,8 @@ Nonostante alcuni elicotteri militari fossero stati progettati principalmente pe
 [UNIT_CARRACK_PREREQ]
 Richiede:
 <L:DATABASE_ADVANCES,ADVANCE_OCEAN_FARING>Navigazione oceanica<e>
+Obsolete:
+<L:DATABASE_ADVANCES,ADVANCE_INTERNAL_COMBUSTION>Combustione interna<e>
 
 Abilità:
 È in grado di <L:DATABASE_ORDERS,ORDER_BOARD_TRANSPORT>imbarcare<e> fino a tre unità terrestri
@@ -5935,6 +5945,8 @@ Due delle più famose caracche furono la Santa Maria, una delle leggendarie navi 
 [UNIT_CATAMARAN_PREREQ]
 Richiede:
 <L:DATABASE_ADVANCES,ADVANCE_SHIP_BUILDING>Costruzioni navali<e>
+Obsolete:
+<L:DATABASE_ADVANCES,ADVANCE_HULL_MAKING>Fabbricazione di navi<e>
 
 Abilità:
 È in grado di <L:DATABASE_ORDERS,ORDER_BOARD_TRANSPORT>imbarcare<e> un'unità di terra
@@ -5965,6 +5977,8 @@ Le barche di vimini fanno la loro prima comparsa in Galles e in Irlanda. Alcune 
 [UNIT_CATAPULT_PREREQ]
 Richiede:
 <L:DATABASE_ADVANCES,ADVANCE_GEOMETRY>Geometria<e>
+Obsolete:
+<L:DATABASE_ADVANCES,ADVANCE_EXPLOSIVES>Esplosivi<e>
 
 Abilità:
 <L:DATABASE_ORDERS,ORDER_BOMBARD>Bombarda<e>
@@ -5995,6 +6009,8 @@ La catapulta era una delle più efficaci armi da assedio utilizzate nei conflitti
 [UNIT_CAVALRY_PREREQ]
 Richiede:
 <L:DATABASE_ADVANCES,ADVANCE_CAVALRY_TACTICS>Tattiche di cavalleria<e>
+Obsolete:
+<L:DATABASE_ADVANCES,ADVANCE_FUSION>Fusione nucleare<e>
 [END]
 
 [UNIT_CAVALRY_STATISTICS]
@@ -6022,6 +6038,8 @@ All'inizio del XIV secolo, lo sviluppo della polvere da sparo e dei proiettili i
 [UNIT_CLERIC_PREREQ]
 Richiede:
 <L:DATABASE_ADVANCES,ADVANCE_THEOLOGY>Teologia<e>
+Obsolete:
+<L:DATABASE_ADVANCES,ADVANCE_MASS_MEDIA>Comunicazione di massa<e>
 
 Abilità:
 <L:DATABASE_ORDERS,ORDER_CONVERT>Converte le città<e>
@@ -6191,6 +6209,8 @@ Una volta sviluppata un'interfaccia neurale interna, i militari iniziarono a tes
 [UNIT_DESTROYER_PREREQ]
 Richiede:
 <L:DATABASE_ADVANCES,ADVANCE_MASS_PRODUCTION>Produzione di massa<e>
+Obsolete:
+<L:DATABASE_ADVANCES,ADVANCE_PLASMA_WEAPONRY>Armi al plasma<e>
 
 Abilità:
 <L:DATABASE_ORDERS,ORDER_BOMBARD>Bombarda<e>
@@ -6225,6 +6245,8 @@ Dopo la Seconda Guerra Mondiale, il doppio ruolo, anti-aerei e anti-sottomarini,
 [UNIT_DIPLOMAT_PREREQ]
 Richiede:
 <L:DATABASE_ADVANCES,ADVANCE_BUREAUCRACY>Burocrazia<e>
+Obsolete:
+<L:DATABASE_ADVANCES,ADVANCE_EUGENICS>Eugenetica<e>
 
 Abilità:
 <L:DATABASE_ORDERS,ORDER_ESTABLISH_EMBASSY>Fonda ambasciate<e>
@@ -6429,6 +6451,8 @@ Nell'aprile del 1925, Adolf Hitler creò le Schutzstaffel (che in tedesco signifi
 [UNIT_FIGHTER_PREREQ]
 Richiede:
 <L:DATABASE_ADVANCES,ADVANCE_AERODYNAMICS>Aerodinamica<e>
+Obsolete:
+<L:DATABASE_ADVANCES,ADVANCE_SUPERSONIC_FLIGHT>Volo supersonico<e>
 
 Abilità:
 Atterra sulle <L:DATABASE_UNITS,UNIT_AIRCRAFT_CARRIER>Portaerei<e>
@@ -6463,6 +6487,8 @@ Durante la Seconda Guerra Mondiale, i caccia completamente in metallo, sospinti 
 [UNIT_FIRE_TRIREME_PREREQ]
 Richiede:
 <L:DATABASE_ADVANCES,ADVANCE_ALCHEMY>Alchimia<e>
+Obsolete:
+<L:DATABASE_ADVANCES,ADVANCE_MODERN_METALLURGY>Metallurgia moderna<e>
 [END]
 
 [UNIT_FIRE_TRIREME_STATISTICS]
@@ -6513,6 +6539,8 @@ I container di dimensioni standard resero la spedizione ancor più facile, potend
 [UNIT_FRIGATE_PREREQ]
 Richiede:
 <L:DATABASE_ADVANCES,ADVANCE_MASS_PRODUCTION>Produzione di massa<e> 
+Obsolete:
+<L:DATABASE_ADVANCES,ADVANCE_PLASMA_WEAPONRY>Armi al plasma<e>
 
 Abilità:
 <L:DATABASE_ORDERS,ORDER_BOMBARD>Bombarda<e>
@@ -6579,6 +6607,8 @@ Il carro armato a fusione era in grado di penetrare obiettivi pesantemente coraz
 [UNIT_HOPLITE_PREREQ]
 Richiede:
 <L:DATABASE_ADVANCES,ADVANCE_BRONZE_WORKING>Lavorazione del bronzo<e>
+Obsolete:
+<L:DATABASE_ADVANCES,ADVANCE_GUNPOWDER>Polvere da sparo<e>
 [END]
 
 [UNIT_HOPLITE_STATISTICS]
@@ -6633,6 +6663,8 @@ Lo sviluppo delle applicazioni della teoria del caos aprì nuove frontiere nello 
 [UNIT_INFANTRYMAN_PREREQ]
 Richiede:
 <L:DATABASE_ADVANCES,ADVANCE_GUNPOWDER>Polvere da sparo<e>
+Obsolete:
+<L:DATABASE_ADVANCES,ADVANCE_ADV_INFANTRY_TACTICS>Tattiche av. fanteria<e>
 [END]
 
 [UNIT_INFANTRYMAN_STATISTICS]
@@ -6698,6 +6730,8 @@ Sebbene la guerra biologica fosse un vero e proprio spauracchio alla fine del XX
 [UNIT_INTERCEPTOR_PREREQ]
 Richiede:
 <L:DATABASE_ADVANCES,ADVANCE_SUPERSONIC_FLIGHT>Volo supersonico<e>
+Obsolete:
+<L:DATABASE_ADVANCES,ADVANCE_AI_SURVEILLANCE>Sorveglianza con IA<e>
 
 Abilità:
 <L:DATABASE_CONCEPTS,CONCEPT_ACTIVE_DEFENSE>Difesa attiva<e>
@@ -6730,6 +6764,8 @@ Le velocità estreme e l'altitudine operativa dell'intercettore rendevano il punt
 [UNIT_IRONCLAD_PREREQ]
 Richiede:
 <L:DATABASE_ADVANCES,ADVANCE_MODERN_METALLURGY>Metallurgia moderna<e>
+Obsolete:
+<L:DATABASE_ADVANCES,ADVANCE_ADV_NAVAL_TACTICS>Tattiche navali avanzate<e>
 
 Abilità:
 <L:DATABASE_ORDERS,ORDER_BOMBARD>Bombarda<e>
@@ -6762,6 +6798,8 @@ Quando, all'inizio della Guerra Civile, gli Unionisti lasciarono il cantiere nav
 [UNIT_KNIGHT_PREREQ]
 Richiede:
 <L:DATABASE_ADVANCES,ADVANCE_FEUDALISM>Feudalesimo<e>
+Obsolete:
+<L:DATABASE_ADVANCES,ADVANCE_INDUSTRIAL_REVOLUTION>Rivoluzione industriale<e>
 
 Abilità:
 <L:DATABASE_CONCEPTS,CONCEPT_SPECIAL_FORCES>Forze speciali<e>
@@ -6892,6 +6930,8 @@ Concepita dagli strateghi militari come la più efficace arma difensiva della sto
 [UNIT_LONGSHIP_PREREQ]
 Richiede:
 <L:DATABASE_ADVANCES,ADVANCE_HULL_MAKING>Fabbricazione di navi<e>
+Obsolete:
+<L:DATABASE_ADVANCES,ADVANCE_INTERNAL_COMBUSTION>Combustione interna<e>
 
 Abilità: 
 Può <L:DATABASE_ORDERS,ORDER_BOARD_TRANSPORT>imbarcare<e> fino a 2 unità terrestri
@@ -6922,6 +6962,8 @@ Il drakkar vichingo fu una delle prime unità navali a impiegare uno scafo a fasc
 [UNIT_MACHINE_GUNNER_PREREQ]
 Richiede:
 <L:DATABASE_ADVANCES,ADVANCE_INDUSTRIAL_REVOLUTION>Rivoluzione industriale<e>
+Obsolete:
+<L:DATABASE_ADVANCES,ADVANCE_CHAOS_THEORY>Teoria del caos<e>
 [END]
 
 [UNIT_MACHINE_GUNNER_STATISTICS]
@@ -7043,6 +7085,8 @@ La prima applicazione militare della progettazione dei sistemi organici culminò 
 [UNIT_MOUNTED_ARCHER_PREREQ]
 Richiede:
 <L:DATABASE_ADVANCES,ADVANCE_HORSE_RIDING>Equitazione<e>
+Obsolete:
+<L:DATABASE_ADVANCES,ADVANCE_INDUSTRIAL_REVOLUTION>Rivoluzione industriale<e>
 [END]
 
 [UNIT_MOUNTED_ARCHER_STATISTICS]
@@ -7070,6 +7114,8 @@ Le prime armate dell'età antica utilizzavano le bighe per sferrare attacchi molt
 [UNIT_NUCLEAR_SUBMARINE_PREREQ]
 Richiede:
 <L:DATABASE_ADVANCES,ADVANCE_NUCLEAR_POWER>Energia nucleare<e>
+Obsolete:
+<L:DATABASE_ADVANCES,ADVANCE_GENETIC_TAILORING>Ingegneria genetica<e>
 
 Abilità:
 Può trasportare fino a 2 <L:DATABASE_UNITS,UNIT_CRUISE_MISSILE>missili da crociera<e> o <L:DATABASE_UNITS,UNIT_NUKE>bombe atomiche<e>
@@ -7172,6 +7218,8 @@ Durante la Seconda Guerra Mondiale, gli eserciti approntarono delle forze di fan
 [UNIT_PIKEMEN_PREREQ]
 Richiede:
 <L:DATABASE_ADVANCES,ADVANCE_FEUDALISM>Feudalesimo<e>
+Obsolete:
+<L:DATABASE_ADVANCES,ADVANCE_FASCISM>Fascismo<e>
 
 Abilità:
 Bonus difensivo contro le unità a cavallo
@@ -7326,6 +7374,8 @@ Fin dalla preistoria gli uomini conducevano un'esistenza nomade, spostandosi di 
 [UNIT_SHIP_OF_THE_LINE_PREREQ]
 Richiede:
 <L:DATABASE_ADVANCES,ADVANCE_NAVAL_TACTICS>Tattiche navali<e>
+Obsolete:
+<L:DATABASE_ADVANCES,ADVANCE_MASS_PRODUCTION>Produzione di massa<e>
 
 Abilità:
 <L:DATABASE_ORDERS,ORDER_BOMBARD>Bombarda<e>
@@ -7420,6 +7470,8 @@ Nel 2047 gli scienziati dell'Amministrazione Nazionale Spaziale e Aeronautica la
 [UNIT_SPY_PREREQ]
 Richiede:
 <L:DATABASE_ADVANCES,ADVANCE_NATIONALISM>Patriottismo<e>
+Obsolete:
+<L:DATABASE_ADVANCES,ADVANCE_NEURAL_INTERFACE>Interfaccia neurale<e>
 Abilità:
 <L:DATABASE_ORDERS,ORDER_INCITE_REVOLUTION>Incita una rivoluzione<e>
 <L:DATABASE_ORDERS,ORDER_INVESTIGATE_CITY>Spia<e>
@@ -7549,6 +7601,8 @@ La tecnologia antiradar non arrivava a buon prezzo: il primo caccia antiradar, l
 [UNIT_SUBMARINE_PREREQ]
 Richiede:
 <L:DATABASE_ADVANCES,ADVANCE_OIL_REFINING>Raffinazione del petrolio<e>
+Obsolete:
+<L:DATABASE_ADVANCES,ADVANCE_NUCLEAR_POWER>Energia nucleare<e>
 
 Abilità:
 Bombarda
@@ -7581,6 +7635,8 @@ I primi sottomarini, costruiti e sperimentati da entrambi i contendenti della Gu
 [UNIT_SWORDSMAN_PREREQ]
 Richiede:
 <L:DATABASE_ADVANCES,ADVANCE_IRON_WORKING>Lavorazione del ferro<e>
+Obsolete:
+<L:DATABASE_ADVANCES,ADVANCE_INDUSTRIAL_REVOLUTION>Rivoluzione industriale<e>
 
 Abilità:
 <L:DATABASE_CONCEPTS,CONCEPT_SPECIAL_FORCES>Forze speciali<e>
@@ -7611,6 +7667,8 @@ I samurai erano la classe di guerrieri dell'età feudale giapponese, attivi dal X
 [UNIT_TANK_PREREQ]
 Richiede:
 <L:DATABASE_ADVANCES,ADVANCE_TANK_WARFARE>Guerra coi carri armati<e>
+Obsolete:
+<L:DATABASE_ADVANCES,ADVANCE_UNIFIED_PHYSICS>Fisica unitaria<e>
 [END]
 
 [UNIT_TANK_STATISTICS]
@@ -7740,6 +7798,8 @@ A metà del XX secolo gli urbanisti iniziarono a sperimentare nuovi concetti per 
 [UNIT_WARRIOR_PREREQ]
 Richiede:
 <L:DATABASE_ADVANCES,ADVANCE_TOOLMAKING>Fabbricazione di utensili<e>
+Obsolete:
+<L:DATABASE_ADVANCES,ADVANCE_GUNPOWDER>Polvere da sparo<e>
 [END]
 
 [UNIT_WARRIOR_STATISTICS]
@@ -9361,6 +9421,8 @@ A player may want to upgrade a unit for a variety of reasons.  Older and obsolet
 [UNIT_LONGBOWMAN_PREREQ]
 Requires:
 <L:DATABASE_ADVANCES,ADVANCE_FEUDALISM><e>
+Obsolete:
+<L:DATABASE_ADVANCES,ADVANCE_CANNON_MAKING>Fabbricazione di cannoni<e>
 [END]
 
 [UNIT_LONGBOWMAN_STATISTICS]

--- a/ctp2_data/spanish/gamedata/Great_Library.txt
+++ b/ctp2_data/spanish/gamedata/Great_Library.txt
@@ -6024,7 +6024,7 @@ La catapulta fue una de las armas de asedio más efectivas de las guerras de la a
 Requiere:
 <L:DATABASE_ADVANCES,ADVANCE_CAVALRY_TACTICS>Tácticas de caballería<e>
 Obsolete:
-<L:DATABASE_ADVANCES,ADVANCE_FUSION>Fusión<e>
+<L:DATABASE_ADVANCES,ADVANCE_TANK_WARFARE>Combate blindados<e>
 [END]
 
 [UNIT_CAVALRY_STATISTICS]
@@ -7711,7 +7711,7 @@ Los samuráis constituyeron la clase guerrera durante el período feudal de la his
 Requiere:
 <L:DATABASE_ADVANCES,ADVANCE_TANK_WARFARE>Combate de blindados<e>
 Obsolete:
-<L:DATABASE_ADVANCES,ADVANCE_UNIFIED_PHYSICS>Física unificada<e>
+<L:DATABASE_ADVANCES,ADVANCE_FUSION>Fusión<e>
 [END]
 
 [UNIT_TANK_STATISTICS]

--- a/ctp2_data/spanish/gamedata/Great_Library.txt
+++ b/ctp2_data/spanish/gamedata/Great_Library.txt
@@ -5702,6 +5702,8 @@ A principios de la Segunda Guerra Mundial, los bombarderos en picado y los bomba
 [UNIT_ARCHER_PREREQ]
 Requiere:
 <L:DATABASE_ADVANCES,ADVANCE_BALLISTICS>Balística<e>
+Obsolete:
+<L:DATABASE_ADVANCES,ADVANCE_CANNON_MAKING>Fab. de cañones<e>
 [END]
 
 [UNIT_ARCHER_STATISTICS]
@@ -5794,6 +5796,8 @@ La Segunda Guerra Mundial representó el apogeo del acorazado, ya que quedó anula
 [UNIT_BOMBER_PREREQ]
 Requiere:
 <L:DATABASE_ADVANCES,ADVANCE_JET_PROPULSION>Propulsión a reacción<e>
+Obsolete:
+<L:DATABASE_ADVANCES,ADVANCE_ADVANCED_COMPOSITES>Compuestos avanz.<e>
 
 Habilidades: 
 Transportar 1 <L:DATABASE_UNITS,UNIT_NUKE>misil nuclear<e>
@@ -5827,6 +5831,8 @@ Aunque los bombarderos propulsados por una hélice probaron su eficacia en repeti
 [UNIT_CANNON_PREREQ]
 Requiere:
 <L:DATABASE_ADVANCES,ADVANCE_CANNON_MAKING>Fabricación de cañones<e>
+Obsolete:
+<L:DATABASE_ADVANCES,ADVANCE_CYBERNETICS>Cibernética<e>
 
 Habilidades:
 <L:DATABASE_ORDERS,ORDER_BOMBARD>Bombardear<e>
@@ -5858,6 +5864,8 @@ Así como la pólvora revolucionó en el siglo XVI el mundo de la infantería y los 
 [UNIT_CARAVAN_PREREQ]
 Requiere:
 <L:DATABASE_ADVANCES,ADVANCE_TRADE>Comercio<e>
+Obsolete:
+<L:DATABASE_ADVANCES,ADVANCE_GLOBAL_ECONOMICS>Economía global<e>
 
 Costes:
 {UnitDB(UnitRecord[0]).ShieldCost} <L:DATABASE_CONCEPTS,CONCEPT_PRODUCTION>producción<e>
@@ -5910,6 +5918,8 @@ Aunque algunos helicópteros militares se diseñaron principalmente para el ataque
 [UNIT_CARRACK_PREREQ]
 Requiere:
 <L:DATABASE_ADVANCES,ADVANCE_OCEAN_FARING>Navegación en alta mar<e>
+Obsolete:
+<L:DATABASE_ADVANCES,ADVANCE_INTERNAL_COMBUSTION>Combustión interna<e>
 
 Habilidades:
 <L:DATABASE_ORDERS,ORDER_BOARD_TRANSPORT>Transportar<e> 1 unidad terrestre
@@ -5947,6 +5957,8 @@ Dos de las carracas más famosas fueron la Santa María, componente de la legendar
 [UNIT_CATAMARAN_PREREQ]
 Requiere:
 <L:DATABASE_ADVANCES,ADVANCE_SHIP_BUILDING>Construcción naval<e>
+Obsolete:
+<L:DATABASE_ADVANCES,ADVANCE_HULL_MAKING>Fab. de cascos <e>
 
 Habilidades:
 <L:DATABASE_ORDERS,ORDER_BOARD_TRANSPORT>Transportar<e> 1 unidad terrestre
@@ -5978,6 +5990,8 @@ La corácora es un barco originario del antiguo País de Gales e Irlanda. Algunas 
 [UNIT_CATAPULT_PREREQ]
 Requiere:
 <L:DATABASE_ADVANCES,ADVANCE_GEOMETRY>Geometría<e>
+Obsolete:
+<L:DATABASE_ADVANCES,ADVANCE_EXPLOSIVES>Explosivos<e>
 
 Habilidades:
 <L:DATABASE_ORDERS,ORDER_BOMBARD>Bombardear<e>
@@ -6009,6 +6023,8 @@ La catapulta fue una de las armas de asedio más efectivas de las guerras de la a
 [UNIT_CAVALRY_PREREQ]
 Requiere:
 <L:DATABASE_ADVANCES,ADVANCE_CAVALRY_TACTICS>Tácticas de caballería<e>
+Obsolete:
+<L:DATABASE_ADVANCES,ADVANCE_FUSION>Fusión<e>
 [END]
 
 [UNIT_CAVALRY_STATISTICS]
@@ -6037,6 +6053,8 @@ Con la aparición, a principios del siglo XIV, de la pólvora y de los proyectiles
 [UNIT_CLERIC_PREREQ]
 Requiere:
 <L:DATABASE_ADVANCES,ADVANCE_THEOLOGY>Teología<e>
+Obsolete:
+<L:DATABASE_ADVANCES,ADVANCE_MASS_MEDIA>Medios de comunicación<e>
 
 Habilidades:
 <L:DATABASE_ORDERS,ORDER_CONVERT>Convertir ciudades<e>
@@ -6205,6 +6223,8 @@ El ejército creó un dispositivo interno de interfaz neuronal y empezó a experime
 [UNIT_DESTROYER_PREREQ]
 Requiere:
 <L:DATABASE_ADVANCES,ADVANCE_MASS_PRODUCTION>Producción en cadena<e>
+Obsolete:
+<L:DATABASE_ADVANCES,ADVANCE_PLASMA_WEAPONRY>Armas de plasma<e>
 
 Habilidades:
 <L:DATABASE_ORDERS,ORDER_BOMBARD>Bombardear<e>
@@ -6240,6 +6260,8 @@ Tras la Segunda Guerra Mundial, las funciones antiaéreas y antisubmarinas de los
 [UNIT_DIPLOMAT_PREREQ]
 Requiere:
 <L:DATABASE_ADVANCES,ADVANCE_BUREAUCRACY>Burocracia<e>
+Obsolete:
+<L:DATABASE_ADVANCES,ADVANCE_EUGENICS>Eugenesia<e>
 
 Habilidades:
 <L:DATABASE_ORDERS,ORDER_ESTABLISH_EMBASSY>Abrir embajadas<e>
@@ -6447,6 +6469,8 @@ En abril de 1925, Adolf Hitler fundó las Schutzstaffel ("escuadras de protección
 [UNIT_FIGHTER_PREREQ]
 Requiere:
 <L:DATABASE_ADVANCES,ADVANCE_AERODYNAMICS>Aerodinámica<e>
+Obsolete:
+<L:DATABASE_ADVANCES,ADVANCE_SUPERSONIC_FLIGHT>Vuelo supersónico<e>
 
 Habilidades:
 Aterrizar en <L:DATABASE_UNITS,UNIT_AIRCRAFT_CARRIER>portaaviones<e>
@@ -6481,6 +6505,8 @@ Durante la Segunda Guerra Mundial, los cazas construidos enteramente de metal e 
 [UNIT_FIRE_TRIREME_PREREQ]
 Requiere:
 <L:DATABASE_ADVANCES,ADVANCE_ALCHEMY>Alquimia<e>
+Obsolete:
+<L:DATABASE_ADVANCES,ADVANCE_MODERN_METALLURGY>Metalurgia moderna<e>
 [END]
 
 [UNIT_FIRE_TRIREME_STATISTICS]
@@ -6532,6 +6558,8 @@ Un tamaño de contenedor estándar facilitaría el transporte. Un único contenedor 
 [UNIT_FRIGATE_PREREQ]
 Requiere:
 <L:DATABASE_ADVANCES,ADVANCE_MASS_PRODUCTION>Producción en cadena<e> 
+Obsolete:
+<L:DATABASE_ADVANCES,ADVANCE_PLASMA_WEAPONRY>Armas de plasma<e>
 
 Habilidades:
 <L:DATABASE_ORDERS,ORDER_BOMBARD>Bombardear<e>
@@ -6600,6 +6628,8 @@ El blindado de fusión podía perforar objetivos fuertemente blindados o fortifica
 [UNIT_HOPLITE_PREREQ]
 Requiere:
 <L:DATABASE_ADVANCES,ADVANCE_BRONZE_WORKING>Trabajo en bronce<e>
+Obsolete:
+<L:DATABASE_ADVANCES,ADVANCE_GUNPOWDER>Pólvora<e>
 [END]
 
 [UNIT_HOPLITE_STATISTICS]
@@ -6656,6 +6686,8 @@ El desarrollo de la Teoría del Caos aplicada abrió la puerta a nuevas oportunida
 [UNIT_INFANTRYMAN_PREREQ]
 Requiere:
 <L:DATABASE_ADVANCES,ADVANCE_GUNPOWDER>Pólvora<e>
+Obsolete:
+<L:DATABASE_ADVANCES,ADVANCE_ADV_INFANTRY_TACTICS>Táctica Infantería avanz.<e>
 [END]
 
 [UNIT_INFANTRYMAN_STATISTICS]
@@ -6720,6 +6752,8 @@ Aunque la guerra biológica era ya una amenaza a finales del siglo XX, no fue has
 [UNIT_INTERCEPTOR_PREREQ]
 Requiere:
 <L:DATABASE_ADVANCES,ADVANCE_SUPERSONIC_FLIGHT>Vuelo supersónico<e>
+Obsolete:
+<L:DATABASE_ADVANCES,ADVANCE_AI_SURVEILLANCE>Vigilancia por IA<e>
 
 Habilidades:
 <L:DATABASE_CONCEPTS,CONCEPT_ACTIVE_DEFENSE>Defensa activa antiaérea<e>
@@ -6752,6 +6786,8 @@ La alta velocidad y gran altura alcanzadas por el interceptador complicaban las 
 [UNIT_IRONCLAD_PREREQ]
 Requiere:
 <L:DATABASE_ADVANCES,ADVANCE_MODERN_METALLURGY>Metalurgia moderna<e>
+Obsolete:
+<L:DATABASE_ADVANCES,ADVANCE_ADV_NAVAL_TACTICS>Táctica naval avanz.<e>
 
 Habilidades:
 <L:DATABASE_ORDERS,ORDER_BOMBARD>Bombardear<e>
@@ -6785,6 +6821,8 @@ Cuando, a principios de la guerra civil, las fuerzas de la Unión abandonaron el 
 [UNIT_KNIGHT_PREREQ]
 Requiere:
 <L:DATABASE_ADVANCES,ADVANCE_FEUDALISM>Feudalismo<e>
+Obsolete:
+<L:DATABASE_ADVANCES,ADVANCE_INDUSTRIAL_REVOLUTION>Rev. Industrial<e>
 
 Habilidades:
 <L:DATABASE_CONCEPTS,CONCEPT_SPECIAL_FORCES>Fuerzas especiales<e>
@@ -6919,6 +6957,8 @@ El leviatán fue concebido por los estrategas militares como la unidad defensiva 
 [UNIT_LONGSHIP_PREREQ]
 Requiere:
 <L:DATABASE_ADVANCES,ADVANCE_HULL_MAKING>Fabricación de cascos<e>
+Obsolete:
+<L:DATABASE_ADVANCES,ADVANCE_INTERNAL_COMBUSTION>Combustión interna<e>
 
 Habilidades: 
 <L:DATABASE_ORDERS,ORDER_BOARD_TRANSPORT>Transportar<e> hasta 2 unidades terrestres
@@ -6950,6 +6990,8 @@ El barco vikingo fue uno de los primeros barcos que incorporó un casco de tingla
 [UNIT_MACHINE_GUNNER_PREREQ]
 Requiere:
 <L:DATABASE_ADVANCES,ADVANCE_INDUSTRIAL_REVOLUTION>Revolución Industrial<e>
+Obsolete:
+<L:DATABASE_ADVANCES,ADVANCE_CHAOS_THEORY>Teoría del caos<e>
 [END]
 
 [UNIT_MACHINE_GUNNER_STATISTICS]
@@ -7075,6 +7117,8 @@ La primera aplicación militar del diseño de sistemas orgánicos culminó con la cr
 [UNIT_MOUNTED_ARCHER_PREREQ]
 Requiere:
 <L:DATABASE_ADVANCES,ADVANCE_HORSE_RIDING>Montar a caballo<e>
+Obsolete:
+<L:DATABASE_ADVANCES,ADVANCE_INDUSTRIAL_REVOLUTION>Rev. Industrial<e>
 [END]
 
 [UNIT_MOUNTED_ARCHER_STATISTICS]
@@ -7103,6 +7147,8 @@ Los primeros ejércitos de la Edad Antigua utilizaban carros para atacar de forma
 [UNIT_NUCLEAR_SUBMARINE_PREREQ]
 Requiere:
 <L:DATABASE_ADVANCES,ADVANCE_NUCLEAR_POWER>Energía nuclear<e>
+Obsolete:
+<L:DATABASE_ADVANCES,ADVANCE_GENETIC_TAILORING>Ingeniería genética<e>
 
 Habilidades:
 Transportar hasta 2 <L:DATABASE_UNITS,UNIT_CRUISE_MISSILE>misiles de crucero<e> o <L:DATABASE_UNITS,UNIT_NUKE>misiles nucleares<e>
@@ -7202,6 +7248,8 @@ Durante la Segunda Guerra Mundial, las fuerzas militares desplegaron soldados de
 [UNIT_PIKEMEN_PREREQ]
 Requiere:
 <L:DATABASE_ADVANCES,ADVANCE_AGRICULTURAL_REVOLUTION>Revolución Agrícola<e>
+Obsolete:
+<L:DATABASE_ADVANCES,ADVANCE_FASCISM>Fascismo<e>
 
 Habilidades:
 Bonificación defensiva contra unidades a caballo 
@@ -7361,6 +7409,8 @@ Desde la época prehistórica existieron pueblos nómadas, que viajaban de un lugar
 [UNIT_SHIP_OF_THE_LINE_PREREQ]
 Requiere:
 <L:DATABASE_ADVANCES,ADVANCE_NAVAL_TACTICS>Tácticas navales<e>
+Obsolete:
+<L:DATABASE_ADVANCES,ADVANCE_MASS_PRODUCTION>Producc. en cadena<e>
 
 Habilidades:
 <L:DATABASE_ORDERS,ORDER_BOMBARD>Bombardear<e>
@@ -7458,6 +7508,8 @@ En el año 2047, los científicos de la NASA lanzaron el primer vehículo de transp
 [UNIT_SPY_PREREQ]
 Requiere:
 <L:DATABASE_ADVANCES,ADVANCE_NATIONALISM>Nacionalismo<e>
+Obsolete:
+<L:DATABASE_ADVANCES,ADVANCE_NEURAL_INTERFACE>Interfaz neuronal<e>
 Habilidades:
 <L:DATABASE_ORDERS,ORDER_INCITE_REVOLUTION>Incitar a la revolución<e>
 <L:DATABASE_ORDERS,ORDER_INVESTIGATE_CITY>Espiar<e>
@@ -7591,6 +7643,8 @@ La tecnología Stealth no era precisamente barata. El primer caza Stealth, el nor
 [UNIT_SUBMARINE_PREREQ]
 Requiere:
 <L:DATABASE_ADVANCES,ADVANCE_OIL_REFINING>Refinado de petróleo<e>
+Obsolete:
+<L:DATABASE_ADVANCES,ADVANCE_NUCLEAR_POWER>Energía nuclear<e>
 
 Habilidades:
 <L:DATABASE_ORDERS,ORDER_BOMBARD>Bombardear<e>
@@ -7623,6 +7677,8 @@ Los primeros submarinos, introducidos por las dos armadas de la Guerra Civil nor
 [UNIT_SWORDSMAN_PREREQ]
 Requiere:
 <L:DATABASE_ADVANCES,ADVANCE_IRON_WORKING>Hierro forjado<e>
+Obsolete:
+<L:DATABASE_ADVANCES,ADVANCE_INDUSTRIAL_REVOLUTION>Rev. Industrial<e>
 
 Habilidades:
 <L:DATABASE_CONCEPTS,CONCEPT_SPECIAL_FORCES>Fuerzas especiales<e>
@@ -7654,6 +7710,8 @@ Los samuráis constituyeron la clase guerrera durante el período feudal de la his
 [UNIT_TANK_PREREQ]
 Requiere:
 <L:DATABASE_ADVANCES,ADVANCE_TANK_WARFARE>Combate de blindados<e>
+Obsolete:
+<L:DATABASE_ADVANCES,ADVANCE_UNIFIED_PHYSICS>Física unificada<e>
 [END]
 
 [UNIT_TANK_STATISTICS]
@@ -7787,6 +7845,8 @@ A mediados del siglo XX, los planificadores urbanos empezaron a experimentar con
 [UNIT_WARRIOR_PREREQ]
 Requiere:
 <L:DATABASE_ADVANCES,ADVANCE_TOOLMAKING>Fabricación de herramientas<e>
+Obsolete:
+<L:DATABASE_ADVANCES,ADVANCE_GUNPOWDER>Pólvora<e>
 [END]
 
 [UNIT_WARRIOR_STATISTICS]
@@ -9385,6 +9445,8 @@ A player may want to upgrade a unit for a variety of reasons.  Older and obsolet
 [UNIT_LONGBOWMAN_PREREQ]
 Requires:
 <L:DATABASE_ADVANCES,ADVANCE_FEUDALISM><e>
+Obsolete:
+<L:DATABASE_ADVANCES,ADVANCE_CANNON_MAKING>Fab. de cañones<e>
 [END]
 
 [UNIT_LONGBOWMAN_STATISTICS]


### PR DESCRIPTION
Formerly, it was possible that thanks could not be built any more even though fusion tanks were not available yet. In contrast cavalry was not deprecated before fusion.
I also noticed that leviathons could already be built with unified physics whereas they should only become available with plasma weaponry.