### PR TITLE
WIP: Hide diplo window if AI accepted proposal

### DIFF
--- a/ctp2_code/ui/interface/diplomacywindow.cpp
+++ b/ctp2_code/ui/interface/diplomacywindow.cpp
@@ -836,7 +836,7 @@ void DiplomacyWindow::Respond(RESPONSE_TYPE disposition)
 
 void DiplomacyWindow::Accept(aui_Control *control, uint32 action, uint32 data, void *cookie)
 {
-
+        Hide();
 }
 
 void DiplomacyWindow::Reject(aui_Control *control, uint32 action, uint32 data, void *cookie)
@@ -1638,6 +1638,7 @@ void DiplomacyWindow::AcceptCounter(aui_Control *control, uint32 action, uint32 
 		}
 		s_dipWindow->ShowSections(k_DIPWIN_PROPOSALS_RECEIVED | k_DIPWIN_PROPOSALS_MADE | k_DIPWIN_PROPOSAL_DETAILS);
 	}
+        Hide();
 }
 
 void DiplomacyWindow::RejectCounter(aui_Control *control, uint32 action, uint32 data, void *cookie)


### PR DESCRIPTION
Currently, the diplomatic window stays open after the AI accepted a proposal, so the evaluation of ther AI moves continues, mostly behind the still open window. This PR is meant to close the window when the AI has accepted the proposal. In case the AI rejects this problem does not arise because the game does not continue directly, instead the human player is asked for giving a thread, which then closes the window.