### PR TITLE
Fix overwriting glyph (mostly capital C)

### DIFF
--- a/ctp2_code/ui/aui_common/aui_bitmapfont.cpp
+++ b/ctp2_code/ui/aui_common/aui_bitmapfont.cpp
@@ -42,8 +42,8 @@
 //  add
 //      aui_BitmapFont::GlyphInfo *aui_BitmapFont::GetGlyphInfo2( MBCHAR *c )
 //
-// - Initialized local variables. (Sep 9th 2005 Martin G�hmann)
-// - Standardized code (May 21th 2006 Martin G�hmann)
+// - Initialized local variables. (Sep 9th 2005 Martin Gühmann)
+// - Standardized code (May 21th 2006 Martin Gühmann)
 //
 //----------------------------------------------------------------------------
 
@@ -521,10 +521,10 @@ aui_BitmapFont::GlyphInfo *aui_BitmapFont::GetGlyphInfo( MBCHAR c )
 		gi->advance = (sint16)floor( (double)ttMetrics.advance / 64.0 + 0.5 );
 
 		uint32 nextOffset;
-		nextOffset = m_curOffset + gi->bbox.right - gi->bbox.left;
+		nextOffset = m_curOffset + gi->bbox.right - (gi->bbox.left < 0 ? gi->bbox.left : 0);
 
 		if ( !m_surfaceList->L()
-		||   nextOffset > k_AUI_BITMAPFONT_SURFACEWIDTH )
+		||   nextOffset >= k_AUI_BITMAPFONT_SURFACEWIDTH )
 		{
 			aui_Surface *cache;
 


### PR DESCRIPTION
Sometimes character 'C' became incorrect (see pictures). This was caused by the fact that in some situation another glyph was drawn exactly over the edge of the surface, as the test was incorrect. It did not take into account that the width is zero-based.

I could reproduce this by loading the attached save-game. Opening the building-manager and going to the tab 'Wonders', and clicking wonder 'Chichen Itza'. After the fix the overwriting does not happen anymore.
![Screenshot from 2021-04-21 22-55-35](https://user-images.githubusercontent.com/10560119/115621789-48fb9080-a2f7-11eb-93a6-64b9634a097a.png)
![Screenshot from 2021-04-21 22-56-15](https://user-images.githubusercontent.com/10560119/115621798-4b5dea80-a2f7-11eb-8b83-f60562fcf931.png)
![Screenshot from 2021-04-21 22-56-27](https://user-images.githubusercontent.com/10560119/115621810-4dc04480-a2f7-11eb-91e3-9416eabc0452.png)
[Genghi-81.zip](https://github.com/civctp2/civctp2/files/6353996/Genghi-81.zip)
