### PR TITLE
Keep advance that is being researched available in advance selection

### DIFF
--- a/ctp2_code/gs/gameobj/Advances.cpp
+++ b/ctp2_code/gs/gameobj/Advances.cpp
@@ -26,14 +26,14 @@
 //
 // - Safeguard FindLevel against infinite recursion.
 // - Speeded up goody hut advance and unit selection.
-// - Replaced old civilisation database by new one. (Aug 22nd 2005 Martin Gühmann)
-// - Fixed GetPollutionProductionModifier (June 11st 2005 Martin Gühmann)
-// - Fixed GetPollutionSizeModifier (June 11st 2005 Martin Gühmann)
+// - Replaced old civilisation database by new one. (Aug 22nd 2005 Martin GÃ¼hmann)
+// - Fixed GetPollutionProductionModifier (June 11st 2005 Martin GÃ¼hmann)
+// - Fixed GetPollutionSizeModifier (June 11st 2005 Martin GÃ¼hmann)
 // - Added checks for advances requiring goods, cultureonly, govt only
 // - Added EitherPreRequisite to allow flexible tech tree like civ4
-// - Added FractionComplete methods. (Feb 4th 2007 Martin Gühmann)
+// - Added FractionComplete methods. (Feb 4th 2007 Martin GÃ¼hmann)
 // - Added commodityGold and GoldSupport to projected science
-// - Replaced old const database by new one. (5-Aug-2007 Martin Gühmann)
+// - Replaced old const database by new one. (5-Aug-2007 Martin GÃ¼hmann)
 // - Added single-player start and end age affects. (11-Apr-2009 Maq)
 //
 //----------------------------------------------------------------------------
@@ -710,8 +710,13 @@ void Advances::ResetCanResearch(sint32 justGot)
 				for(h = p; h > howMany; h--)
 				{
 					sint32 which = g_rand->Next(p);
+					// Do not remove advance that is currently being researched
+					while (possible[which] == m_researching) {
+						which = g_rand->Next(p);
+					}
 					m_canResearch[possible[which]] = 0;
-					memmove(&possible[which], &possible[which + 1], p - which - 1);
+					// Copy last record to selected record
+					possible[which] = possible[p-1];
 					p--;
 				}
 

--- a/ctp2_code/gs/gameobj/Player.cpp
+++ b/ctp2_code/gs/gameobj/Player.cpp
@@ -8098,7 +8098,8 @@ void Player::SetHasAdvance(AdvanceType advance, const bool init)
 
 	SetCityRoads();
 
-	if(!init)
+	// Only need to set research when the advance that is currently researched, cannot be researched any more
+	if(!init && !m_advances->CanResearch(m_advances->GetResearching()))
 	{
 		CtpAi::SetResearch(m_owner);
 	}


### PR DESCRIPTION
Ensure that when a new advance is given by 'goody hut' or due to diplomacy, the advance that is being researched, is still available in the advance selection list (research-dialog).

I expect that this solves #327.