### PR TITLE
Debugged victory enslavement 

### DIFF
--- a/ctp2_code/gs/gameobj/armyevent.cpp
+++ b/ctp2_code/gs/gameobj/armyevent.cpp
@@ -1050,21 +1050,29 @@ STDEHANDLER(AftermathEvent)
 		g_director->AddTerminateFaceoff(td);
 	}
 
-	bool attackerWon = false;
-
+	//// similar to ArmyData::IsWounded()
+	double attacker_relTotHP= 0;
 	if(army.IsValid() && army.Num() > 0)
 	{
 		for(sint32 i = 0; i < army.Num(); i++)
 		{
-			if(army[i].GetHP() < 0.5)
-			{
-				continue;
-			}
-
-			attackerWon = true;
-			break;
+			attacker_relTotHP+= army[i].GetHP();
 		}
+		attacker_relTotHP/= army.Num();
 	}
+	
+	//// similar to ArmyData::IsWounded()
+	double defender_relTotHP= 0;
+	if(defender.Num() > 0)
+	{
+		for(sint32 i = 0; i < defender.Num(); i++)
+		{
+			defender_relTotHP+= defender[i].GetHP();
+		}
+		defender_relTotHP/= defender.Num();
+	}
+
+	bool attackerWon = attacker_relTotHP > defender_relTotHP;
 
 	if(attackerWon)
 	{


### PR DESCRIPTION
PR to solve #346 by determining if attacker won by relating total relative HPs of both sides.

With enough units and much HPs:
![ss_2021-02-20_23:36:47](https://user-images.githubusercontent.com/21012234/108610723-3557aa80-73d8-11eb-9183-6c846f363376.png)
victory enslavement succeeds:
![ss_2021-02-20_23:37:01](https://user-images.githubusercontent.com/21012234/108610726-37216e00-73d8-11eb-8be6-f58c2471b459.png)
If total rel. HPs are too low
![ss_2021-02-20_23:37:51](https://user-images.githubusercontent.com/21012234/108610732-3c7eb880-73d8-11eb-8df5-da6d2b9f5812.png)
victory enslavement fails:
![ss_2021-02-20_23:39:01](https://user-images.githubusercontent.com/21012234/108610734-42749980-73d8-11eb-92d7-c41388254c17.png)
