### PR TITLE
Allow order sounds to be defined as string-identifier

### DIFF
--- a/ctp2_code/gs/gameobj/ArmyData.cpp
+++ b/ctp2_code/gs/gameobj/ArmyData.cpp
@@ -9605,8 +9605,8 @@ bool ArmyData::ExecuteSpecialOrder(Order *order, bool &keepGoing)
 			deduct = true;
 
 			sint32	spriteID = g_theSpecialEffectDB->Get(g_theSpecialEffectDB->FindTypeIndex("SPECEFFECT_GENERAL_FAIL"))->GetValue();
-			sint32 soundID;
-			if(!order_rec->GetFailSound(soundID)) {
+			sint32 soundID = order_rec->GetFailSoundIndex();
+			if(soundID < 0) {
 				soundID = gamesounds_GetGameSoundID(GAMESOUNDS_GENERALFAIL);
 			}
 
@@ -9634,8 +9634,8 @@ bool ArmyData::ExecuteSpecialOrder(Order *order, bool &keepGoing)
 				}
 
 				sint32	spriteID = g_theSpecialEffectDB->Get(g_theSpecialEffectDB->FindTypeIndex("SPECEFFECT_GENERAL_SUCCESS"))->GetValue();
-				sint32 soundID;
-				if(!order_rec->GetSound(soundID)) {
+				sint32 soundID = order_rec->GetSoundIndex();
+				if(soundID < 0) {
 					soundID = gamesounds_GetGameSoundID(GAMESOUNDS_GENERALSUCCEED);
 				}
 

--- a/ctp2_code/gs/newdb/order.cdb
+++ b/ctp2_code/gs/newdb/order.cdb
@@ -21,8 +21,8 @@
 #    - UnitPretest_NoFuelThenCrash: To allow the AI to order planes back 
 #                                   when fuel is low.
 #    - UnitPretest_CanParadrop:     To allow paradropping.
-#    - April 23rd 2005 Martin Gühmann
-#  - Added TargetPretest:CanRefuel - April 30th 2005 Martin Gühmann
+#    - April 23rd 2005 Martin GÃ¼hmann
+#  - Added TargetPretest:CanRefuel - April 30th 2005 Martin GÃ¼hmann
 #
 #-----------------------------------------------------------------------------
 
@@ -123,6 +123,6 @@ Order {
 
   Int Cursor
   Int InvalidCursor
-  Bit(Int) FailSound
-  Bit(Int) Sound
+  Record Sound FailSound
+  Record Sound Sound
 }


### PR DESCRIPTION
Order sound can be defined in orders.txt. This was done by an integer which was hard to determine. The sound identifier can now be determined by a string-identifier.

This means that you can specify special order sounds in Orders.txt by the string identifier, per example:
```
Sound SOUND_ID_PILLAGE
FailSound SOUND_ID_GENERALFAIL
```
In case this sound would be declared in the current master it will play through the general success sound that is always played. That is solved/changed in #314.