### PR TITLE
Fix issues introduced to AI scheduler by #311

### DIFF
--- a/ctp2_code/ai/strategy/scheduler/Scheduler.h
+++ b/ctp2_code/ai/strategy/scheduler/Scheduler.h
@@ -219,7 +219,7 @@ private:
 
 	void Rollback_Matches_For_Goal(const Goal_ptr & goal_ptr);
 
-	void Reprioritize_Goal(Goal_List::iterator &goal_iter);
+	Goal_List::iterator Reprioritize_Goal(Goal_List::iterator &goal_iter);
 
 	bool Add_Transport_Matches_For_Goal(const Goal_ptr & goal_ptr);
 


### PR DESCRIPTION
In two cases goal_iter would not be pointing to the correct item in the m_goals list in the next loop iteration.

1. Fix iterator when a goal is erased
2. Fix iterator when Reprioritize_Goal moves the current goal to later in the list

see [https://github.com/civctp2/civctp2/pull/311#issuecomment-651999928](#311 (comment)) and following comments and pull request #336 

Also fix the debugging loopCount to only increment when moving on to the next item in the list - not erasing, replacing or repeating the current item.