### PR TITLE
Not render actors while scrolling

### DIFF
--- a/ctp2_code/gfx/spritesys/EffectActor.cpp
+++ b/ctp2_code/gfx/spritesys/EffectActor.cpp
@@ -90,10 +90,6 @@ void EffectActor::Process(void)
 
 	if (m_curAction)
 	{
-		POINT current = m_curAction->CalculatePixelXY(m_pos);
-		m_x = current.x;
-		m_y = current.y;
-
 		m_facing = m_curAction->CalculateFacing(m_facing);
 		m_frame = m_curAction->GetSpriteFrame();
 		m_transparency = m_curAction->GetTransparency();
@@ -146,29 +142,25 @@ void EffectActor::Draw(RECT * paintRect) const
 		maputils_MapX2TileX(m_pos.x, m_pos.y, &tileX);
 		if (maputils_TilePointInTileRect(tileX, m_pos.y, paintRect))
 		{
-			Draw();
+			POINT current = m_curAction->CalculatePixelXY(m_pos);
+			Draw(current);
 
 			RECT rect;
-			GetBoundingRect(&rect);
+			GetBoundingRect(&rect, current);
 			g_tiledMap->AddDirtyRectToMix(rect);
 		}
 	}
 }
 
-void EffectActor::Draw() const
+void EffectActor::Draw(const POINT & pos) const
 {
 	uint16  flags   = k_DRAWFLAGS_NORMAL;
 	Pixel16 color   = 0x0000;
 	sint32  xoffset = (sint32)((double)k_ACTOR_CENTER_OFFSET_X * g_tiledMap->GetScale());
 	sint32  yoffset = (sint32)((double)k_ACTOR_CENTER_OFFSET_Y * g_tiledMap->GetScale());
 
-	m_effectSpriteGroup->Draw(m_curEffectAction, m_frame, m_x+xoffset, m_y+yoffset,
-			m_x+xoffset, m_y+yoffset, m_facing, g_tiledMap->GetScale(), m_transparency, color, flags);
-}
-
-void EffectActor::DrawDirect(aui_Surface * surf) const
-{
-	DrawDirectWithFlags(surf, k_DRAWFLAGS_NORMAL);
+	m_effectSpriteGroup->Draw(m_curEffectAction, m_frame, pos.x+xoffset, pos.y+yoffset,
+			pos.x+xoffset, pos.y+yoffset, m_facing, g_tiledMap->GetScale(), m_transparency, color, flags);
 }
 
 void EffectActor::DrawDirectWithFlags(aui_Surface * surf, uint16 flags) const
@@ -219,7 +211,7 @@ uint16 EffectActor::GetHeight() const
 	return sprite ? sprite->GetHeight() : 0;
 }
 
-void EffectActor::GetBoundingRect(RECT * rect) const
+void EffectActor::GetBoundingRect(RECT * rect, const POINT & pos) const
 {
 	Assert(rect);
 	if (!rect) {
@@ -236,5 +228,5 @@ void EffectActor::GetBoundingRect(RECT * rect) const
 	rect->right  = (sint32)((double)GetWidth() * scale);
 	rect->bottom = (sint32)((double)GetHeight() * scale);
 
-	OffsetRect(rect, m_x + xoffset, m_y + yoffset);
+	OffsetRect(rect, pos.x + xoffset, pos.y + yoffset);
 }

--- a/ctp2_code/gfx/spritesys/EffectActor.h
+++ b/ctp2_code/gfx/spritesys/EffectActor.h
@@ -16,10 +16,6 @@ class Action;
 class EffectActor : public Actor
 {
 public:
-	// Make position methods public
-	using Actor::GetX;
-	using Actor::GetY;
-
 	EffectActor(SpriteState * spriteState, const MapPoint & pos);
 	virtual ~EffectActor();
 
@@ -37,14 +33,13 @@ public:
 
 	uint16 GetWidth() const;
 	uint16 GetHeight() const;
-	void   GetBoundingRect(RECT * rect) const;
 
 protected:
 	Anim * CreateAnim(EFFECTACTION action) const;
 
-	void Draw() const;
-	void DrawDirect(aui_Surface * surf) const;
+	void Draw(const POINT & pos) const;
 	void DrawText(sint32 x, sint32 y, MBCHAR * EffectText) const;
+	void GetBoundingRect(RECT * rect, const POINT & pos) const;
 
 	MapPoint            m_pos;
 

--- a/ctp2_code/gfx/spritesys/UnitActor.cpp
+++ b/ctp2_code/gfx/spritesys/UnitActor.cpp
@@ -864,6 +864,12 @@ bool UnitActor::Draw(bool fogged)
 
 	if (m_unitSpriteGroup)
 	{
+		if (m_curAction) {
+			POINT current = m_curAction->CalculatePixelXY(m_pos);
+			m_x = current.x;
+			m_y = current.y;
+		}
+
 		sint32 xoffset = (sint32)(k_ACTOR_CENTER_OFFSET_X * g_tiledMap->GetScale());
 		sint32 yoffset = (sint32)(k_ACTOR_CENTER_OFFSET_Y * g_tiledMap->GetScale());
 

--- a/ctp2_code/gfx/spritesys/director.cpp
+++ b/ctp2_code/gfx/spritesys/director.cpp
@@ -460,11 +460,7 @@ public:
 		m_activeActor->Draw(paintRect);
 	}
 
-	virtual void Offset(sint32 deltaX, sint32 deltaY)
-	{
-		m_activeActor->SetX(m_activeActor->GetX() + deltaX);
-		m_activeActor->SetY(m_activeActor->GetY() + deltaY);
-	}
+	virtual void Offset(sint32 deltaX, sint32 deltaY) {}
 
 	virtual bool IsAnimationFinished()
 	{

--- a/ctp2_code/gfx/tilesys/tiledmap.cpp
+++ b/ctp2_code/gfx/tilesys/tiledmap.cpp
@@ -3517,7 +3517,7 @@ bool TiledMap::ScrollMap(sint32 deltaX, sint32 deltaY)
 	InvalidateMix();
 
 	g_theTradePool->Draw(m_surface);
-	RepaintSprites(m_surface, &m_mapViewRect, true);
+	RepaintSprites(m_surface, &tempRect, true);
 
 	return true;
 }


### PR DESCRIPTION
As map is copied and not rendered during scrolling, rendering actors will cause the actor to be redrawn in (almost) the same position multiple times which causes side-effects. Actors are not rendered during the scrolling actions, which may cause a small jump when the scrolling stops.

I expect this to fix the issue reported by @LynxAbraxas that actors are rendered multiple times on the same location.