### PR TITLE
Force-fields not depending on city-walls

### DIFF
--- a/ctp2_data/default/gamedata/buildings.txt
+++ b/ctp2_data/default/gamedata/buildings.txt
@@ -397,8 +397,6 @@ IMPROVE_FORCEFIELD {
    Description DESCRIPTION_IMPROVE_FORCEFIELD
    EnableAdvance ADVANCE_UNIFIED_PHYSICS
 
-   PrerequisiteBuilding IMPROVE_CITY_WALLS
-
    ProductionCost 10000
    Upkeep 20
    DefendersPercent 80


### PR DESCRIPTION
- makes little sense
- allows water-cities to build force-fields

Would solve #333.