### PR TITLE
Play only one franchise animation (moving)

### DIFF
--- a/ctp2_code/gs/gameobj/UnitData.cpp
+++ b/ctp2_code/gs/gameobj/UnitData.cpp
@@ -4643,7 +4643,6 @@ void UnitData::MakeFranchise(sint32 player)
 		return;
 
 	m_city_data->MakeFranchise(player);
-	SpecialCityAttackResult(ORDER_RESULT_SUCCEEDED, SPECATTACK_CREATEFRANCHISE, Unit(m_id));
 }
 
 sint32 UnitData::GetFranchiseOwner() const


### PR DESCRIPTION
Before two animations were started both the moving from unit to city, and the stationary within the city. This has been fixed to only one animation is shown, moving if the unit is visible else  stationary.