### PR TITLE
Debian packages of CTP2 from GL-CI

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -14,3 +14,4 @@
 
 ## files essential for testing
 !ctp2CD/
+!deb/

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -85,7 +85,7 @@ debug:
     - echo $DOCKER_PARAMS
     - echo $CTP_PARAMS
     - mkdir -p $(pwd)/logs/ && chmod a+rw $(pwd)/logs/ # needs to be rw for diUser
-    - XVFBtmp=${SHARED_PATH}/.X11-unix/ HOME=$(pwd) ./run.sh
+    - XVFBtmp=${SHARED_PATH}/.X11-unix/ HOME=$(pwd) tools/run-DI.sh
              $DOCKER_PARAMS
              $IMAGE_TAG:${CI_JOB_STAGE}-${BTYP}
              ./ctp2 $CTP_PARAMS &

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -39,6 +39,13 @@ variables:
                    --target builder 
                    .
     - docker push $IMAGE_TAG:builder-latest-${CI_JOB_NAME}
+    - mkdir -p deb/ # create artifacts folder
+    - docker run --rm
+                 --volume $(pwd)/debian/:/debian/
+                 --volume $(pwd)/deb/:/deb/
+                 --volume $(pwd)/tools/build-deb.sh:/tools/build-deb.sh:ro
+                 $IMAGE_TAG:builder-latest-${CI_JOB_NAME}
+                 tools/build-deb.sh ${CI_JOB_NAME} # create deb-package from pre-compiled files
     ## 3rd stage build using system-latest and builder-latest for caching
     - apk add --update --no-cache curl
     - 'curl -sS -f -L --header  "Private-Token: ${ARTIFACTKEY}" -o ctp2CD.zip "${CI_API_V4_URL}/projects/${CI_PROJECT_NAMESPACE}%2Fctp2CD/jobs/artifacts/master/download?job=ctp2CDpack"'
@@ -55,6 +62,9 @@ variables:
                    .
     - docker push $IMAGE_TAG:test-${CI_JOB_NAME}
   retry: 2
