### PR TITLE
Render idle animation also in mirrored idle facing

### DIFF
--- a/ctp2_code/gfx/spritesys/Sprite.h
+++ b/ctp2_code/gfx/spritesys/Sprite.h
@@ -107,6 +107,11 @@ typedef  void (Sprite::*_SPRITE_DRAWLOW2)(Pixel16 *frame,
 class Sprite
 {
 public:
+	static bool IsIdleFacing(sint32 facing)
+	{
+		static const int k_MIRRORED_IDLE_SPRITEFACING = 5;
+		return facing == k_DEFAULTSPRITEFACING || facing == k_MIRRORED_IDLE_SPRITEFACING;
+	}
 	static bool IsReversedFacing(sint32 facing) { return facing >= 5; }
 
 	Sprite();

--- a/ctp2_code/gfx/spritesys/UnitSpriteGroup.cpp
+++ b/ctp2_code/gfx/spritesys/UnitSpriteGroup.cpp
@@ -112,7 +112,7 @@ void UnitSpriteGroup::Draw(UNITACTION action, sint32 frame, sint32 drawX, sint32
 	Assert(action >= UNITACTION_MOVE && action <= UNITACTION_WORK);
 
 	if (// UNITACTION_IDLE only supports default facing
-		(action == UNITACTION_IDLE && (m_sprites[action] == NULL || facing != k_DEFAULTSPRITEFACING))
+		(action == UNITACTION_IDLE && (m_sprites[action] == NULL || !Sprite::IsIdleFacing(facing)))
 		|| (action == UNITACTION_ATTACK && m_sprites[action] == NULL)
 		|| (action == UNITACTION_MOVE && m_sprites[UNITACTION_IDLE] == NULL)
 		)


### PR DESCRIPTION

This will allow units to execute the idle animation also when facing the mirrored idle position.