### PR TITLE
Adjust listing of the trade manager

### DIFF
--- a/ctp2_code/ui/interface/trademanager.cpp
+++ b/ctp2_code/ui/interface/trademanager.cpp
@@ -417,7 +417,7 @@ void TradeManager::UpdateCreateList(const PLAYER_INDEX & player_id)
 
 						for(i = 0; i < m_numCities; i++) {
 							if(valuePerCaravan > maxValuePerCaravan[i]) { // determine best offer
-								for(j = m_numCities - 1; j>= i; j--) {
+								for(j = m_numCities - 1; j > i; j--) {
 									maxValuePerCaravan[j] = maxValuePerCaravan[j - 1];
 									maxCity[j].m_id = maxCity[j - 1].m_id;
 								}

--- a/ctp2_code/ui/interface/trademanager.cpp
+++ b/ctp2_code/ui/interface/trademanager.cpp
@@ -357,25 +357,28 @@ void TradeManager::UpdateCreateList(const PLAYER_INDEX & player_id)
 			if(city.CD()->IsLocalResource(g)) { // only consider collected goods (not bought goods)
 
 				sint32 op;
-				sint32 maxPrice[k_MAX_CITIES_PER_GOOD];
-				sint32 sellingPrice = -1;
+				sint32 maxValuePerCaravan[k_MAX_CITIES_PER_GOOD];
+				double sellingVPC = -1;
+				sint32 sellingCost = -1;
+				TradeRoute curDestRoute;
 				Unit curDestCity;
 
 				sint32 i,j;
 				for(i = 0; i < k_MAX_CITIES_PER_GOOD; i++) {
 					maxCity[i].m_id = 0;
-					maxPrice[i] = 0;
+					maxValuePerCaravan[i] = 0;
 				}
 
 
-				if(city.CD()->IsSellingResourceTo(g, curDestCity)) { // have already a route for g
-					sellingPrice = tradeutil_GetTradeValue(player_id, curDestCity, g);
-
+				if(city.CD()->GetResourceTradeRoute(g, curDestRoute)){ // have already a route for g
+					sellingCost = curDestRoute->GetCost();
+					curDestCity = curDestRoute->GetDestination();
+					sellingVPC = static_cast<double>(tradeutil_GetTradeValue(player_id, curDestCity, g))
+					    / sellingCost; // tradeutil_GetTradeDistance returns > 1.0
 				//need to add something here where cities that have an improvement that needs a good will demand the good. May be increase the value of selling that good?
 				}
 				else {
 					curDestCity.m_id = 0;
-					sellingPrice = -1;
 				}
 
 				for(op = 1; op < k_MAX_PLAYERS; op++) { // determine player offering highest price for good g
@@ -408,14 +411,17 @@ void TradeManager::UpdateCreateList(const PLAYER_INDEX & player_id)
 
 						if(curDestCity.m_id == destCity.m_id) continue; // exclude standing trade route destination
 
-						sint32 price = tradeutil_GetTradeValue(player_id, destCity, g); // # of gold
+						const sint32 price = tradeutil_GetTradeValue(player_id, destCity, g); // # of gold
+						const sint32 cost = tradeutil_GetTradeDistance(city, destCity); // # of caravans
+						const double valuePerCaravan = static_cast<double>(price) / cost; // cost = tradeutil_GetAccurateTradeDistance returns > 1.0
+
 						for(i = 0; i < m_numCities; i++) {
-							if(price > maxPrice[i]) { // determine best offer
+							if(valuePerCaravan > maxValuePerCaravan[i]) { // determine best offer
 								for(j = m_numCities - 1; j>= i; j--) {
-									maxPrice[j] = maxPrice[j - 1];
+									maxValuePerCaravan[j] = maxValuePerCaravan[j - 1];
 									maxCity[j].m_id = maxCity[j - 1].m_id;
 								}
-								maxPrice[i] = price;
+								maxValuePerCaravan[i] = valuePerCaravan;
 								maxCity[i] = destCity;
 								break;
 							}
@@ -424,7 +430,7 @@ void TradeManager::UpdateCreateList(const PLAYER_INDEX & player_id)
 				}
 
 				for(i = 0; i < k_MAX_CITIES_PER_GOOD; i++) {
-					if(maxPrice[i] > 0) {
+					if(maxValuePerCaravan[i] > 0) {
 
 						if(maxCity[i].m_id == curDestCity.m_id)
 							continue;
@@ -440,7 +446,7 @@ void TradeManager::UpdateCreateList(const PLAYER_INDEX & player_id)
 						data->m_source = city;
 						data->m_resource = g;
 						data->m_destination = maxCity[i];
-						data->m_price = maxPrice[i];
+						data->m_price = maxValuePerCaravan[i];
 						data->m_caravans = tradeutil_GetTradeDistance(city, maxCity[i]);
 						data->m_curDestination.m_id = curDestCity.m_id;
 
@@ -487,7 +493,7 @@ void TradeManager::UpdateCreateList(const PLAYER_INDEX & player_id)
 						}
 
 						MBCHAR buf[20];
-						sprintf(buf, "%d", maxPrice[i]);
+						sprintf(buf, "%d", maxValuePerCaravan[i]);
 						if (ctp2_Static * price = (ctp2_Static *)item->GetChildByIndex(k_PRICE_COL_INDEX))
                         {
 							price->SetText(buf);


### PR DESCRIPTION
So far the list of possible trade routes is based on first to fifth route yielding the best price for each good owned. Since this is not necessarily the best choice due to high cost of trade points, this PR changes the list to show the first fife best routes concerning maximum value per trade point, similar to what the AI now uses since #252.
It makes it much easier to maximize the total trade income with the given number of caravans but still this is a limited amount of the total number of all possible trade routes. So the trade manager is still lacking some means to create an arbitrary trade route, which can be of special interest for domestic trade, e.g. when one wants to boost a newly created city, no matter how many trade points those routes cost.
This could be realized with e.g. a scroll list of all possible source cities (all owned cities that have at least one good) and another scroll list with all other own|specific civ|friendly|all (not at war and not embargo) cities. A drop down list (as uses in some places of the game) would probably not be so suited in case there are many entries in the list.