### PR TITLE
Fix linking error

### DIFF
--- a/ctp2_code/ui/ldl/ldl.l
+++ b/ctp2_code/ui/ldl/ldl.l
@@ -18,7 +18,6 @@
 #endif
 #include "ldlif.h"
 
-int state;
 int g_ldlLineNumber = 1;
 
 YY_BUFFER_STATE ldl_include_stack[MAX_INCLUDE_DEPTH];


### PR DESCRIPTION
When trying to build the game I got the following error during linking:

```
/usr/bin/ld.gold: error: gs/slic/.libs/libgsslic.a(lex.yy.o): multiple definition of 'state'
/usr/bin/ld.gold: ui/ldl/lex.ldl.o: previous definition here
```

From what I can see the variable `state` is not used anyway, so just delete it.