### PR TITLE
Make the debug version create the logs folder before creating CivCTP_debug000.txt

### DIFF
--- a/ctp2_code/ctp/debugtools/log.cpp
+++ b/ctp2_code/ctp/debugtools/log.cpp
@@ -9,6 +9,7 @@
 #include <string.h>
 #include <stdio.h>
 #include <stdarg.h>
+#include "c3files.h"
 
 #ifdef WIN32
 #include <crtdbg.h>
@@ -375,7 +376,7 @@ void Log_Open (const char *config_file, int number)
 
 	char name[30];
 	sprintf(name, k_DEBUG_FILENAME, number);
-
+	c3files_CreateDirectory("logs");
 	Log_InitReadConfig (config_file, name);
 
 #ifdef USE_SDL


### PR DESCRIPTION
This pull request make it easier to set up a fresh working copy on Windows.

Right now it creates the logs subdirectory, before it creates CivCTP_debug000.txt.