+  artifacts:
+    paths:
+    - deb/*.deb
 
 plain:
   <<: *build

--- a/debian/DEBIAN/control
+++ b/debian/DEBIAN/control
@@ -1,0 +1,11 @@
+Package: ctp2
+Version: 1.0-0
+Section: base
+Priority: optional
+Architecture: all
+Depends: libsdl2 (>= 2.0-0), libsdl2-mixer-2.0 (>= 2.0-0), libsdl2-image-2.0 (>= 2.0-0), libavcodec57, libavformat57, libswscale4
+Maintainer: Maintainer of civctp2 (https://github.com/civctp2/civctp2)
+Description: Linux version of Call to Power II (ctp2) without game files
+  The game files need to be provided before the installation of the dep-package
+  The game files can be taken from the original CD or GoG (https://www.gog.com/game/call_to_power_2), e.g.:
+  cp -r Scenarios/ ctp2_data/ ctp2_program/  /opt/ctp2/

--- a/debian/DEBIAN/control
+++ b/debian/DEBIAN/control
@@ -3,7 +3,7 @@ Version: 1.0-0
 Section: base
 Priority: optional
 Architecture: all
-Depends: libsdl2 (>= 2.0-0), libsdl2-mixer-2.0 (>= 2.0-0), libsdl2-image-2.0 (>= 2.0-0), libavcodec57, libavformat57, libswscale4
+Depends: libsdl2-2.0-0, libsdl2-mixer-2.0-0, libsdl2-image-2.0-0, libavcodec57, libavformat57, libswscale4
 Maintainer: Maintainer of civctp2 (https://github.com/civctp2/civctp2)
 Description: Linux version of Call to Power II (ctp2) without game files
   The game files need to be provided before the installation of the dep-package

--- a/run.sh
+++ b/run.sh
@@ -1,5 +1,30 @@
 #!/bin/sh
 
+## shell script to run docker image (DI) created by GitLab CI (or built locally)
+## used in .gitlab-ci.yml for running smoke tests in GitLab CI
+## also ment for playing ctp2 directly from DI (needs no local built, only docker)
+##
+## saves games, maps, Scenarios, scores, user settinges etc in $HOME/.civctp2/
+## use -v to specify the folder with OGGs (TrackXX.ogg) for the game music and videos, e.g.:
+## ./run.sh \
+##     -v $HOME/ctp2CD/ctp2_program/ctp/music/:/opt/ctp2/ctp2_program/ctp/music/:ro \
+##     -v $HOME/ctp2CD/ctp2_program/ctp/videos/:opt/ctp2/ctp2_data/default/videos/:ro \
+##     registry.gitlab.com/civctp2/civctp2/master:latest ./ctp2 fullscreen
+## 
+## start a saved game directly with e.g.:
+## ./run.sh \
+##     -v $HOME/ctp2CD/ctp2_program/ctp/music/:/opt/ctp2/ctp2_program/ctp/music/:ro \
+##     -v $HOME/ctp2CD/ctp2_program/ctp/videos/:opt/ctp2/ctp2_data/default/videos/:ro \
+##     registry.gitlab.com/civctp2/civctp2/master:latest ./ctp2 -lsave/games/Julius/QUICKSAVE-Julius
+## 
+## specify environment vars for the docker environment (e.g. use different sound card):
+## ./run.sh \
+##     -v $HOME/ctp2CD/ctp2_program/ctp/music/:/opt/ctp2/ctp2_program/ctp/music/:ro \
+##     -v $HOME/ctp2CD/ctp2_program/ctp/videos/:opt/ctp2/ctp2_data/default/videos/:ro \
+##     --env="ALSA_CARD=1" \
+##     registry.gitlab.com/civctp2/civctp2/master:latest ./ctp2 fullscreen
+
+
 XSOCK=/tmp/.X11-unix
 if [ -z ${XVFBtmp+x} ]; then 
     XAUTH=/tmp/.docker.xauth
@@ -24,8 +49,6 @@ if test -s $HOME/.civctp2/Const.txt # file must exist for docker file-vol
 then CON="-v $HOME/.civctp2/Const.txt:/opt/ctp2/ctp2_program/ctp/Const.txt"
 fi     
 
-## use -v to specify the folder with OGGs (TrackXX.ogg) for the game music, e.g.:
-## ./run.sh -v $HOME/ctp2CD/ctp2_program/ctp/music/:/opt/ctp2/ctp2_program/ctp/music/:ro registry.gitlab.com/civctp2/civctp2/master:latest ./ctp2 fullscreen
 docker run \
        --rm \
        $DOCKERARGS \

--- a/tools/build-deb.sh
+++ b/tools/build-deb.sh
@@ -10,5 +10,6 @@ BTYP=$1
 mkdir -p /debian/opt/ctp2/
 cp -r /opt/ctp2/ /debian/opt/
 
+find ./debian -type d | xargs chmod 755 # to avoid error: control directory has bad permissions 777 (must be >=0755 and <=0775)
 dpkg-deb --build /debian # uses debian/ to built debian.deb
 mv /debian.deb /deb/ctp2-$BTYP.deb

--- a/tools/build-deb.sh
+++ b/tools/build-deb.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+## shell script to build debian package from within GitLab CI
+## expects ctp2 to be installed under /opt in the GL-CI docker image (DI)
+## needs dpkg-deb installed in the DI
+## saves deb-file under /deb/, which is expected to be mounted as docker volume
+
+BTYP=$1
+
+mkdir -p /debian/opt/ctp2/
+cp -r /opt/ctp2/ /debian/opt/
+
+dpkg-deb --build /debian # uses debian/ to built debian.deb
+mv /debian.deb /deb/ctp2-$BTYP.deb

--- a/tools/run-DI.sh
+++ b/tools/run-DI.sh
@@ -6,19 +6,19 @@
 ##
 ## saves games, maps, Scenarios, scores, user settinges etc in $HOME/.civctp2/
 ## use -v to specify the folder with OGGs (TrackXX.ogg) for the game music and videos, e.g.:
-## ./run.sh \
+## ./run-DI.sh \
 ##     -v $HOME/ctp2CD/ctp2_program/ctp/music/:/opt/ctp2/ctp2_program/ctp/music/:ro \
 ##     -v $HOME/ctp2CD/ctp2_program/ctp/videos/:opt/ctp2/ctp2_data/default/videos/:ro \
 ##     registry.gitlab.com/civctp2/civctp2/master:latest ./ctp2 fullscreen
 ## 
 ## start a saved game directly with e.g.:
-## ./run.sh \
+## ./run-DI.sh \
 ##     -v $HOME/ctp2CD/ctp2_program/ctp/music/:/opt/ctp2/ctp2_program/ctp/music/:ro \
 ##     -v $HOME/ctp2CD/ctp2_program/ctp/videos/:opt/ctp2/ctp2_data/default/videos/:ro \
 ##     registry.gitlab.com/civctp2/civctp2/master:latest ./ctp2 -lsave/games/Julius/QUICKSAVE-Julius
 ## 
 ## specify environment vars for the docker environment (e.g. use different sound card):
-## ./run.sh \
+## ./run-DI.sh \
 ##     -v $HOME/ctp2CD/ctp2_program/ctp/music/:/opt/ctp2/ctp2_program/ctp/music/:ro \
 ##     -v $HOME/ctp2CD/ctp2_program/ctp/videos/:opt/ctp2/ctp2_data/default/videos/:ro \
 ##     --env="ALSA_CARD=1" \


### PR DESCRIPTION
For the 20th anniversary of CTP2, this PR offers a means to create Debian packages with the GL-CI (resolves #322) thereby providing automated releases for Linux.

With that, the installation of ctp2 only needs two actions (the game files need to be provided before the installation of the dep-package):
```
cp -r Scenarios/ ctp2_data/ ctp2_program/  /opt/ctp2/ # copy game files from the original CD or GoG
apt install ctp2-plain.deb
```
as done in the DF:
https://github.com/civctp2/civctp2/blob/ef6d8f720b9109d14e9a127b465cab861a4a0707/Dockerfile#L57-L66

Both, plain and debug versions get packaged (`ctp2-plain.deb` and `ctp2-debug.deb`) and are used/tested in the GL-CI test-stage.