### PR TITLE
Draw fogged tiles while scrolling up

### DIFF
--- a/ctp2_code/gfx/tilesys/tiledraw.cpp
+++ b/ctp2_code/gfx/tilesys/tiledraw.cpp
@@ -1097,8 +1097,8 @@ sint32 TiledMap::DrawBlendedTile(aui_Surface *surface, const MapPoint &pos,sint3
         if (!surface) return 0;
     }
 
-    if (xpos >= surface->Width() - k_TILE_PIXEL_WIDTH) return 0;
-    if (ypos >= surface->Height() - k_TILE_PIXEL_HEIGHT) return 0;
+    if (xpos > surface->Width() - k_TILE_PIXEL_WIDTH) return 0;
+    if (ypos > surface->Height() - k_TILE_PIXEL_HEIGHT) return 0;
 
 	TileInfo * tileInfo = GetTileInfo(pos);
 	Assert(tileInfo);


### PR DESCRIPTION
Fogged tiles where not drawn (shown as black tiles) while scrolling up. There was a difference in implementation between non-fogged and fogged tiles. 'bigger than' (non-fogged) versus 'bigger than and equal' (fogged). The latter has been replaced by 'bigger than' as well.

Before
![Screenshot from 2021-05-08 13-03-30](https://user-images.githubusercontent.com/10560119/117537197-c0bc0180-afff-11eb-9c52-79be8e96bea5.png)
After
![Screenshot from 2021-05-08 13-08-05](https://user-images.githubusercontent.com/10560119/117537202-c580b580-afff-11eb-891b-f92342f750f5.png)
