### PR TITLE
Unit control-panel improvements

### DIFF
--- a/ctp2_code/ui/interface/UnitControlPanel.cpp
+++ b/ctp2_code/ui/interface/UnitControlPanel.cpp
@@ -899,7 +899,12 @@ AUI_ERRCODE UnitControlPanel::StackSymbolDrawCallback(ctp2_Static * control, aui
 		return AUI_ERRCODE_BLTFAILED;
 	}
 
-	Pixel16 playerColor = g_colorSet->GetPlayerColor(panel->GetSelectedArmy().GetOwner());
+	Army army = panel->GetSelectedArmy();
+	if (!army.IsValid()) {
+		return AUI_ERRCODE_BLTFAILED;
+	}
+
+	Pixel16 playerColor = g_colorSet->GetPlayerColor(army.GetOwner());
 	Pixel16 colorizePixel = (sourceSurface->PixelFormat() == AUI_SURFACE_PIXELFORMAT_555) ? k_16_BIT_COLORIZE_PIXEL
 			: (k_16_BIT_COLORIZE_PIXEL & 0x7FE0) << 1 | (k_16_BIT_COLORIZE_PIXEL & 0x001F);
 	Pixel16 chromaPixel = sourceSurface->GetChromaKey();

--- a/ctp2_code/ui/interface/UnitControlPanel.cpp
+++ b/ctp2_code/ui/interface/UnitControlPanel.cpp
@@ -820,23 +820,7 @@ void UnitControlPanel::NextUnitButtonActionCallback(aui_Control * control, uint3
 		return;
 	}
 
-	UnitControlPanel * panel = static_cast<UnitControlPanel*>(cookie);
-	switch (panel->m_currentMode)
-	{
-		case SINGLE_SELECTION:
-		case ARMY_SELECTION:
-			if (SelectionContainsMultipleArmies()) {
-				panel->SetSelectionMode(MULTIPLE_SELECTION);
-			} else {
-				g_selected_item->NextUnmovedUnit();
-			}
-			break;
-
-		case MULTIPLE_SELECTION:
-		default:
-			g_selected_item->NextUnmovedUnit();
-			break;
-	}
+	g_selected_item->NextUnmovedUnit();
 }
 
 bool UnitControlPanel::SelectionContainsMultipleArmies()

--- a/ctp2_code/ui/interface/UnitControlPanel.cpp
+++ b/ctp2_code/ui/interface/UnitControlPanel.cpp
@@ -63,66 +63,49 @@ extern C3UI *g_c3ui;
 static MBCHAR * ARMY_SYMBOL  = "UPIC21.tga";
 static MBCHAR * CARGO_SYMBOL = "UPC045.tga";
 
-UnitControlPanel::UnitControlPanel(MBCHAR *ldlBlock) :
-m_unitDisplayGroup(static_cast<ctp2_Static*>(
-	aui_Ldl::GetObject(ldlBlock,
-	"UnitTab.TabPanel.UnitSelectionDisplay"))),
-m_unitListPreviousButton(static_cast<ctp2_Button*>(
-	aui_Ldl::GetObject(ldlBlock,
-	"UnitTab.TabPanel.UnitSelectionDisplay.UnitSelect.Previous"))),
-m_unitListLabel(static_cast<ctp2_Static*>(
-	aui_Ldl::GetObject(ldlBlock,
-	"UnitTab.TabPanel.UnitSelectionDisplay.UnitSelect.Label"))),
-m_unitListNextButton(static_cast<ctp2_Button*>(
-	aui_Ldl::GetObject(ldlBlock,
-	"UnitTab.TabPanel.UnitSelectionDisplay.UnitSelect.Next"))),
-m_singleSelectionDisplay(static_cast<ctp2_Static*>(
-	aui_Ldl::GetObject(ldlBlock,
-	"UnitTab.TabPanel.UnitSelectionDisplay.SingleSelect"))),
-m_singleSelectionIcon(static_cast<ctp2_Static*>(
-	aui_Ldl::GetObject(ldlBlock,
-	"UnitTab.TabPanel.UnitSelectionDisplay.SingleSelect.Icon"))),
-m_singleSelectionSymbol(static_cast<ctp2_Static*>(
-	aui_Ldl::GetObject(ldlBlock,
-	"UnitTab.TabPanel.UnitSelectionDisplay.SingleSelect.Icon.Symbol"))),
-m_singleSelectionAttack(static_cast<ctp2_Static*>(
-	aui_Ldl::GetObject(ldlBlock,
-	"UnitTab.TabPanel.UnitSelectionDisplay.SingleSelect.Attack.Value"))),
-m_singleSelectionDefend(static_cast<ctp2_Static*>(
-	aui_Ldl::GetObject(ldlBlock,
-	"UnitTab.TabPanel.UnitSelectionDisplay.SingleSelect.Defend.Value"))),
-m_singleSelectionMove(static_cast<ctp2_Static*>(
-	aui_Ldl::GetObject(ldlBlock,
-	"UnitTab.TabPanel.UnitSelectionDisplay.SingleSelect.Move.Value"))),
-m_singleSelectionRange(static_cast<ctp2_Static*>(
-	aui_Ldl::GetObject(ldlBlock,
-	"UnitTab.TabPanel.UnitSelectionDisplay.SingleSelect.Range.Value"))),
-m_singleSelectionArmor(static_cast<ctp2_Static*>(
-	aui_Ldl::GetObject(ldlBlock,
-					   "UnitTab.TabPanel.UnitSelectionDisplay.SingleSelect.Armor.Value"))),
-m_singleSelectionFirepower(static_cast<ctp2_Static *>(
-	aui_Ldl::GetObject(ldlBlock,
-					   "UnitTab.TabPanel.UnitSelectionDisplay.SingleSelect.Firepower.Value"))),
-m_singleSelectionHealth(static_cast<ctp2_Static*>(
-	aui_Ldl::GetObject(ldlBlock,
-	"UnitTab.TabPanel.UnitSelectionDisplay.SingleSelect.Health"))),
-m_singleSelectionFuel(static_cast<ctp2_Static *>(
-	aui_Ldl::GetObject(ldlBlock, "UnitTab.TabPanel.UnitSelectionDisplay.SingleSelect.Fuel"))),
-m_multipleSelectionDisplay(static_cast<ctp2_Static*>(
-	aui_Ldl::GetObject(ldlBlock,
-	"UnitTab.TabPanel.UnitSelectionDisplay.MultipleSelect"))),
-m_armySelectionDisplay(static_cast<ctp2_Static*>(
-	aui_Ldl::GetObject(ldlBlock,
-	"UnitTab.TabPanel.UnitSelectionDisplay.ArmySelect"))),
-m_armySelectionIcon(static_cast<ctp2_Static*>(
-	aui_Ldl::GetObject(ldlBlock,
-	"UnitTab.TabPanel.UnitSelectionDisplay.ArmySelect.Background.Icon"))),
-m_transportSelectionDisplay(static_cast<ctp2_Static *>(
-	aui_Ldl::GetObject(ldlBlock, "UnitTab.TabPanel.UnitSelectionDisplay.TransportSelect"))),
-m_transportSelectionIcon(static_cast<ctp2_Static *>(
-	aui_Ldl::GetObject(ldlBlock, "UnitTab.TabPanel.UnitSelectionDisplay.TransportSelect.Background.Icon"))),
-	m_cellUnitList      (),
-    m_cellArmyList      ()
+UnitControlPanel::UnitControlPanel(MBCHAR * ldlBlock) :
+m_unitDisplayGroup(static_cast<ctp2_Static*>(aui_Ldl::GetObject(ldlBlock,
+		"UnitTab.TabPanel.UnitSelectionDisplay"))),
+m_unitListPreviousButton(static_cast<ctp2_Button*>(aui_Ldl::GetObject(ldlBlock,
+		"UnitTab.TabPanel.UnitSelectionDisplay.UnitSelect.Previous"))),
+m_unitListLabel(static_cast<ctp2_Static*>(aui_Ldl::GetObject(ldlBlock,
+		"UnitTab.TabPanel.UnitSelectionDisplay.UnitSelect.Label"))),
+m_unitListNextButton(static_cast<ctp2_Button*>(aui_Ldl::GetObject(ldlBlock,
+		"UnitTab.TabPanel.UnitSelectionDisplay.UnitSelect.Next"))),
+m_singleSelectionDisplay(static_cast<ctp2_Static*>(aui_Ldl::GetObject(ldlBlock,
+		"UnitTab.TabPanel.UnitSelectionDisplay.SingleSelect"))),
+m_singleSelectionIcon(static_cast<ctp2_Static*>(aui_Ldl::GetObject(ldlBlock,
+		"UnitTab.TabPanel.UnitSelectionDisplay.SingleSelect.Icon"))),
+m_singleSelectionSymbol(static_cast<ctp2_Static*>(aui_Ldl::GetObject(ldlBlock,
+		"UnitTab.TabPanel.UnitSelectionDisplay.SingleSelect.Icon.Symbol"))),
+m_singleSelectionAttack(static_cast<ctp2_Static*>(aui_Ldl::GetObject(ldlBlock,
+		"UnitTab.TabPanel.UnitSelectionDisplay.SingleSelect.Attack.Value"))),
+m_singleSelectionDefend(static_cast<ctp2_Static*>(aui_Ldl::GetObject(ldlBlock,
+		"UnitTab.TabPanel.UnitSelectionDisplay.SingleSelect.Defend.Value"))),
+m_singleSelectionMove(static_cast<ctp2_Static*>(aui_Ldl::GetObject(ldlBlock,
+		"UnitTab.TabPanel.UnitSelectionDisplay.SingleSelect.Move.Value"))),
+m_singleSelectionRange(static_cast<ctp2_Static*>(aui_Ldl::GetObject(ldlBlock,
+		"UnitTab.TabPanel.UnitSelectionDisplay.SingleSelect.Range.Value"))),
+m_singleSelectionArmor(static_cast<ctp2_Static*>(aui_Ldl::GetObject(ldlBlock,
+		"UnitTab.TabPanel.UnitSelectionDisplay.SingleSelect.Armor.Value"))),
+m_singleSelectionFirepower(static_cast<ctp2_Static *>(aui_Ldl::GetObject(ldlBlock,
+		"UnitTab.TabPanel.UnitSelectionDisplay.SingleSelect.Firepower.Value"))),
+m_singleSelectionHealth(static_cast<ctp2_Static*>(aui_Ldl::GetObject(ldlBlock,
+		"UnitTab.TabPanel.UnitSelectionDisplay.SingleSelect.Health"))),
+m_singleSelectionFuel(static_cast<ctp2_Static *>(aui_Ldl::GetObject(ldlBlock,
+		"UnitTab.TabPanel.UnitSelectionDisplay.SingleSelect.Fuel"))),
+m_multipleSelectionDisplay(static_cast<ctp2_Static*>(aui_Ldl::GetObject(ldlBlock,
+		"UnitTab.TabPanel.UnitSelectionDisplay.MultipleSelect"))),
+m_armySelectionDisplay(static_cast<ctp2_Static*>(aui_Ldl::GetObject(ldlBlock,
+		"UnitTab.TabPanel.UnitSelectionDisplay.ArmySelect"))),
+m_armySelectionIcon(static_cast<ctp2_Static*>(aui_Ldl::GetObject(ldlBlock,
+		"UnitTab.TabPanel.UnitSelectionDisplay.ArmySelect.Background.Icon"))),
+m_transportSelectionDisplay(static_cast<ctp2_Static *>(aui_Ldl::GetObject(ldlBlock,
+		"UnitTab.TabPanel.UnitSelectionDisplay.TransportSelect"))),
+m_transportSelectionIcon(static_cast<ctp2_Static *>(aui_Ldl::GetObject(ldlBlock,
+		"UnitTab.TabPanel.UnitSelectionDisplay.TransportSelect.Background.Icon"))),
+m_cellUnitList(),
+m_cellArmyList()
 {
 	Assert(m_unitDisplayGroup);
 	Assert(m_unitListPreviousButton);
@@ -143,235 +126,94 @@ m_transportSelectionIcon(static_cast<ctp2_Static *>(
 	m_curHealth = -1;
 	m_curCargo = -2;
 
-	for(int multiIndex = 0; multiIndex <
-		NUMBER_OF_MULTIPLE_SELECTION_BUTTONS; multiIndex++) {
-
+	for (sint32 multiIndex = 0; multiIndex < NUMBER_OF_MULTIPLE_SELECTION_BUTTONS; multiIndex++)
+	{
 		MBCHAR multiButtonName[128];
-		sprintf(multiButtonName,
-			"UnitTab.TabPanel.UnitSelectionDisplay.MultipleSelect.Unit%d",
-			multiIndex);
+		sprintf(multiButtonName,"UnitTab.TabPanel.UnitSelectionDisplay.MultipleSelect.Unit%d", multiIndex);
 
-		m_multipleSelectionButton[multiIndex] = static_cast<ctp2_Button*>(
-			aui_Ldl::GetObject(ldlBlock, multiButtonName));
-		m_multipleSelectionHealth[multiIndex] = (ctp2_Static *)m_multipleSelectionButton[multiIndex]->GetChildByIndex(0);
+		m_multipleSelectionButton[multiIndex] =
+				static_cast<ctp2_Button*>(aui_Ldl::GetObject(ldlBlock, multiButtonName));
+		m_multipleSelectionHealth[multiIndex] =
+				(ctp2_Static *)m_multipleSelectionButton[multiIndex]->GetChildByIndex(0);
 
 		Assert(m_multipleSelectionButton[multiIndex]);
 	}
 
-	for(int armyIndex = 0; armyIndex <
-		NUMBER_OF_ARMY_SELECTION_BUTTONS; armyIndex++) {
-
+	for (sint32 armyIndex = 0; armyIndex < NUMBER_OF_ARMY_SELECTION_BUTTONS; armyIndex++)
+	{
 		MBCHAR armyButtonName[128];
-		sprintf(armyButtonName,
-			"UnitTab.TabPanel.UnitSelectionDisplay.ArmySelect.Unit%d",
-			armyIndex);
+		sprintf(armyButtonName,"UnitTab.TabPanel.UnitSelectionDisplay.ArmySelect.Unit%d", armyIndex);
 
-		m_armySelectionButton[armyIndex] = static_cast<ctp2_Button*>(
-			aui_Ldl::GetObject(ldlBlock, armyButtonName));
+		m_armySelectionButton[armyIndex] = static_cast<ctp2_Button*>(aui_Ldl::GetObject(ldlBlock, armyButtonName));
 		m_armySelectionHealth[armyIndex] = (ctp2_Static *)m_armySelectionButton[armyIndex]->GetChildByIndex(0);
 
 		Assert(m_armySelectionButton[armyIndex]);
 
-		m_armySelectionButton[armyIndex]->SetActionFuncAndCookie(
-			ArmyButtonActionCallback, this);
+		m_armySelectionButton[armyIndex]->SetActionFuncAndCookie(ArmyButtonActionCallback, this);
 	}
 
-	sint32 transIndex;
-	for(transIndex = 0; transIndex < k_MAX_CP_CARGO; transIndex++) {
+	for (sint32 transIndex = 0; transIndex < k_MAX_CP_CARGO; transIndex++)
+	{
 		MBCHAR transportButtonName[256];
-		sprintf(transportButtonName, "UnitTab.TabPanel.UnitSelectionDisplay.TransportSelect.Cargo%d",
-				transIndex);
+		sprintf(transportButtonName, "UnitTab.TabPanel.UnitSelectionDisplay.TransportSelect.Cargo%d", transIndex);
 		m_transportSelectionButton[transIndex] = (ctp2_Switch *)aui_Ldl::GetObject(ldlBlock, transportButtonName);
-		m_transportSelectionHealth[transIndex] = (ctp2_Static *)m_transportSelectionButton[transIndex]->GetChildByIndex(0);
+		m_transportSelectionHealth[transIndex] =
+				(ctp2_Static *)m_transportSelectionButton[transIndex]->GetChildByIndex(0);
 	}
 
-//// this gets all the buttons and limits it to the 12 you see in game...change to a list box like in scenario editor?
-//emod1
-	for(int orderIndex = 0; orderIndex < NUMBER_OF_ORDER_BUTTONS; orderIndex++) {
-
+	for (sint32 orderIndex = 0; orderIndex < NUMBER_OF_ORDER_BUTTONS; orderIndex++)
+	{
 		MBCHAR orderButtonName[128];
-		sprintf(orderButtonName,
-			"UnitTab.TabPanel.UnitOrderButtonGrid.Order%d", orderIndex);
+		sprintf(orderButtonName,"UnitTab.TabPanel.UnitOrderButtonGrid.Order%d", orderIndex);
 
-		m_orderButton[orderIndex] = static_cast<ctp2_Button*>(
-			aui_Ldl::GetObject(ldlBlock, orderButtonName));
+		m_orderButton[orderIndex] = static_cast<ctp2_Button*>(aui_Ldl::GetObject(ldlBlock, orderButtonName));
 
 		Assert(m_orderButton[orderIndex]);
 
 		m_orderButton[orderIndex]->Enable(false);
 	}
-/*
-#define k_TERRAINIMP_COLS_PER_ROW 6
-	m_terrainImpSwitches        (NULL),
-new and delete in constructor/dest
-  		s_scenarioEditor->PopulateTerrainImprovementList();  //emod5 definitely need something to populate it
-
-void ScenarioEditor::PopulateTerrainImprovementList()  //emod1 note  use this format instead of current switches but add item populating checks?
-{
-
-	ctp2_ListBox *lb = (ctp2_ListBox *)aui_Ldl::GetObject(s_scenarioEditorBlock, "TabGroup.City.TerrainImprovementList");
-	Assert(lb);
-	if(!lb)	return;
-
-	lb->SetAbsorbancy(FALSE);
-	lb->Clear();
-
-	sint32 col = 0;
-	ctp2_ListItem *curItem = NULL;
-	ctp2_Static *curItemBox = NULL;
-
-	delete [] m_terrainImpSwitches;
-	m_terrainImpSwitches = new ctp2_Switch *[g_theTerrainImprovementDB->NumRecords()];
-
-	for (sint32 t = 0; t < g_theTerrainImprovementDB->NumRecords(); t++) {
-		if(col == 0) {
-			curItem = (ctp2_ListItem *)aui_Ldl::BuildHierarchyFromRoot("ScenTerrainImprovementItem");
-			Assert(curItem);
-			if(!curItem)
-				break;
-
-			curItemBox = (ctp2_Static *)curItem->GetChildByIndex(0);
-			Assert(curItemBox);
-			if(!curItemBox)
-				break;
-
-			lb->AddItem(curItem);
-		}
-
-		Assert(curItem && curItemBox);
-		if(!curItem || !curItemBox)
-			break;
-
-		ctp2_Switch *sw = (ctp2_Switch *)curItemBox->GetChildByIndex(col);
-		Assert(sw);
-		if(!sw)
-			break;
-
-		const TerrainImprovementRecord *rec = g_theTerrainImprovementDB->Get(t);
-		Assert(rec);
-		if(!rec)
-			break;
-
-		const MBCHAR *iconname = rec->GetIcon()->GetIcon();
-		Assert(iconname);
-		if(iconname) {
-			sw->SetImage((char *)iconname, 0);
-			sw->SetImage((char *)iconname, 1);
-		}
-
-		m_terrainImpSwitches[t] = sw;
-
-		sw->SetActionFuncAndCookie(ScenarioEditor::TerrainImprovementSwitch, (void *)t);
-		((aui_TipWindow *)sw->GetTipWindow())->SetTipText((MBCHAR *)rec->GetNameText());
-
-		col++;
-		if(col >= k_TERRAINIMP_COLS_PER_ROW) {
-			col = 0;
-			curItem = NULL;
-			curItemBox = NULL;
-		}
-	}
-
-	if(col > 0) {
-		Assert(curItem && curItemBox);
-		for (sint32 dis = col; dis < k_TERRAINIMP_COLS_PER_ROW; dis++) {
-			ctp2_Switch *sw = (ctp2_Switch *)curItemBox->GetChildByIndex(dis);
-			Assert(sw);
-			if(sw)
-				sw->Enable(FALSE);
-		}
-	}
-}
-
-void ScenarioEditor::TerrainImprovementSwitch(aui_Control *control, uint32 action, uint32 data, void *cookie)
-{//emod4 need this functionality should be there
-	Assert(s_scenarioEditor);
-	if(!s_scenarioEditor)
-		return;
-
-	if(action == 0) {
-
-		return;
-	}
-
-	if (action == AUI_SWITCH_ACTION_PRESS)
-		DisableErase();
-
-	sint32 ter = (sint32)cookie;
-
-	if(s_scenarioEditor->m_terrainImpSwitches[ter]->GetState() == 0) {
-		s_scenarioEditor->m_paintTerrainImprovement = -1;
-		if(s_scenarioEditor->m_mapMode == SCEN_MAP_TERRAINIMP) {
-			s_scenarioEditor->m_mapMode = SCEN_MAP_NONE;
-		}
-
-		return;
-	}
-
-	for (sint32 i = 0; i < g_theTerrainImprovementDB->NumRecords(); i++) {
-		if(i == ter)
-			continue;
-		if(s_scenarioEditor->m_terrainImpSwitches[i]) {
-			s_scenarioEditor->m_terrainImpSwitches[i]->SetState(0);
-		}
-	}
-
-	s_scenarioEditor->m_paintTerrainImprovement = ter;
-	s_scenarioEditor->m_mapMode = SCEN_MAP_TERRAINIMP;
-}
-
-*/
-/////////////////////end note
 
 	m_transportSelectionIcon->SetImageMapCallback(TransportSelectionImageCallback, this);
 
-	m_unitListPreviousButton->SetActionFuncAndCookie(
-		PrevUnitButtonActionCallback, this);
-	m_unitListNextButton->SetActionFuncAndCookie(
-		NextUnitButtonActionCallback, this);
+	m_unitListPreviousButton->SetActionFuncAndCookie(PrevUnitButtonActionCallback, this);
+	m_unitListNextButton->SetActionFuncAndCookie(NextUnitButtonActionCallback, this);
 
 	SetSelectionMode(MULTIPLE_SELECTION);
 
-
-	m_unitDisplayGroup->SetShowCallback(
-		UnitDisplayGroupCallback, this);
+	m_unitDisplayGroup->SetShowCallback(UnitDisplayGroupCallback, this);
 }
 
 void UnitControlPanel::Update()
 {
-
 	switch(m_currentMode) {
-	case SINGLE_SELECTION:
-		UpdateSingleSelectionDisplay();
-		break;
-	case MULTIPLE_SELECTION:
-		UpdateMultipleSelectionDisplay();
-		break;
-	case ARMY_SELECTION:
-		UpdateArmySelectionDisplay();
-		break;
-	case TRANSPORT_SELECTION:
-		UpdateTransportSelectionDisplay();
-		break;
-	default:
-		Assert(false);
-		break;
+		case SINGLE_SELECTION:
+			UpdateSingleSelectionDisplay();
+			break;
+		case MULTIPLE_SELECTION:
+			UpdateMultipleSelectionDisplay();
+			break;
+		case ARMY_SELECTION:
+			UpdateArmySelectionDisplay();
+			break;
+		case TRANSPORT_SELECTION:
+			UpdateTransportSelectionDisplay();
+			break;
+		default:
+			Assert(false);
+			break;
 	}
 
-	if(!m_unitDisplayGroup->IsHidden()) {
-
+	if (!m_unitDisplayGroup->IsHidden()) {
 		m_unitDisplayGroup->ShouldDraw();
-
 	}
 
-	UpdateOrderButtons();  //emod2 - check how to use this method
+	UpdateOrderButtons();
 }
 
 void UnitControlPanel::SelectedUnit()
 {
-
-	Army a;
-	if(g_selected_item->GetSelectedArmy(a) && (!a.IsValid() || (a.Num() < 2))) {
+	Army army;
+	if (g_selected_item->GetSelectedArmy(army) && (!army.IsValid() || (army.Num() < 2))) {
 		SetSelectionMode(SINGLE_SELECTION);
 	} else {
 		SetSelectionMode(ARMY_SELECTION);
@@ -383,47 +225,47 @@ void UnitControlPanel::SelectedUnit()
 
 void UnitControlPanel::SetSelectionMode(UnitSelectionMode mode)
 {
-
 	m_currentMode = mode;
-
 	m_armySelectionUnit = -1;
 
-	if(m_unitDisplayGroup->IsHidden())
+	if (m_unitDisplayGroup->IsHidden()) {
 		return;
-
-	switch(m_currentMode) {
-	case SINGLE_SELECTION:
-		m_singleSelectionDisplay->Show();
-		m_multipleSelectionDisplay->Hide();
-		m_armySelectionDisplay->Hide();
-		m_transportSelectionDisplay->Hide();
-		break;
-	case MULTIPLE_SELECTION:
-		m_singleSelectionDisplay->Hide();
-		m_multipleSelectionDisplay->Show();
-		m_armySelectionDisplay->Hide();
-		m_transportSelectionDisplay->Hide();
-		break;
-	case ARMY_SELECTION:
-		m_singleSelectionDisplay->Hide();
-		m_multipleSelectionDisplay->Hide();
-		m_armySelectionDisplay->Show();
-		m_transportSelectionDisplay->Hide();
-		break;
-	case TRANSPORT_SELECTION:
-		m_singleSelectionDisplay->Hide();
-		m_multipleSelectionDisplay->Hide();
-		m_armySelectionDisplay->Hide();
-		UnsetCargoButtons();
-		m_transportSelectionDisplay->Show();
-		break;
-	default:
-		Assert(false);
-		break;
 	}
 
-	if(g_selected_item)
+	switch(m_currentMode) {
+		case SINGLE_SELECTION:
+			m_singleSelectionDisplay->Show();
+			m_multipleSelectionDisplay->Hide();
+			m_armySelectionDisplay->Hide();
+			m_transportSelectionDisplay->Hide();
+			break;
+		case MULTIPLE_SELECTION:
+			m_singleSelectionDisplay->Hide();
+			m_multipleSelectionDisplay->Show();
+			m_armySelectionDisplay->Hide();
+			m_transportSelectionDisplay->Hide();
+			break;
+		case ARMY_SELECTION:
+			m_singleSelectionDisplay->Hide();
+			m_multipleSelectionDisplay->Hide();
+			m_armySelectionDisplay->Show();
+			m_transportSelectionDisplay->Hide();
+			break;
+		case TRANSPORT_SELECTION:
+			m_singleSelectionDisplay->Hide();
+			m_multipleSelectionDisplay->Hide();
+			m_armySelectionDisplay->Hide();
+			UnsetCargoButtons();
+			m_transportSelectionDisplay->Show();
+			break;
+		default:
+			Assert(false);
+			break;
+	}
+
+	if (g_selected_item) {
 		Update();
+	}
 }
 
 void UnitControlPanel::UpdateSingleSelectionDisplay()
@@ -435,36 +277,36 @@ void UnitControlPanel::UpdateSingleSelectionDisplay()
 	sint32 cargo = -1;
 	sint32 fuel = -1;
 	sint32 maxFuel = -1;
+
 	if(army.IsValid())
     {
-		if(m_armySelectionUnit >= 0 && m_armySelectionUnit < army.Num()) {
+		if (m_armySelectionUnit >= 0 && m_armySelectionUnit < army.Num()) {
 			unit.m_id = army[m_armySelectionUnit].m_id;
 		} else {
 			unit.m_id = army[0].m_id;
 		}
-		if(unit.IsValid()) {
+		if (unit.IsValid())
+		{
 			movement = unit.GetMovementPoints();
 			health = unit.GetHP();
-			if(!unit.GetUsedFuel(fuel, maxFuel)) {
+			if (!unit.GetUsedFuel(fuel, maxFuel))
+			{
 				fuel = -1;
 				maxFuel = -1;
 			}
-			if(unit.GetDBRec()->HasCargoData()) {
-				cargo = unit->GetNumCarried();
-			} else {
-				cargo = -1;
-			}
+			cargo = unit.GetDBRec()->HasCargoData() ? unit->GetNumCarried() : -1;
 		}
 	}
 
 	m_unitListLabel->SetText(unit.IsValid() ? unit.GetDisplayName().c_str() : "");
 
-	if((m_curSingleArmy.m_id == army.m_id) &&
-	   (m_curSingleUnit.m_id == unit.m_id) &&
-	   (m_curMovement == movement) &&
-	   (m_curHealth == health) &&
-	   (m_curCargo == cargo) &&
-	   (m_curFuel == fuel)) {
+	if ((m_curSingleArmy.m_id == army.m_id)
+		&& (m_curSingleUnit.m_id == unit.m_id)
+		&& (m_curMovement == movement)
+		&& (m_curHealth == health)
+		&& (m_curCargo == cargo)
+		&& (m_curFuel == fuel))
+	{
 		return;
 	}
 
@@ -475,7 +317,8 @@ void UnitControlPanel::UpdateSingleSelectionDisplay()
 	m_curCargo = cargo;
 	m_curFuel = fuel;
 
-	if(!unit.IsValid()) {
+	if (!unit.IsValid())
+	{
 		m_singleSelectionIcon->SetImage(NULL);
 		m_singleSelectionSymbol->SetImage(NULL);
 		m_singleSelectionAttack->SetText("");
@@ -489,49 +332,36 @@ void UnitControlPanel::UpdateSingleSelectionDisplay()
 		m_singleSelectionIcon->SetDrawCallbackAndCookie(NULL, NULL);
 		m_singleSelectionIcon->SetImageMapCallback(NULL, NULL);
 		m_singleSelectionFuel->SetDrawCallbackAndCookie(NULL, NULL);
-
-
 		return;
 	}
 
-	const IconRecord *iconRecord = unit.GetDBRec()->GetDefaultIcon();
+	const IconRecord * iconRecord   = unit.GetDBRec()->GetDefaultIcon();
+	const MBCHAR     * unitIconName = iconRecord->GetLargeIcon();
 
-	const MBCHAR *unitIconName = iconRecord->GetLargeIcon();
-
-	if(unitIconName && strcmp(unitIconName, "NULL")) {
+	if (unitIconName && strcmp(unitIconName, "NULL"))
+	{
 		m_singleSelectionIcon->SetImage((char *) unitIconName);
 		m_singleSelectionSymbol->ExchangeImage(0, 0, m_curCargo >= 0 ? CARGO_SYMBOL : NULL);
 	}
 
 	MBCHAR valueString[16];
-
-
-	sprintf(valueString, "%d",
-		static_cast<sint32>(unit.GetAttack()));
+	sprintf(valueString, "%d", static_cast<sint32>(unit.GetAttack()));
 	m_singleSelectionAttack->SetText(valueString);
-	sprintf(valueString, "%d",
-		static_cast<sint32>(unit.GetDefense()));
+	sprintf(valueString, "%d", static_cast<sint32>(unit.GetDefense()));
 	m_singleSelectionDefend->SetText(valueString);
-
-	sprintf(valueString, "%d",
-		static_cast<sint32>(ceil(unit.GetMovementPoints() / 100.0)));
+	sprintf(valueString, "%d", static_cast<sint32>(ceil(unit.GetMovementPoints() / 100.0)));
 	m_singleSelectionMove->SetText(valueString);
-	sprintf(valueString, "%d",
-		static_cast<sint32>(unit.GetZBRange()));
+	sprintf(valueString, "%d", static_cast<sint32>(unit.GetZBRange()));
 	m_singleSelectionRange->SetText(valueString);
-
 	sprintf(valueString, "%d", (sint32)(unit.GetDBRec()->GetArmor()));
 	m_singleSelectionArmor->SetText(valueString);
-
 	sprintf(valueString, "%d", (sint32)(unit.GetDBRec()->GetFirepower()));
 	m_singleSelectionFirepower->SetText(valueString);
 
 	m_singleSelectionFuel->SetDrawCallbackAndCookie(FuelBarDrawCallback, (void *)unit.m_id);
+	m_singleSelectionHealth->SetDrawCallbackAndCookie(HealthBarActionCallback, reinterpret_cast<void*>(unit.m_id));
 
-	m_singleSelectionHealth->SetDrawCallbackAndCookie(
-		HealthBarActionCallback, reinterpret_cast<void*>(unit.m_id));
-
-	if(m_curCargo >= 0)
+	if (m_curCargo >= 0)
 	{
 		m_singleSelectionIcon->SetDrawCallbackAndCookie(DrawCargoCallback, (void *)unit.m_id, false);
 		m_singleSelectionIcon->SetImageMapCallback(TransportImageCallback, (void *)this);
@@ -545,13 +375,14 @@ void UnitControlPanel::UpdateSingleSelectionDisplay()
 
 void UnitControlPanel::UpdateMultipleSelectionDisplay()
 {
-	if (!g_selected_item)
+	if (!g_selected_item) {
 		return;
+	}
 
-	CellUnitList        newUnitList;
+	CellUnitList newUnitList;
     g_theWorld->GetCell(g_selected_item->GetCurSelectPos())->GetArmy(newUnitList);
 
-    std::vector<Army>   newArmyList;
+    std::vector<Army> newArmyList;
 	for (sint32 i = 0; i < newUnitList.Num(); ++i)
     {
 		newArmyList.push_back(newUnitList[i].GetArmy());
@@ -560,14 +391,11 @@ void UnitControlPanel::UpdateMultipleSelectionDisplay()
 	m_unitListLabel->SetText("");
 
 	bool changed = false;
-
 	if (static_cast<size_t>(newUnitList.Num()) == m_cellUnitList.size())
     {
 		for (sint32 i = 0; i < newUnitList.Num(); ++i)
         {
-			if (newUnitList[i].m_id != m_cellUnitList[i].m_id ||
-			    newArmyList[i].m_id != m_cellArmyList[i].m_id
-               )
+			if (newUnitList[i].m_id != m_cellUnitList[i].m_id || newArmyList[i].m_id != m_cellArmyList[i].m_id)
             {
 				changed = true;
 				break;
@@ -585,20 +413,19 @@ void UnitControlPanel::UpdateMultipleSelectionDisplay()
 	}
 
 	sint32 multiIndex = 0;
-	sint32 unitIndex = 0;
+	sint32 unitIndex  = 0;
 
 	while (multiIndex < NUMBER_OF_MULTIPLE_SELECTION_BUTTONS)
     {
 		if (unitIndex < newUnitList.Num())
         {
-			Unit &  unit    = newUnitList[unitIndex++];
-			Army    army    = unit.GetArmy();
+			Unit & unit = newUnitList[unitIndex++];
+			Army   army = unit.GetArmy();
 
-			bool    armyAlreadyShown = false;
+			bool armyAlreadyShown = false;
 			for (sint32 testIndex = unitIndex - 2; testIndex >= 0; testIndex--)
-            {
-				if (newUnitList[testIndex].GetArmy().m_id == army.m_id)
-                {
+			{
+				if (newUnitList[testIndex].GetArmy().m_id == army.m_id) {
 					armyAlreadyShown = true;
                 }
 			}
@@ -608,24 +435,22 @@ void UnitControlPanel::UpdateMultipleSelectionDisplay()
 				m_multiPair[multiIndex].first   = this;
 				m_multiPair[multiIndex].second  = army.m_id;
 
-				m_multipleSelectionButton[multiIndex]->SetActionFuncAndCookie(
-					MultiButtonActionCallback, &m_multiPair[multiIndex]);
-				if(army.IsValid() && army.Num() == 1) {
-					m_multipleSelectionHealth[multiIndex]->SetDrawCallbackAndCookie(HealthBarActionCallback, (void *)army[0].m_id);
-				} else {
+				m_multipleSelectionButton[multiIndex]->SetActionFuncAndCookie(MultiButtonActionCallback,
+						&m_multiPair[multiIndex]);
+				if (army.IsValid() && army.Num() == 1)
+				{
+					m_multipleSelectionHealth[multiIndex]->SetDrawCallbackAndCookie(HealthBarActionCallback,
+							(void *)army[0].m_id);
+				}
+				else {
 					m_multipleSelectionHealth[multiIndex]->SetDrawCallbackAndCookie(NULL, NULL);
 				}
-				if(m_multipleSelectionButton[multiIndex]->IsDisabled())
-					m_multipleSelectionButton[multiIndex]->Enable(true);
-
+				m_multipleSelectionButton[multiIndex]->Enable(true);
 
 				m_multipleSelectionButton[multiIndex]->ExchangeImage(0, 0,
-					unit.GetDBRec()->GetDefaultIcon()->GetIcon());
-				if(army.IsValid() && army.Num() > 1) {
-					m_multipleSelectionButton[multiIndex]->ExchangeImage(1, 0, ARMY_SYMBOL);
-				} else {
-					m_multipleSelectionButton[multiIndex]->ExchangeImage(1, 0, NULL);
-				}
+						unit.GetDBRec()->GetDefaultIcon()->GetIcon());
+				m_multipleSelectionButton[multiIndex]->ExchangeImage(1, 0,
+						(army.IsValid() && army.Num() > 1) ?  ARMY_SYMBOL : NULL);
 				multiIndex++;
 			}
 		}
@@ -633,8 +458,7 @@ void UnitControlPanel::UpdateMultipleSelectionDisplay()
         {
 			m_multipleSelectionButton[multiIndex]->SetActionFuncAndCookie(NULL, NULL);
 			m_multipleSelectionHealth[multiIndex]->SetDrawCallbackAndCookie(NULL, NULL);
-			if(!m_multipleSelectionButton[multiIndex]->IsDisabled())
-				m_multipleSelectionButton[multiIndex]->Enable(false);
+			m_multipleSelectionButton[multiIndex]->Enable(false);
 			m_multipleSelectionButton[multiIndex]->ExchangeImage(0, 0, NULL);
 			m_multipleSelectionButton[multiIndex]->ExchangeImage(1, 0, NULL);
 			multiIndex++;
@@ -652,8 +476,7 @@ void UnitControlPanel::UpdateMultipleSelectionDisplay()
 void UnitControlPanel::UpdateArmySelectionDisplay()
 {
 	Army army = GetSelectedArmy();
-
-	if(!army.IsValid() || (army.Num() <= 1))
+	if (!army.IsValid() || (army.Num() <= 1))
     {
 		SetSelectionMode(SINGLE_SELECTION);
 		return;
@@ -671,29 +494,29 @@ void UnitControlPanel::UpdateArmySelectionDisplay()
 		}
 	}
 
-	for (int armyIndex = 0; armyIndex <
-		NUMBER_OF_ARMY_SELECTION_BUTTONS; armyIndex++) {
-
-		if(armyIndex < army.Num()) {
-
-			const MBCHAR *unitIconName =
-				army[armyIndex].GetDBRec()->GetDefaultIcon()->GetSmallIcon();
-
-			if(unitIconName && strcmp(unitIconName, "NULL")) {
-				m_armySelectionButton[armyIndex]->ExchangeImage(0, 0,
-																unitIconName);
-				m_armySelectionHealth[armyIndex]->SetDrawCallbackAndCookie(HealthBarActionCallback, (void *)army[armyIndex].m_id);
-			} else {
+	for (sint32 armyIndex = 0; armyIndex < NUMBER_OF_ARMY_SELECTION_BUTTONS; armyIndex++)
+	{
+		if (armyIndex < army.Num())
+		{
+			const MBCHAR *unitIconName = army[armyIndex].GetDBRec()->GetDefaultIcon()->GetSmallIcon();
+			if (unitIconName && strcmp(unitIconName, "NULL"))
+			{
+				m_armySelectionButton[armyIndex]->ExchangeImage(0, 0, unitIconName);
+				m_armySelectionHealth[armyIndex]->SetDrawCallbackAndCookie(HealthBarActionCallback,
+						(void *)army[armyIndex].m_id);
+			}
+			else
+			{
 				m_armySelectionButton[armyIndex]->ExchangeImage(0, 0, NULL);
 				m_armySelectionHealth[armyIndex]->SetDrawCallbackAndCookie(NULL, NULL);
 			}
-			if(m_armySelectionButton[armyIndex]->IsDisabled())
-				m_armySelectionButton[armyIndex]->Enable(true);
-		} else {
+			m_armySelectionButton[armyIndex]->Enable(true);
+		}
+		else
+		{
 			m_armySelectionButton[armyIndex]->ExchangeImage(0, 0, NULL);
 			m_armySelectionHealth[armyIndex]->SetDrawCallbackAndCookie(NULL, NULL);
-			if(!m_armySelectionButton[armyIndex]->IsDisabled())
-				m_armySelectionButton[armyIndex]->Enable(false);
+			m_armySelectionButton[armyIndex]->Enable(false);
 		}
 	}
 
@@ -702,22 +525,24 @@ void UnitControlPanel::UpdateArmySelectionDisplay()
 
 void UnitControlPanel::UpdateTransportSelectionDisplay()
 {
-	if(m_transportSelectionDisplay->IsHidden())
+	if (m_transportSelectionDisplay->IsHidden()) {
 		return;
+	}
 
 	Army army = GetSelectedArmy();
 	Unit unit;
 
 	if (army.IsValid())
 	{
-		if(m_armySelectionUnit >= 0 && m_armySelectionUnit < army.Num()) {
+		if (m_armySelectionUnit >= 0 && m_armySelectionUnit < army.Num()) {
 			unit.m_id = army[m_armySelectionUnit].m_id;
 		} else {
 			unit.m_id = army[0].m_id;
 		}
 	}
 
-	if(unit.IsValid()) {
+	if (unit.IsValid())
+	{
 		UnitDynamicArray *cargoList = unit->GetCargoList();
 
 		const MBCHAR * transportIconName = unit.GetDBRec()->GetDefaultIcon()->GetLargeIcon();
@@ -729,48 +554,58 @@ void UnitControlPanel::UpdateTransportSelectionDisplay()
 		}
 
 		Assert(cargoList);
-		if(!cargoList) {
+		if (!cargoList) {
 			SetSelectionMode(SINGLE_SELECTION);
 			return;
 		}
 
 		sint32 capacity = unit.GetDBRec()->GetCargoDataPtr()->GetMaxCargo();
 
-		sint32 i;
-		for(i = 0; i < k_MAX_CP_CARGO; i++) {
-			ctp2_Switch *butt = m_transportSelectionButton[i];
-			if(i >= capacity) {
-				butt->Hide();
-				m_transportSelectionHealth[i]->SetDrawCallbackAndCookie(NULL, NULL);
-			} else {
-				butt->Show();
-				if(i >= cargoList->Num()) {
-					if(m_transportSelectionCargo[i] != 0) {
-						butt->SetImage(NULL, 0);
-						butt->SetImage(NULL, 1);
-						butt->Enable(FALSE);
-						m_transportSelectionCargo[i] = 0;
-						m_transportSelectionHealth[i]->SetDrawCallbackAndCookie(NULL, NULL);
-
+		for (sint32 index = 0; index < k_MAX_CP_CARGO; index++)
+		{
+			ctp2_Switch * button = m_transportSelectionButton[index];
+			if (index >= capacity)
+			{
+				button->Hide();
+				m_transportSelectionHealth[index]->SetDrawCallbackAndCookie(NULL, NULL);
+			}
+			else
+			{
+				button->Show();
+				if (index >= cargoList->Num())
+				{
+					if (m_transportSelectionCargo[index] != 0)
+					{
+						button->SetImage(NULL, 0);
+						button->SetImage(NULL, 1);
+						button->Enable(FALSE);
+						m_transportSelectionCargo[index] = 0;
+						m_transportSelectionHealth[index]->SetDrawCallbackAndCookie(NULL, NULL);
 					}
-				} else {
-					if(m_transportSelectionCargo[i] != cargoList->Access(i).m_id) {
-						char *icon = (char *)cargoList->Access(i).GetDBRec()->GetDefaultIcon()->GetIcon();
-						butt->SetImage(icon, 0);
-						butt->SetImage(icon, 1);
-						butt->Enable(TRUE);
-						m_transportSelectionCargo[i] = cargoList->Access(i).m_id;
-						m_transportSelectionHealth[i]->SetDrawCallbackAndCookie(HealthBarActionCallback, (void *)cargoList->Access(i).m_id);
+				}
+				else
+				{
+					if (m_transportSelectionCargo[index] != cargoList->Access(index).m_id)
+					{
+						const char * icon = cargoList->Access(index).GetDBRec()->GetDefaultIcon()->GetIcon();
+						button->SetImage(icon, 0);
+						button->SetImage(icon, 1);
+						button->Enable(true);
+						m_transportSelectionCargo[index] = cargoList->Access(index).m_id;
+						m_transportSelectionHealth[index]->SetDrawCallbackAndCookie(HealthBarActionCallback,
+								(void *)cargoList->Access(index).m_id);
 					}
 				}
 			}
 		}
-	} else {
-		sint32 i;
-		for(i = 0; i < k_MAX_CP_CARGO; i++) {
-			ctp2_Switch *butt = m_transportSelectionButton[i];
-			if(!butt->IsHidden()) {
-				butt->Hide();
+	}
+	else
+	{
+		for(sint32 index = 0; index < k_MAX_CP_CARGO; index++)
+		{
+			ctp2_Switch * button = m_transportSelectionButton[index];
+			if (!button->IsHidden()) {
+				button->Hide();
 			}
 		}
 
@@ -778,28 +613,23 @@ void UnitControlPanel::UpdateTransportSelectionDisplay()
 	}
 }
 
-void UnitControlPanel::UpdateOrderButtons()  //emod3 this is the method
+void UnitControlPanel::UpdateOrderButtons()
 {
 	static bool enableState[NUMBER_OF_ORDER_BUTTONS];
 
 	Army army = GetSelectedArmy();
-	if(m_lastSelectionUnit == m_armySelectionUnit)
+	if ((m_lastSelectionUnit == m_armySelectionUnit) && (army.m_id == m_lastSelectedArmy.m_id)
+		&& ((army.IsValid() && army.Num() == m_lastSelectedArmyCount)
+			|| (!army.IsValid() && !m_lastSelectedArmy.IsValid())))
 	{
-		if(army.m_id == m_lastSelectedArmy.m_id)
-		{
-			if(army.IsValid() && army.Num() == m_lastSelectedArmyCount)
-				return;
-			else if(!army.IsValid() && !m_lastSelectedArmy.IsValid())
-				return;
-		}
+		return;
 	}
 
-	m_lastSelectionUnit = m_armySelectionUnit;
-	m_lastSelectedArmy = army;
+	m_lastSelectionUnit     = m_armySelectionUnit;
+	m_lastSelectedArmy      = army;
 	m_lastSelectedArmyCount = army.IsValid() ? army.Num() : 0;
 
-	sint32 orderIndex;
-	for(orderIndex = 0; orderIndex < NUMBER_OF_ORDER_BUTTONS; orderIndex++)
+	for (sint32 orderIndex = 0; orderIndex < NUMBER_OF_ORDER_BUTTONS; orderIndex++)
 	{
 		m_orderButton[orderIndex]->ExchangeImage(4, 0, NULL);
 		m_orderButton[orderIndex]->ShouldDraw();
@@ -807,43 +637,34 @@ void UnitControlPanel::UpdateOrderButtons()  //emod3 this is the method
 
 		enableState[orderIndex] = false;
 
-		aui_TipWindow *tipwin = (aui_TipWindow *)m_orderButton[orderIndex]->GetTipWindow();
-		if(tipwin)
-		{
-			tipwin->SetTipText("");
+		aui_TipWindow * tipWindow = (aui_TipWindow *)m_orderButton[orderIndex]->GetTipWindow();
+		if (tipWindow) {
+			tipWindow->SetTipText("");
 		}
 	}
 
-	if(army.IsValid())
+	if (army.IsValid())
 	{
-		ArmyData *armyData = army.AccessData();
-		if(armyData)
+		ArmyData * armyData = army.AccessData();
+		if (armyData)
 		{
-			bool const 	isShowOrderIntersection	=
-				!g_theProfileDB->GetValueByName("ShowOrderUnion");
-
-			for(sint32 index = 0; index < g_theOrderDB->NumRecords(); index++)
+			bool isShowOrderIntersection = !g_theProfileDB->GetValueByName("ShowOrderUnion");
+			for (sint32 index = 0; index < g_theOrderDB->NumRecords(); index++)
 			{
-				const OrderRecord *orderRecord = g_theOrderDB->Get(index);
-
-				if(stricmp(orderRecord->GetIDText(), "ORDER_ENSLAVE_SETTLER") == 0)
+				const OrderRecord * orderRecord = g_theOrderDB->Get(index);
+				if (stricmp(orderRecord->GetIDText(), "ORDER_ENSLAVE_SETTLER") == 0) {
 					continue;
+				}
 
-				bool const	isSelectedCapable	=
-					(m_armySelectionUnit >= 0) &&
-					armyData->TestOrderUnit(orderRecord, m_armySelectionUnit);
-				bool const	isArmyCapable		=
-					isSelectedCapable || ((isShowOrderIntersection)
-									      ? armyData->TestOrderAll(orderRecord)
-										  : armyData->TestOrderAny(orderRecord)
-										 );
+				bool isSelectedCapable = (m_armySelectionUnit >= 0)
+						&& armyData->TestOrderUnit(orderRecord, m_armySelectionUnit);
+				bool isArmyCapable = isSelectedCapable || (isShowOrderIntersection
+						? armyData->TestOrderAll(orderRecord) : armyData->TestOrderAny(orderRecord));
 
-				if(isArmyCapable)
+				if (isArmyCapable)
 				{
 					sint32 orderButtonIndex = orderRecord->GetButtonLocation();
-
-					m_orderButton[orderButtonIndex]->ExchangeImage(4, 0,
-						orderRecord->GetCPIcon());
+					m_orderButton[orderButtonIndex]->ExchangeImage(4, 0, orderRecord->GetCPIcon());
 
 					bool   full          = true;
 					sint32 costs         = 0;
@@ -851,69 +672,70 @@ void UnitControlPanel::UpdateOrderButtons()  //emod3 this is the method
 					sint8  numUpgrade    = 0;
 					sint8  numUpgradeAll = 0;
 
-					if
-					  (
-					       stricmp(orderRecord->GetEventName(), "UpgradeOrder") == 0
-					    && armyData->UpgradeTypeAndCosts(full, costs, fullCosts, numUpgrade, numUpgradeAll)
-					  )
+					if (stricmp(orderRecord->GetEventName(), "UpgradeOrder") == 0
+					    && armyData->UpgradeTypeAndCosts(full, costs, fullCosts, numUpgrade, numUpgradeAll))
 					{
-						char buff[1024];
-						sprintf(buff, "%s, %d/%d/%d, %s%d/%d", g_theStringDB->GetNameStr(orderRecord->GetStatusText()), numUpgrade, numUpgradeAll, army->Num(), g_theStringDB->GetNameStr("str_ldl_Gold_COLON_"), costs, fullCosts);
+						char buffer[1024];
+						sprintf(buffer, "%s, %d/%d/%d, %s%d/%d",
+								g_theStringDB->GetNameStr(orderRecord->GetStatusText()), numUpgrade, numUpgradeAll,
+								army->Num(), g_theStringDB->GetNameStr("str_ldl_Gold_COLON_"), costs, fullCosts);
+						m_orderButton[orderButtonIndex]->SetStatusTextCopy(buffer);
 
-						m_orderButton[orderButtonIndex]->SetStatusTextCopy(buff);
-
-						aui_TipWindow *tipwin = (aui_TipWindow *)m_orderButton[orderButtonIndex]->GetTipWindow();
-						if(tipwin)
+						aui_TipWindow * tipWindow = (aui_TipWindow *)m_orderButton[orderButtonIndex]->GetTipWindow();
+						if (tipWindow)
 						{
-							sprintf(buff, "%s, %d/%d/%d, %s%d/%d", g_theStringDB->GetNameStr(orderRecord->GetLocalizedName()), numUpgrade, numUpgradeAll, army->Num(), g_theStringDB->GetNameStr("str_ldl_Gold_COLON_"), costs, fullCosts);
-							tipwin->SetTipText(buff);
+							sprintf(buffer, "%s, %d/%d/%d, %s%d/%d",
+									g_theStringDB->GetNameStr(orderRecord->GetLocalizedName()), numUpgrade,
+									numUpgradeAll, army->Num(), g_theStringDB->GetNameStr("str_ldl_Gold_COLON_"),
+									costs, fullCosts);
+							tipWindow->SetTipText(buffer);
 						}
 					}
 					else
 					{
-						m_orderButton[orderButtonIndex]->SetStatusText(g_theStringDB->GetNameStr(orderRecord->GetStatusText()));
+						m_orderButton[orderButtonIndex]->SetStatusText(
+								g_theStringDB->GetNameStr(orderRecord->GetStatusText()));
 
-						aui_TipWindow *tipwin = (aui_TipWindow *)m_orderButton[orderButtonIndex]->GetTipWindow();
-						if(tipwin)
-						{
-							tipwin->SetTipText((char *)g_theStringDB->GetNameStr(orderRecord->GetLocalizedName()));
+						aui_TipWindow * tipWindow = (aui_TipWindow *)m_orderButton[orderButtonIndex]->GetTipWindow();
+						if (tipWindow) {
+							tipWindow->SetTipText((char *)g_theStringDB->GetNameStr(orderRecord->GetLocalizedName()));
 						}
 					}
 
 					ORDER_TEST orderTest = armyData->TestOrder(orderRecord);
 
 					sint32 range;
-					if(!orderRecord->GetRange(range))
+					if (!orderRecord->GetRange(range)) {
 						range = 0;
+					}
 
-					if((orderTest == ORDER_TEST_OK) ||
-						(orderTest == ORDER_TEST_NEEDS_TARGET) ||
-						(orderTest == ORDER_TEST_NO_MOVEMENT) ||
-						(orderTest == ORDER_TEST_INVALID_TARGET)) {
+					if ((orderTest == ORDER_TEST_OK)
+						|| (orderTest == ORDER_TEST_NEEDS_TARGET)
+						|| (orderTest == ORDER_TEST_NO_MOVEMENT)
+						|| (orderTest == ORDER_TEST_INVALID_TARGET))
+					{
+						m_orderPair[orderButtonIndex].first  = this;
+						m_orderPair[orderButtonIndex].second = const_cast<OrderRecord*>(orderRecord);
 
-						m_orderPair[orderButtonIndex].first = this; //change the index to a list?
-						m_orderPair[orderButtonIndex].second = //change the index to a list?
-							const_cast<OrderRecord*>(orderRecord);
+						m_orderButton[orderButtonIndex]->SetActionFuncAndCookie(OrderButtonActionCallback,
+								&m_orderPair[orderButtonIndex]);
 
-						m_orderButton[orderButtonIndex]->SetActionFuncAndCookie(  //change the index to a list?
-							OrderButtonActionCallback, &m_orderPair[orderButtonIndex]);
-
-						enableState[orderButtonIndex] = true; //change the index to a list?
+						enableState[orderButtonIndex] = true;
 					}
 				}
 			}
 		}
 	}
 
-	for(orderIndex = 0; orderIndex < NUMBER_OF_ORDER_BUTTONS; orderIndex++)
-	{ //change the index to a list?
-		if(m_orderButton[orderIndex]->IsDisabled())
+	for (sint32 orderIndex = 0; orderIndex < NUMBER_OF_ORDER_BUTTONS; orderIndex++)
+	{
+		if (m_orderButton[orderIndex]->IsDisabled())
 		{
-			if(enableState[orderIndex])
+			if (enableState[orderIndex]) {
 				m_orderButton[orderIndex]->Enable(true);
+			}
 		}
-		else if(!enableState[orderIndex])
-		{
+		else if (!enableState[orderIndex]) {
 			m_orderButton[orderIndex]->Enable(false);
 		}
 	}
@@ -922,102 +744,65 @@ void UnitControlPanel::UpdateOrderButtons()  //emod3 this is the method
 
 Army UnitControlPanel::GetSelectedArmy()
 {
+	if (!g_selected_item) {
+		return Army();
+	}
 
-	if(!g_selected_item)
-		return(Army());
+	Player * player = g_player[g_selected_item->GetVisiblePlayer()];
 
-	Player *player = g_player[g_selected_item->GetVisiblePlayer()];
-
-	if(!player)
-		return(Army());
+	if (!player) {
+		return Army();
+	}
 
 	ID id;
 	PLAYER_INDEX playerIndex;
 	SELECT_TYPE selectionType;
-	g_selected_item->GetTopCurItem(playerIndex, id,
-		selectionType);
-
-  	if(selectionType == SELECT_TYPE_LOCAL_ARMY) {
-
+	g_selected_item->GetTopCurItem(playerIndex, id, selectionType);
+	if(selectionType == SELECT_TYPE_LOCAL_ARMY) {
 		return id;
 	}
 
-	if(selectionType == SELECT_TYPE_LOCAL_CITY) {
+	if (selectionType == SELECT_TYPE_LOCAL_CITY)
+	{
 		Unit city(id);
-		Cell *cell = g_theWorld->GetCell(city.RetPos());
-		if(cell->UnitArmy()) {
+		Cell * cell = g_theWorld->GetCell(city.RetPos());
+		if (cell->UnitArmy())
+		{
 			Unit top = cell->UnitArmy()->GetTopVisibleUnit(player->m_owner);
-			if(top.IsValid()) {
-				return top.GetArmy();
-			} else {
-				return cell->AccessUnit(0).GetArmy();
-			}
+			return top.IsValid() ? top.GetArmy() : cell->AccessUnit(0).GetArmy();
 		}
 	}
 
 	return Army();
 }
 
-void UnitControlPanel::GiveOrder(OrderRecord *order)  //emod4 this needs to work from selecting a list
+void UnitControlPanel::GiveOrder(OrderRecord * order)
 {
-
 	g_controlPanel->BeginOrderDelivery(order);
-
-#if 0
-
-	Army army = GetSelectedArmy();
-	if(!g_theArmyPool->IsValid(army))
-		return;
-
-
-	ArmyData *armyData = army.AccessData();
-	if(!armyData)
-		return;
-
-	ORDER_TEST orderTest = armyData->TestOrderHere(order, armyData->RetPos());
-
-	if((orderTest==ORDER_TEST_OK) &&
-		(!order->GetTargetPretestMovePosition()))
-		armyData->PerformOrder(order);
-	else {
-
-
-		g_controlPanel->BeginOrderDelivery(order);
-	}
-#endif
 }
 
-
-
-
-void UnitControlPanel::UnitDisplayGroupCallback(aui_Region *region,
-												void *userData)
+void UnitControlPanel::UnitDisplayGroupCallback(aui_Region * region, void * userData)
 {
-
-	UnitControlPanel *panel = static_cast<UnitControlPanel*>(userData);
-
+	UnitControlPanel * panel = static_cast<UnitControlPanel*>(userData);
 	panel->SetSelectionMode(panel->m_currentMode);
 }
 
-
-void UnitControlPanel::PrevUnitButtonActionCallback(aui_Control *control,
-	uint32 action, uint32 data, void *cookie)
+void UnitControlPanel::PrevUnitButtonActionCallback(aui_Control * control, uint32 action, uint32 data, void * cookie)
 {
-
-	if(action != static_cast<uint32>(AUI_BUTTON_ACTION_EXECUTE))
+	if (action != static_cast<uint32>(AUI_BUTTON_ACTION_EXECUTE)) {
 		return;
+	}
 
-	UnitControlPanel *panel = static_cast<UnitControlPanel*>(cookie);
-
-	switch(panel->m_currentMode) {
+	UnitControlPanel * panel = static_cast<UnitControlPanel*>(cookie);
+	switch (panel->m_currentMode)
+	{
 		case SINGLE_SELECTION:
 		case ARMY_SELECTION:
-
 			panel->SetSelectionMode(MULTIPLE_SELECTION);
 			break;
+
 		case MULTIPLE_SELECTION:
 		default:
-
 			g_selected_item->NextUnmovedUnit();
 			break;
 	}
@@ -1035,7 +820,7 @@ void UnitControlPanel::NextUnitButtonActionCallback(aui_Control * control, uint3
 		case SINGLE_SELECTION:
 		case ARMY_SELECTION:
 			if (SelectionContainsMultipleArmies()) {
-					panel->SetSelectionMode(MULTIPLE_SELECTION);
+				panel->SetSelectionMode(MULTIPLE_SELECTION);
 			} else {
 				g_selected_item->NextUnmovedUnit();
 			}
@@ -1066,28 +851,26 @@ bool UnitControlPanel::SelectionContainsMultipleArmies()
 	return false;
 }
 
-AUI_ERRCODE UnitControlPanel::HealthBarActionCallback(ctp2_Static *control,
-	aui_Surface *surface, RECT &rect, void *cookie)
+AUI_ERRCODE UnitControlPanel::HealthBarActionCallback(ctp2_Static * control, aui_Surface * surface, RECT & rect,
+		void * cookie)
 {
-	Unit        unit        (reinterpret_cast<uint32>(cookie));
+	Unit unit(reinterpret_cast<uint32>(cookie));
+	AUI_ERRCODE errorCode = g_c3ui->TheBlitter()->ColorBlt(surface, &rect, RGB(0,0,0), 0);
+	if (errorCode != AUI_ERRCODE_OK) {
+		return errorCode;
+	}
 
-	AUI_ERRCODE errorCode =
-		g_c3ui->TheBlitter()->ColorBlt(surface, &rect, RGB(0,0,0), 0);
-
-	if(errorCode != AUI_ERRCODE_OK)
-		return(errorCode);
-
-	if(!unit.IsValid())
+	if (!unit.IsValid()) {
 		return AUI_ERRCODE_OK;
+	}
 
-	double healthPercent = (unit->CalculateTotalHP() > 0) ? //.GetDBRec()->GetMaxHP() > 0) ?
-		static_cast<double>(unit.GetHP()) /
-		static_cast<double>(unit->CalculateTotalHP()) : 1.0;//.GetDBRec()->GetMaxHP()) : 1.0;
+	double healthPercent = (unit->CalculateTotalHP() > 0)
+			? static_cast<double>(unit.GetHP()) / static_cast<double>(unit->CalculateTotalHP()) : 1.0;
 
 	Pixel16 color = RGB(255, 0, 0);
-	if(healthPercent > 0.666) {
+	if (healthPercent > 0.666) {
 		color = RGB(0, 255, 0);
-	} else if(healthPercent > 0.333) {
+	} else if (healthPercent > 0.333) {
 		color = RGB(255, 255, 0);
 	}
 
@@ -1096,97 +879,83 @@ AUI_ERRCODE UnitControlPanel::HealthBarActionCallback(ctp2_Static *control,
 	healthRectangle.right = healthRectangle.left +
 		static_cast<sint32>(static_cast<double>(width) * healthPercent);
 
-	if(healthRectangle.right <= healthRectangle.left)
+	if (healthRectangle.right <= healthRectangle.left) {
 		return AUI_ERRCODE_OK;
+	}
 
-	AUI_ERRCODE err = (g_c3ui->TheBlitter()->ColorBlt(surface,
-		&healthRectangle, color, 0));
-
-	return err;
+	return g_c3ui->TheBlitter()->ColorBlt(surface, &healthRectangle, color, 0);
 }
 
-AUI_ERRCODE UnitControlPanel::FuelBarDrawCallback(ctp2_Static *control,
- 												  aui_Surface *surface, RECT &rect, void *cookie)
+AUI_ERRCODE UnitControlPanel::FuelBarDrawCallback(ctp2_Static * control, aui_Surface * surface, RECT & rect,
+		void * cookie)
 {
-	Unit        u  (reinterpret_cast<uint32>(cookie));
+	Unit unit (reinterpret_cast<uint32>(cookie));
 	AUI_ERRCODE errCode = g_c3ui->TheBlitter()->ColorBlt(surface, &rect, RGB(0,0,0), 0);
-
-	if(errCode != AUI_ERRCODE_OK)
+	if (errCode != AUI_ERRCODE_OK) {
 		return errCode;
+	}
 
-	if(!u.IsValid())
+	if (!unit.IsValid()) {
 		return AUI_ERRCODE_OK;
+	}
 
 	sint32 fuel, maxFuel;
-	if(u->GetUsedFuel(fuel, maxFuel)) {
+	if (unit->GetUsedFuel(fuel, maxFuel))
+	{
 		double fuelPercent;
-		if(maxFuel != 0) {
+		if (maxFuel != 0) {
 			fuelPercent = (double)fuel / (double)maxFuel;
 		} else {
 			fuelPercent = 0;
 		}
 
 		RECT fuelRect = rect;
-		fuelRect.left += 2;
-		fuelRect.right -= 2;
-		fuelRect.top += 2;
+		fuelRect.left   += 2;
+		fuelRect.right  -= 2;
+		fuelRect.top    += 2;
 		fuelRect.bottom -= 2;
 
 		sint32 width = fuelRect.right - fuelRect.left;
 		width = sint32(fuelPercent * double(width));
 		fuelRect.right = fuelRect.left + width;
 
-		Pixel16 color;
-		if(fuelPercent < 0.2) {
-			color = RGB(255,0,0);
-		} else if(fuelPercent < 0.5) {
-			color = RGB(255,255,0);
-		} else {
-			color = RGB(0,255,0);
-		}
+		Pixel16 color = (fuelPercent < 0.2) ? RGB(255,0,0) : ((fuelPercent < 0.5) ? RGB(255,255,0)
+				: RGB(0,255,0));
 		errCode = g_c3ui->TheBlitter()->ColorBlt(surface, &fuelRect, color, 0);
 	}
 	return errCode;
 }
 
-
-
-
-void UnitControlPanel::MultiButtonActionCallback(aui_Control *control,
-	uint32 action, uint32 data, void *cookie)
+void UnitControlPanel::MultiButtonActionCallback(aui_Control * control, uint32 action, uint32 data, void * cookie)
 {
-	if (action != static_cast<uint32>(AUI_BUTTON_ACTION_EXECUTE))
+	if (action != static_cast<uint32>(AUI_BUTTON_ACTION_EXECUTE)) {
 		return;
+	}
 
-	std::pair<UnitControlPanel*, uint32> *multiPair =
-		static_cast<std::pair<UnitControlPanel*, uint32>*>(cookie);
-
+	std::pair<UnitControlPanel*, uint32> *multiPair = static_cast<std::pair<UnitControlPanel*, uint32>*>(cookie);
 	Army army(multiPair->second);
 	if (army.IsValid())
-    {
-    	Unit unit = army[0];
-	    if (unit.IsValid())
-        {
-        	g_selected_item->SetSelectUnit(unit);
-        	multiPair->first->SetSelectionMode(ARMY_SELECTION);
-        }
-    }
+	{
+		Unit unit = army[0];
+		if (unit.IsValid())
+		{
+			g_selected_item->SetSelectUnit(unit);
+			multiPair->first->SetSelectionMode(ARMY_SELECTION);
+		}
+	}
 }
 
-
-void UnitControlPanel::ArmyButtonActionCallback(aui_Control *control,
-	uint32 action, uint32 data, void *cookie)
+void UnitControlPanel::ArmyButtonActionCallback(aui_Control * control, uint32 action, uint32 data, void * cookie)
 {
-
-	if(action != static_cast<uint32>(AUI_BUTTON_ACTION_EXECUTE))
+	if (action != static_cast<uint32>(AUI_BUTTON_ACTION_EXECUTE)) {
 		return;
+	}
 
-	UnitControlPanel *panel = static_cast<UnitControlPanel*>(cookie);
-
-
-	for(int armyIndex = 0; armyIndex <
-		NUMBER_OF_ARMY_SELECTION_BUTTONS; armyIndex++) {
-		if(panel->m_armySelectionButton[armyIndex] == control) {
+	UnitControlPanel * panel = static_cast<UnitControlPanel*>(cookie);
+	for (sint32 armyIndex = 0; armyIndex < NUMBER_OF_ARMY_SELECTION_BUTTONS; armyIndex++)
+	{
+		if (panel->m_armySelectionButton[armyIndex] == control)
+		{
 			panel->SetSelectionMode(SINGLE_SELECTION);
 			panel->m_armySelectionUnit = armyIndex;
 			break;
@@ -1196,62 +965,61 @@ void UnitControlPanel::ArmyButtonActionCallback(aui_Control *control,
 	panel->Update();
 }
 
-void UnitControlPanel::OrderButtonActionCallback(aui_Control *control,
-	uint32 action, uint32 data, void *cookie)
+void UnitControlPanel::OrderButtonActionCallback(aui_Control * control, uint32 action, uint32 data, void * cookie)
 {
-
-	if(action != static_cast<uint32>(AUI_BUTTON_ACTION_EXECUTE))
+	if (action != static_cast<uint32>(AUI_BUTTON_ACTION_EXECUTE)) {
 		return;
+	}
 
 	std::pair<UnitControlPanel*, OrderRecord*> *orderPair =
-		static_cast<std::pair<UnitControlPanel*, OrderRecord*>*>(cookie);
-
+			static_cast<std::pair<UnitControlPanel*, OrderRecord*>*>(cookie);
 	orderPair->first->GiveOrder(orderPair->second);
 }
 
 void UnitControlPanel::Activated()
 {
-
 	m_lastSelectedArmy.m_id = 0;
 
-	Army a;
-	if(g_selected_item->GetSelectedArmy(a))
+	Army army;
+	if (g_selected_item->GetSelectedArmy(army)) {
 		return;
+	}
 
-	a = GetSelectedArmy();
-	if(a.IsValid()) {
-		g_selected_item->SetSelectUnit(a[0]);
+	army = GetSelectedArmy();
+	if (army.IsValid()) {
+		g_selected_item->SetSelectUnit(army[0]);
 	}
 }
 
-AUI_ERRCODE UnitControlPanel::DrawCargoCallback(ctp2_Static *control,
-										 aui_Surface *surface,
-										 RECT &rect,
-										 void *cookie)
+AUI_ERRCODE UnitControlPanel::DrawCargoCallback(ctp2_Static * control, aui_Surface * surface, RECT & rect,
+		void * cookie)
 {
-	Unit theTransport   (reinterpret_cast<uint32>(cookie));
-	if (!theTransport.IsValid())
+	Unit transport(reinterpret_cast<uint32>(cookie));
+	if (!transport.IsValid()) {
 		return AUI_ERRCODE_OK;
+	}
 
-	sint32 numCarried = theTransport.GetNumCarried();
-	sint32 capacity = theTransport.GetDBRec()->GetCargoDataPtr()->GetMaxCargo();
-	if(capacity > k_MAX_CP_CARGO)
+	sint32 numCarried = transport.GetNumCarried();
+	sint32 capacity   = transport.GetDBRec()->GetCargoDataPtr()->GetMaxCargo();
+	if (capacity > k_MAX_CP_CARGO) {
 		capacity = k_MAX_CP_CARGO;
+	}
 
 	RECT box = rect;
-	box.left += 2;
-	box.right -= 2;
+	box.left   += 2;
+	box.right  -= 2;
 	box.bottom -= 2;
-	box.top = box.bottom - k_CP_CARGO_HEIGHT;
+	box.top     = box.bottom - k_CP_CARGO_HEIGHT;
 
-	sint32 boxwidth = box.right - box.left;
-	sint32 tickspacewidth = boxwidth / k_MAX_CP_CARGO;
-	sint32 tickwidth = tickspacewidth - 2;
+	sint32 boxWidth       = box.right - box.left;
+	sint32 tickSpaceWidth = boxWidth / k_MAX_CP_CARGO;
+	sint32 tickWidth      = tickSpaceWidth - 2;
 
 	sint32 i;
-	for(i = 0; i < capacity; i++) {
-		RECT tickRect = { box.left + i * tickspacewidth, box.top,
-						  box.left + i * tickspacewidth + tickwidth, box.bottom };
+	for (sint32 i = 0; i < capacity; i++)
+	{
+		RECT tickRect = { box.left + i * tickSpaceWidth, box.top, box.left + i * tickSpaceWidth + tickWidth,
+				box.bottom };
 		Pixel16 color = (i < numCarried) ? RGB(0,255,0) : RGB(0,0,0);
 		g_c3ui->TheBlitter()->ColorBlt(surface, &tickRect, color, 0);
 	}
@@ -1288,17 +1056,18 @@ void UnitControlPanel::TransportSelectionImageCallback(ctp2_Static * control, au
 	g_c3ui->AddAction(new TransportSwitchAction((UnitControlPanel *) cookie, SINGLE_SELECTION));
 }
 
-bool UnitControlPanel::GetSelectedCargo(CellUnitList &cargo)
+bool UnitControlPanel::GetSelectedCargo(CellUnitList & cargoList)
 {
-	cargo.Clear();
-	if(m_transportSelectionDisplay->IsHidden())
+	cargoList.Clear();
+	if (m_transportSelectionDisplay->IsHidden()) {
 		return false;
+	}
 
-	sint32 i;
-	for(i = 0; i < k_MAX_CP_CARGO; i++) {
-		if(m_transportSelectionButton[i]->GetState() &&
-		   Unit(m_transportSelectionCargo[i]).IsValid()) {
-			cargo.Insert(Unit(m_transportSelectionCargo[i]));
+	for(sint32 index = 0; index < k_MAX_CP_CARGO; index++)
+	{
+		Unit cargo(m_transportSelectionCargo[index]);
+		if (m_transportSelectionButton[index]->GetState() && cargo.IsValid()) {
+			cargoList.Insert(cargo);
 		}
 	}
 	return true;
@@ -1306,8 +1075,7 @@ bool UnitControlPanel::GetSelectedCargo(CellUnitList &cargo)
 
 void UnitControlPanel::UnsetCargoButtons()
 {
-	sint32 i;
-	for(i = 0; i < k_MAX_CP_CARGO; i++) {
-		m_transportSelectionButton[i]->SetState(FALSE);
+	for(sint32 index = 0; index < k_MAX_CP_CARGO; index++) {
+		m_transportSelectionButton[index]->SetState(false);
 	}
 }

--- a/ctp2_code/ui/interface/UnitControlPanel.cpp
+++ b/ctp2_code/ui/interface/UnitControlPanel.cpp
@@ -366,7 +366,7 @@ void UnitControlPanel::SelectedUnit()
 	if(g_selected_item->GetSelectedArmy(a) && (!a.IsValid() || (a.Num() < 2))) {
 		SetSelectionMode(SINGLE_SELECTION);
 	} else {
-		SetSelectionMode(MULTIPLE_SELECTION);
+		SetSelectionMode(ARMY_SELECTION);
 	}
 
 	m_lastSelectedArmy.m_id = 0;
@@ -1015,10 +1015,9 @@ void UnitControlPanel::NextUnitButtonActionCallback(aui_Control * control, uint3
 	{
 		case SINGLE_SELECTION:
 		case ARMY_SELECTION:
-			if (g_theWorld->GetCell(g_selected_item->GetCurSelectPos())->GetNumUnits() > 1) {
-				panel->SetSelectionMode(MULTIPLE_SELECTION);
-			}
-			else {
+			if (SelectionContainsMultipleArmies()) {
+					panel->SetSelectionMode(MULTIPLE_SELECTION);
+			} else {
 				g_selected_item->NextUnmovedUnit();
 			}
 			break;
@@ -1028,6 +1027,24 @@ void UnitControlPanel::NextUnitButtonActionCallback(aui_Control * control, uint3
 			g_selected_item->NextUnmovedUnit();
 			break;
 	}
+}
+
+bool UnitControlPanel::SelectionContainsMultipleArmies()
+{
+	CellUnitList unitList;
+	g_theWorld->GetCell(g_selected_item->GetCurSelectPos())->GetArmy(unitList);
+	if (unitList.Num() <= 0) {
+		return false;
+	}
+
+	Army army = unitList.Get(0).GetArmy();
+	for (sint32 i = 1; i < unitList.Num(); i++)
+	{
+		if (unitList.Get(i).GetArmy() != army) {
+			return true;
+		}
+	}
+	return false;
 }
 
 AUI_ERRCODE UnitControlPanel::HealthBarActionCallback(ctp2_Static *control,

--- a/ctp2_code/ui/interface/UnitControlPanel.cpp
+++ b/ctp2_code/ui/interface/UnitControlPanel.cpp
@@ -60,7 +60,8 @@
 
 extern C3UI *g_c3ui;
 
-static MBCHAR * ARMY_SYMBOL = "UPIC21.tga";
+static MBCHAR * ARMY_SYMBOL  = "UPIC21.tga";
+static MBCHAR * CARGO_SYMBOL = "UPC045.tga";
 
 UnitControlPanel::UnitControlPanel(MBCHAR *ldlBlock) :
 m_unitDisplayGroup(static_cast<ctp2_Static*>(
@@ -81,6 +82,9 @@ m_singleSelectionDisplay(static_cast<ctp2_Static*>(
 m_singleSelectionIcon(static_cast<ctp2_Static*>(
 	aui_Ldl::GetObject(ldlBlock,
 	"UnitTab.TabPanel.UnitSelectionDisplay.SingleSelect.Icon"))),
+m_singleSelectionSymbol(static_cast<ctp2_Static*>(
+	aui_Ldl::GetObject(ldlBlock,
+	"UnitTab.TabPanel.UnitSelectionDisplay.SingleSelect.Icon.Symbol"))),
 m_singleSelectionAttack(static_cast<ctp2_Static*>(
 	aui_Ldl::GetObject(ldlBlock,
 	"UnitTab.TabPanel.UnitSelectionDisplay.SingleSelect.Attack.Value"))),
@@ -473,6 +477,7 @@ void UnitControlPanel::UpdateSingleSelectionDisplay()
 
 	if(!unit.IsValid()) {
 		m_singleSelectionIcon->SetImage(NULL);
+		m_singleSelectionSymbol->SetImage(NULL);
 		m_singleSelectionAttack->SetText("");
 		m_singleSelectionDefend->SetText("");
 		m_singleSelectionMove->SetText("");
@@ -493,8 +498,10 @@ void UnitControlPanel::UpdateSingleSelectionDisplay()
 
 	const MBCHAR *unitIconName = iconRecord->GetLargeIcon();
 
-	if(unitIconName && strcmp(unitIconName, "NULL"))
-		m_singleSelectionIcon->SetImage((char *)unitIconName);
+	if(unitIconName && strcmp(unitIconName, "NULL")) {
+		m_singleSelectionIcon->SetImage((char *) unitIconName);
+		m_singleSelectionSymbol->ExchangeImage(0, 0, m_curCargo >= 0 ? CARGO_SYMBOL : NULL);
+	}
 
 	MBCHAR valueString[16];
 

--- a/ctp2_code/ui/interface/UnitControlPanel.cpp
+++ b/ctp2_code/ui/interface/UnitControlPanel.cpp
@@ -451,6 +451,8 @@ void UnitControlPanel::UpdateSingleSelectionDisplay()
 		}
 	}
 
+	m_unitListLabel->SetText(unit.IsValid() ? unit.GetDisplayName().c_str() : "");
+
 	if((m_curSingleArmy.m_id == army.m_id) &&
 	   (m_curSingleUnit.m_id == unit.m_id) &&
 	   (m_curMovement == movement) &&
@@ -475,7 +477,6 @@ void UnitControlPanel::UpdateSingleSelectionDisplay()
 		m_singleSelectionRange->SetText("");
 		m_singleSelectionArmor->SetText("");
 		m_singleSelectionFirepower->SetText("");
-		m_unitListLabel->SetText("");
 
 		m_singleSelectionHealth->SetDrawCallbackAndCookie(NULL, NULL);
 		m_singleSelectionIcon->SetDrawCallbackAndCookie(NULL, NULL);
@@ -532,8 +533,6 @@ void UnitControlPanel::UpdateSingleSelectionDisplay()
 		m_singleSelectionIcon->SetDrawCallbackAndCookie(NULL, NULL, false);
 		m_singleSelectionIcon->SetImageMapCallback(NULL, NULL);
 	}
-
-	m_unitListLabel->SetText(unit.GetDisplayName().c_str());
 }
 
 void UnitControlPanel::UpdateMultipleSelectionDisplay()
@@ -549,6 +548,8 @@ void UnitControlPanel::UpdateMultipleSelectionDisplay()
     {
 		newArmyList.push_back(newUnitList[i].GetArmy());
 	}
+
+	m_unitListLabel->SetText("");
 
 	bool changed = false;
 
@@ -631,8 +632,6 @@ void UnitControlPanel::UpdateMultipleSelectionDisplay()
 			multiIndex++;
 		}
 	}
-
-	m_unitListLabel->SetText("");
 
     m_cellArmyList.swap(newArmyList);
     m_cellUnitList.clear();

--- a/ctp2_code/ui/interface/UnitControlPanel.cpp
+++ b/ctp2_code/ui/interface/UnitControlPanel.cpp
@@ -60,6 +60,8 @@
 
 extern C3UI *g_c3ui;
 
+static MBCHAR * ARMY_SYMBOL = "UPIC21.tga";
+
 UnitControlPanel::UnitControlPanel(MBCHAR *ldlBlock) :
 m_unitDisplayGroup(static_cast<ctp2_Static*>(
 	aui_Ldl::GetObject(ldlBlock,
@@ -611,8 +613,7 @@ void UnitControlPanel::UpdateMultipleSelectionDisplay()
 				m_multipleSelectionButton[multiIndex]->ExchangeImage(0, 0,
 					unit.GetDBRec()->GetDefaultIcon()->GetIcon());
 				if(army.IsValid() && army.Num() > 1) {
-					m_multipleSelectionButton[multiIndex]->ExchangeImage(1, 0,
-																		 "UPIC21.tga");
+					m_multipleSelectionButton[multiIndex]->ExchangeImage(1, 0, ARMY_SYMBOL);
 				} else {
 					m_multipleSelectionButton[multiIndex]->ExchangeImage(1, 0, NULL);
 				}
@@ -653,10 +654,10 @@ void UnitControlPanel::UpdateArmySelectionDisplay()
 
 	Unit unit = army[0];
 	if (unit.IsValid())
-    {
-		m_armySelectionIcon->ExchangeImage
-            (0, 0, unit.GetDBRec()->GetDefaultIcon()->GetIcon());
-    }
+	{
+		m_armySelectionIcon->ExchangeImage(0, 0, unit.GetDBRec()->GetDefaultIcon()->GetIcon());
+		m_armySelectionIcon->ExchangeImage(1, 0, ARMY_SYMBOL);
+	}
 
 	for (int armyIndex = 0; armyIndex <
 		NUMBER_OF_ARMY_SELECTION_BUTTONS; armyIndex++) {

--- a/ctp2_code/ui/interface/UnitControlPanel.cpp
+++ b/ctp2_code/ui/interface/UnitControlPanel.cpp
@@ -110,9 +110,9 @@ m_multipleSelectionDisplay(static_cast<ctp2_Static*>(
 m_armySelectionDisplay(static_cast<ctp2_Static*>(
 	aui_Ldl::GetObject(ldlBlock,
 	"UnitTab.TabPanel.UnitSelectionDisplay.ArmySelect"))),
-m_armySelectionIcon(static_cast<ctp2_Button*>(
+m_armySelectionIcon(static_cast<ctp2_Static*>(
 	aui_Ldl::GetObject(ldlBlock,
-	"UnitTab.TabPanel.UnitSelectionDisplay.ArmySelect.Icon"))),
+	"UnitTab.TabPanel.UnitSelectionDisplay.ArmySelect.Background.Icon"))),
 m_transportSelectionDisplay(static_cast<ctp2_Static *>(
 	aui_Ldl::GetObject(ldlBlock, "UnitTab.TabPanel.UnitSelectionDisplay.TransportSelect"))),
 m_transportSelectionIcon(static_cast<ctp2_Button *>(
@@ -654,8 +654,13 @@ void UnitControlPanel::UpdateArmySelectionDisplay()
 	Unit unit = army[0];
 	if (unit.IsValid())
 	{
-		m_armySelectionIcon->ExchangeImage(0, 0, unit.GetDBRec()->GetDefaultIcon()->GetIcon());
-		m_armySelectionIcon->ExchangeImage(1, 0, ARMY_SYMBOL);
+		const MBCHAR * armyIconName = unit.GetDBRec()->GetDefaultIcon()->GetLargeIcon();
+		if (!armyIconName || strcmp(armyIconName, "NULL") == 0) {
+			armyIconName = unit.GetDBRec()->GetDefaultIcon()->GetIcon();
+		}
+		if (armyIconName && strcmp(armyIconName, "NULL") != 0) {
+			m_armySelectionIcon->ExchangeImage(0, 0, armyIconName);
+		}
 	}
 
 	for (int armyIndex = 0; armyIndex <

--- a/ctp2_code/ui/interface/UnitControlPanel.cpp
+++ b/ctp2_code/ui/interface/UnitControlPanel.cpp
@@ -26,9 +26,9 @@
 //
 // - Option added to select which order buttons are displayed for an army.
 // - Added unit display name.
-// - Standartized code (May 21st 2006 Martin Gühmann)
-// - Added a custom status bar text for the upgrade order. (13-Sep-2008 Martin Gühmann)
-// - Changed occurances of UnitRecord::GetMaxHP to
+// - Standardized code (May 21st 2006 Martin GÃ¼hmann)
+// - Added a custom status bar text for the upgrade order. (13-Sep-2008 Martin GÃ¼hmann)
+// - Changed occurrences of UnitRecord::GetMaxHP to
 //   UnitData::CalculateTotalHP. (Aug 3rd 2009 Maq)
 //
 //----------------------------------------------------------------------------
@@ -38,7 +38,6 @@
 
 #include "ArmyData.h"
 #include "ArmyPool.h"
-#include "aui_blitter.h"
 #include "aui_ldl.h"
 #include "c3ui.h"
 #include "Cell.h"
@@ -199,7 +198,7 @@ m_transportSelectionIcon(static_cast<ctp2_Button *>(
 #define k_TERRAINIMP_COLS_PER_ROW 6
 	m_terrainImpSwitches        (NULL),
 new and delete in constructor/dest
-  		s_scenarioEditor->PopulateTerrainImprovementList();  //emod5 defientely need something to populate it
+  		s_scenarioEditor->PopulateTerrainImprovementList();  //emod5 definitely need something to populate it
 
 void ScenarioEditor::PopulateTerrainImprovementList()  //emod1 note  use this format instead of current switches but add item populating checks?
 {
@@ -940,7 +939,7 @@ Army UnitControlPanel::GetSelectedArmy()
 	return Army();
 }
 
-void UnitControlPanel::GiveOrder(OrderRecord *order)  //emod4 this needs to work from selectinga list
+void UnitControlPanel::GiveOrder(OrderRecord *order)  //emod4 this needs to work from selecting a list
 {
 
 	g_controlPanel->BeginOrderDelivery(order);
@@ -1005,24 +1004,27 @@ void UnitControlPanel::PrevUnitButtonActionCallback(aui_Control *control,
 	}
 }
 
-void UnitControlPanel::NextUnitButtonActionCallback(aui_Control *control,
-	uint32 action, uint32 data, void *cookie)
+void UnitControlPanel::NextUnitButtonActionCallback(aui_Control * control, uint32 action, uint32 data, void * cookie)
 {
-
-	if(action != static_cast<uint32>(AUI_BUTTON_ACTION_EXECUTE))
+	if (action != static_cast<uint32>(AUI_BUTTON_ACTION_EXECUTE)) {
 		return;
+	}
 
-	UnitControlPanel *panel = static_cast<UnitControlPanel*>(cookie);
-
-	switch(panel->m_currentMode) {
+	UnitControlPanel * panel = static_cast<UnitControlPanel*>(cookie);
+	switch (panel->m_currentMode)
+	{
 		case SINGLE_SELECTION:
 		case ARMY_SELECTION:
-
-			panel->SetSelectionMode(MULTIPLE_SELECTION);
+			if (g_theWorld->GetCell(g_selected_item->GetCurSelectPos())->GetNumUnits() > 1) {
+				panel->SetSelectionMode(MULTIPLE_SELECTION);
+			}
+			else {
+				g_selected_item->NextUnmovedUnit();
+			}
 			break;
+
 		case MULTIPLE_SELECTION:
 		default:
-
 			g_selected_item->NextUnmovedUnit();
 			break;
 	}

--- a/ctp2_code/ui/interface/UnitControlPanel.cpp
+++ b/ctp2_code/ui/interface/UnitControlPanel.cpp
@@ -68,8 +68,6 @@ static MBCHAR * ARMY_SYMBOL  = "UPIC21.tga";
 UnitControlPanel::UnitControlPanel(MBCHAR * ldlBlock) :
 m_unitDisplayGroup(static_cast<ctp2_Static*>(aui_Ldl::GetObject(ldlBlock,
 		"UnitTab.TabPanel.UnitSelectionDisplay"))),
-m_unitListPreviousButton(static_cast<ctp2_Button*>(aui_Ldl::GetObject(ldlBlock,
-		"UnitTab.TabPanel.UnitSelectionDisplay.UnitSelect.Previous"))),
 m_unitListLabel(static_cast<ctp2_Static*>(aui_Ldl::GetObject(ldlBlock,
 		"UnitTab.TabPanel.UnitSelectionDisplay.UnitSelect.Label"))),
 m_unitListNextButton(static_cast<ctp2_Button*>(aui_Ldl::GetObject(ldlBlock,
@@ -118,7 +116,6 @@ m_cellUnitList(),
 m_cellArmyList()
 {
 	Assert(m_unitDisplayGroup);
-	Assert(m_unitListPreviousButton);
 	Assert(m_unitListLabel);
 	Assert(m_unitListNextButton);
 	Assert(m_singleSelectionDisplay);
@@ -195,7 +192,6 @@ m_cellArmyList()
 	m_singleSelectionArmySymbol->SetImageMapCallback(SingleSelectionArmySymbolImageCallback, this);
 	m_transportSelectionIcon->SetImageMapCallback(TransportSelectionImageCallback, this);
 
-	m_unitListPreviousButton->SetActionFuncAndCookie(PrevUnitButtonActionCallback, this);
 	m_unitListNextButton->SetActionFuncAndCookie(NextUnitButtonActionCallback, this);
 
 	SetSelectionMode(MULTIPLE_SELECTION);
@@ -816,27 +812,6 @@ void UnitControlPanel::UnitDisplayGroupCallback(aui_Region * region, void * user
 {
 	UnitControlPanel * panel = static_cast<UnitControlPanel*>(userData);
 	panel->SetSelectionMode(panel->m_currentMode);
-}
-
-void UnitControlPanel::PrevUnitButtonActionCallback(aui_Control * control, uint32 action, uint32 data, void * cookie)
-{
-	if (action != static_cast<uint32>(AUI_BUTTON_ACTION_EXECUTE)) {
-		return;
-	}
-
-	UnitControlPanel * panel = static_cast<UnitControlPanel*>(cookie);
-	switch (panel->m_currentMode)
-	{
-		case SINGLE_SELECTION:
-		case ARMY_SELECTION:
-			panel->SetSelectionMode(MULTIPLE_SELECTION);
-			break;
-
-		case MULTIPLE_SELECTION:
-		default:
-			g_selected_item->NextUnmovedUnit();
-			break;
-	}
 }
 
 void UnitControlPanel::NextUnitButtonActionCallback(aui_Control * control, uint32 action, uint32 data, void * cookie)

--- a/ctp2_code/ui/interface/UnitControlPanel.h
+++ b/ctp2_code/ui/interface/UnitControlPanel.h
@@ -9,8 +9,8 @@
 
 class UnitControlPanel;
 
-#include "Army.h"           // Army
-#include "Unit.h"           // Unit
+#include "Army.h"
+#include "Unit.h"
 
 class aui_Control;
 class aui_Region;
@@ -26,17 +26,6 @@ struct aui_MouseEvent;
 
 class UnitControlPanel {
 public:
-
-	UnitControlPanel(MBCHAR *ldlBlock);
-
-	void Update();
-
-	void SelectedUnit();
-
-	void Activated();
-
-	bool GetSelectedCargo(CellUnitList &cargo);
-
 	enum UnitSelectionMode {
 		SINGLE_SELECTION,
 		MULTIPLE_SELECTION,
@@ -44,128 +33,102 @@ public:
 		TRANSPORT_SELECTION,
 	};
 
+	UnitControlPanel(MBCHAR *ldlBlock);
+
+	void Update();
+	void SelectedUnit();
+	void Activated();
+
+	bool GetSelectedCargo(CellUnitList & cargoList);
 
 	void SetSelectionMode(UnitSelectionMode mode);
 
 private:
-
 	void UpdateSingleSelectionDisplay();
-
 	void UpdateMultipleSelectionDisplay();
-
 	void UpdateArmySelectionDisplay();
-
 	void UpdateTransportSelectionDisplay();
-
 	void UpdateOrderButtons();
 
-
 	Army GetSelectedArmy();
-
 	void GiveOrder(OrderRecord *order);
+	void UnsetCargoButtons();
 
+	static void UnitDisplayGroupCallback(aui_Region * region, void * userData);
+	static void PrevUnitButtonActionCallback(aui_Control * control, uint32 action, uint32 data, void * cookie);
+	static void NextUnitButtonActionCallback(aui_Control * control, uint32 action, uint32 data, void * cookie);
+	static void MultiButtonActionCallback(aui_Control * control, uint32 action, uint32 data, void * cookie);
+	static void ArmyButtonActionCallback(aui_Control * control, uint32 action, uint32 data, void * cookie);
+	static void OrderButtonActionCallback(aui_Control * control, uint32 action, uint32 data, void * cookie);
 
-
-
-	static void UnitDisplayGroupCallback(aui_Region *region,
-		void *userData);
-
-	static void PrevUnitButtonActionCallback(aui_Control *control,
-		uint32 action, uint32 data, void *cookie);
-
-	static void NextUnitButtonActionCallback(aui_Control *control,
-		uint32 action, uint32 data, void *cookie);
-
-	static AUI_ERRCODE HealthBarActionCallback(ctp2_Static *control,
-		aui_Surface *surface, RECT &rect, void *cookie);
-
-	static AUI_ERRCODE FuelBarDrawCallback(ctp2_Static *control,
-		aui_Surface *surface, RECT &rect, void *cookie);
-
-	static AUI_ERRCODE DrawCargoCallback(ctp2_Static *control, aui_Surface *surface,
-										 RECT &rect, void *cookie);
-
-
-	static void MultiButtonActionCallback(aui_Control *control,
-		uint32 action, uint32 data, void *cookie);
-
-
-	static void ArmyButtonActionCallback(aui_Control *control,
-		uint32 action, uint32 data, void *cookie);
-
-	static void OrderButtonActionCallback(aui_Control *control,
-		uint32 action, uint32 data, void *cookie);
+	static AUI_ERRCODE HealthBarActionCallback(ctp2_Static * control, aui_Surface * surface, RECT & rect,
+			void * cookie);
+	static AUI_ERRCODE FuelBarDrawCallback(ctp2_Static * control, aui_Surface * surface, RECT & rect, void * cookie);
+	static AUI_ERRCODE DrawCargoCallback(ctp2_Static * control, aui_Surface * surface, RECT & rect, void * cookie);
 
 	static void TransportImageCallback(ctp2_Static * control, aui_MouseEvent * event, void * cookie);
 	static void TransportSelectionImageCallback(ctp2_Static * control, aui_MouseEvent * event, void * cookie);
-	static bool SelectionContainsMultipleArmies();
 
-	void UnsetCargoButtons();
+	static bool SelectionContainsMultipleArmies();
 
 	UnitSelectionMode m_currentMode;
 
-	ctp2_Static *m_unitDisplayGroup;
+	ctp2_Static * m_unitDisplayGroup;
 
-	ctp2_Button *m_unitListPreviousButton;
-	ctp2_Static *m_unitListLabel;
-	ctp2_Button *m_unitListNextButton;
+	ctp2_Button * m_unitListPreviousButton;
+	ctp2_Static * m_unitListLabel;
+	ctp2_Button * m_unitListNextButton;
 
-	ctp2_Static *m_singleSelectionDisplay;
-	ctp2_Static *m_singleSelectionIcon;
-	ctp2_Static *m_singleSelectionSymbol;
-	ctp2_Static *m_singleSelectionAttack;
-	ctp2_Static *m_singleSelectionDefend;
-	ctp2_Static *m_singleSelectionMove;
-	ctp2_Static *m_singleSelectionRange;
-	ctp2_Static *m_singleSelectionArmor;
-	ctp2_Static *m_singleSelectionFirepower;
-	ctp2_Static *m_singleSelectionHealth;
-	ctp2_Static *m_singleSelectionFuel;
+	ctp2_Static * m_singleSelectionDisplay;
+	ctp2_Static * m_singleSelectionIcon;
+	ctp2_Static * m_singleSelectionSymbol;
+	ctp2_Static * m_singleSelectionAttack;
+	ctp2_Static * m_singleSelectionDefend;
+	ctp2_Static * m_singleSelectionMove;
+	ctp2_Static * m_singleSelectionRange;
+	ctp2_Static * m_singleSelectionArmor;
+	ctp2_Static * m_singleSelectionFirepower;
+	ctp2_Static * m_singleSelectionHealth;
+	ctp2_Static * m_singleSelectionFuel;
 
-	enum { NUMBER_OF_MULTIPLE_SELECTION_BUTTONS = 12 };
-	ctp2_Static *m_multipleSelectionDisplay;
-	ctp2_Button *m_multipleSelectionButton[
-		NUMBER_OF_MULTIPLE_SELECTION_BUTTONS];
-	ctp2_Static *m_multipleSelectionHealth[NUMBER_OF_MULTIPLE_SELECTION_BUTTONS];
+	static const sint32 NUMBER_OF_MULTIPLE_SELECTION_BUTTONS = 12;
+	ctp2_Static * m_multipleSelectionDisplay;
+	ctp2_Button * m_multipleSelectionButton[NUMBER_OF_MULTIPLE_SELECTION_BUTTONS];
+	ctp2_Static * m_multipleSelectionHealth[NUMBER_OF_MULTIPLE_SELECTION_BUTTONS];
+	std::pair<UnitControlPanel*, uint32> m_multiPair[NUMBER_OF_MULTIPLE_SELECTION_BUTTONS];
 
-	std::pair<UnitControlPanel*, uint32>
-		m_multiPair[NUMBER_OF_MULTIPLE_SELECTION_BUTTONS];
+	static const sint32 NUMBER_OF_ARMY_SELECTION_BUTTONS = 12;
+	ctp2_Static * m_armySelectionDisplay;
+	ctp2_Static * m_armySelectionIcon;
+	ctp2_Button * m_armySelectionButton[NUMBER_OF_ARMY_SELECTION_BUTTONS];
+	ctp2_Static * m_armySelectionHealth[NUMBER_OF_ARMY_SELECTION_BUTTONS];
 
-	enum { NUMBER_OF_ARMY_SELECTION_BUTTONS = 12 };
-	ctp2_Static *m_armySelectionDisplay;
-	ctp2_Static *m_armySelectionIcon;
-	ctp2_Button *m_armySelectionButton[
-		NUMBER_OF_ARMY_SELECTION_BUTTONS];
-	ctp2_Static *m_armySelectionHealth[NUMBER_OF_ARMY_SELECTION_BUTTONS];
-
-	ctp2_Static *m_transportSelectionDisplay;
-	ctp2_Static *m_transportSelectionIcon;
-	ctp2_Switch *m_transportSelectionButton[k_MAX_CP_CARGO];
-	uint32       m_transportSelectionCargo[k_MAX_CP_CARGO];
-	ctp2_Static *m_transportSelectionHealth[k_MAX_CP_CARGO];
+	ctp2_Static * m_transportSelectionDisplay;
+	ctp2_Static * m_transportSelectionIcon;
+	ctp2_Switch * m_transportSelectionButton[k_MAX_CP_CARGO];
+	uint32        m_transportSelectionCargo[k_MAX_CP_CARGO];
+	ctp2_Static * m_transportSelectionHealth[k_MAX_CP_CARGO];
 
 	sint32 m_armySelectionUnit;
 
-	enum { NUMBER_OF_ORDER_BUTTONS = 12 };
-	sint32 m_displayedOrderIndex[NUMBER_OF_ORDER_BUTTONS];
-	ctp2_Button *m_orderButton[NUMBER_OF_ORDER_BUTTONS];
+	static const sint32 NUMBER_OF_ORDER_BUTTONS = 12;
+	sint32        m_displayedOrderIndex[NUMBER_OF_ORDER_BUTTONS];
+	ctp2_Button * m_orderButton[NUMBER_OF_ORDER_BUTTONS];
+	std::pair<UnitControlPanel*, OrderRecord*> m_orderPair[NUMBER_OF_ORDER_BUTTONS];
 
-	std::pair<UnitControlPanel*, OrderRecord*>
-		m_orderPair[NUMBER_OF_ORDER_BUTTONS];
-
-	Army m_curSingleArmy;
-	Unit m_curSingleUnit;
+	Army   m_curSingleArmy;
+	Unit   m_curSingleUnit;
 	double m_curMovement;
 	double m_curHealth;
 	sint32 m_curCargo;
 	sint32 m_curFuel;
 
-	Army m_lastSelectedArmy;
+	Army   m_lastSelectedArmy;
 	sint32 m_lastSelectionUnit;
 	sint32 m_lastSelectedArmyCount;
 
-    std::vector<Unit>   m_cellUnitList;
-    std::vector<Army>   m_cellArmyList;
+    std::vector<Unit> m_cellUnitList;
+    std::vector<Army> m_cellArmyList;
 };
 
 #endif

--- a/ctp2_code/ui/interface/UnitControlPanel.h
+++ b/ctp2_code/ui/interface/UnitControlPanel.h
@@ -44,6 +44,8 @@ public:
 	void SetSelectionMode(UnitSelectionMode mode);
 
 private:
+	void DoSetSelectionMode(UnitSelectionMode mode);
+
 	void UpdateSingleSelectionDisplay();
 	void UpdateMultipleSelectionDisplay();
 	void UpdateArmySelectionDisplay();
@@ -53,6 +55,7 @@ private:
 	Army GetSelectedArmy();
 	void GiveOrder(OrderRecord *order);
 	void UnsetCargoButtons();
+	void updateSingleSelectionSymbols();
 
 	static void UnitDisplayGroupCallback(aui_Region * region, void * userData);
 	static void PrevUnitButtonActionCallback(aui_Control * control, uint32 action, uint32 data, void * cookie);
@@ -66,6 +69,7 @@ private:
 	static AUI_ERRCODE FuelBarDrawCallback(ctp2_Static * control, aui_Surface * surface, RECT & rect, void * cookie);
 	static AUI_ERRCODE DrawCargoCallback(ctp2_Static * control, aui_Surface * surface, RECT & rect, void * cookie);
 
+	static void SingleSelectionArmySymbolImageCallback(ctp2_Static * control, aui_MouseEvent * event, void * cookie);
 	static void TransportImageCallback(ctp2_Static * control, aui_MouseEvent * event, void * cookie);
 	static void TransportSelectionImageCallback(ctp2_Static * control, aui_MouseEvent * event, void * cookie);
 
@@ -81,7 +85,8 @@ private:
 
 	ctp2_Static * m_singleSelectionDisplay;
 	ctp2_Static * m_singleSelectionIcon;
-	ctp2_Static * m_singleSelectionSymbol;
+	ctp2_Static * m_singleSelectionArmySymbol;
+	ctp2_Static * m_singleSelectionCargoSymbol;
 	ctp2_Static * m_singleSelectionAttack;
 	ctp2_Static * m_singleSelectionDefend;
 	ctp2_Static * m_singleSelectionMove;
@@ -102,14 +107,14 @@ private:
 	ctp2_Static * m_armySelectionIcon;
 	ctp2_Button * m_armySelectionButton[NUMBER_OF_ARMY_SELECTION_BUTTONS];
 	ctp2_Static * m_armySelectionHealth[NUMBER_OF_ARMY_SELECTION_BUTTONS];
+	sint32        m_armySelectionUnit;
 
 	ctp2_Static * m_transportSelectionDisplay;
 	ctp2_Static * m_transportSelectionIcon;
+	ctp2_Static * m_transportSelectionIconArmySymbol;
 	ctp2_Switch * m_transportSelectionButton[k_MAX_CP_CARGO];
 	uint32        m_transportSelectionCargo[k_MAX_CP_CARGO];
 	ctp2_Static * m_transportSelectionHealth[k_MAX_CP_CARGO];
-
-	sint32 m_armySelectionUnit;
 
 	static const sint32 NUMBER_OF_ORDER_BUTTONS = 12;
 	sint32        m_displayedOrderIndex[NUMBER_OF_ORDER_BUTTONS];
@@ -129,6 +134,8 @@ private:
 
     std::vector<Unit> m_cellUnitList;
     std::vector<Army> m_cellArmyList;
+
+    class SetSelectionAction;
 };
 
 #endif

--- a/ctp2_code/ui/interface/UnitControlPanel.h
+++ b/ctp2_code/ui/interface/UnitControlPanel.h
@@ -96,9 +96,8 @@ private:
 	static void OrderButtonActionCallback(aui_Control *control,
 		uint32 action, uint32 data, void *cookie);
 
-	static void TransportImageCallback(ctp2_Static *control,
-									   aui_MouseEvent *event,
-									   void *cookie);
+	static void TransportImageCallback(ctp2_Static * control, aui_MouseEvent * event, void * cookie);
+	static void TransportSelectionImageCallback(ctp2_Static * control, aui_MouseEvent * event, void * cookie);
 	static bool SelectionContainsMultipleArmies();
 
 	void UnsetCargoButtons();
@@ -139,7 +138,7 @@ private:
 	ctp2_Static *m_armySelectionHealth[NUMBER_OF_ARMY_SELECTION_BUTTONS];
 
 	ctp2_Static *m_transportSelectionDisplay;
-	ctp2_Button *m_transportSelectionIcon;
+	ctp2_Static *m_transportSelectionIcon;
 	ctp2_Switch *m_transportSelectionButton[k_MAX_CP_CARGO];
 	uint32       m_transportSelectionCargo[k_MAX_CP_CARGO];
 	ctp2_Static *m_transportSelectionHealth[k_MAX_CP_CARGO];

--- a/ctp2_code/ui/interface/UnitControlPanel.h
+++ b/ctp2_code/ui/interface/UnitControlPanel.h
@@ -58,7 +58,6 @@ private:
 	void UpdateSingleSelectionSymbols();
 
 	static void UnitDisplayGroupCallback(aui_Region * region, void * userData);
-	static void PrevUnitButtonActionCallback(aui_Control * control, uint32 action, uint32 data, void * cookie);
 	static void NextUnitButtonActionCallback(aui_Control * control, uint32 action, uint32 data, void * cookie);
 	static void MultiButtonActionCallback(aui_Control * control, uint32 action, uint32 data, void * cookie);
 	static void ArmyButtonActionCallback(aui_Control * control, uint32 action, uint32 data, void * cookie);
@@ -84,7 +83,6 @@ private:
 
 	ctp2_Static * m_unitDisplayGroup;
 
-	ctp2_Button * m_unitListPreviousButton;
 	ctp2_Static * m_unitListLabel;
 	ctp2_Button * m_unitListNextButton;
 

--- a/ctp2_code/ui/interface/UnitControlPanel.h
+++ b/ctp2_code/ui/interface/UnitControlPanel.h
@@ -56,6 +56,7 @@ private:
 	void GiveOrder(OrderRecord *order);
 	void UnsetCargoButtons();
 	void UpdateSingleSelectionSymbols();
+	void UpdateMultiSelectionArmySymbols();
 
 	static void UnitDisplayGroupCallback(aui_Region * region, void * userData);
 	static void NextUnitButtonActionCallback(aui_Control * control, uint32 action, uint32 data, void * cookie);
@@ -104,6 +105,7 @@ private:
 	ctp2_Static * m_multipleSelectionDisplay;
 	ctp2_Button * m_multipleSelectionButton[NUMBER_OF_MULTIPLE_SELECTION_BUTTONS];
 	ctp2_Static * m_multipleSelectionHealth[NUMBER_OF_MULTIPLE_SELECTION_BUTTONS];
+	ctp2_Static * m_multipleSelectionArmySymbol[NUMBER_OF_MULTIPLE_SELECTION_BUTTONS];
 
 	static const sint32 NUMBER_OF_ARMY_SELECTION_BUTTONS = 12;
 	ctp2_Static * m_armySelectionDisplay;

--- a/ctp2_code/ui/interface/UnitControlPanel.h
+++ b/ctp2_code/ui/interface/UnitControlPanel.h
@@ -55,7 +55,7 @@ private:
 	Army GetSelectedArmy();
 	void GiveOrder(OrderRecord *order);
 	void UnsetCargoButtons();
-	void updateSingleSelectionSymbols();
+	void UpdateSingleSelectionSymbols();
 
 	static void UnitDisplayGroupCallback(aui_Region * region, void * userData);
 	static void PrevUnitButtonActionCallback(aui_Control * control, uint32 action, uint32 data, void * cookie);
@@ -66,6 +66,8 @@ private:
 
 	static AUI_ERRCODE HealthBarActionCallback(ctp2_Static * control, aui_Surface * surface, RECT & rect,
 			void * cookie);
+	static AUI_ERRCODE StackSymbolDrawCallback(ctp2_Static * control, aui_Surface * surface, RECT & rect,
+			void * cookie);
 	static AUI_ERRCODE FuelBarDrawCallback(ctp2_Static * control, aui_Surface * surface, RECT & rect, void * cookie);
 	static AUI_ERRCODE DrawCargoCallback(ctp2_Static * control, aui_Surface * surface, RECT & rect, void * cookie);
 
@@ -74,6 +76,7 @@ private:
 	static void TransportSelectionImageCallback(ctp2_Static * control, aui_MouseEvent * event, void * cookie);
 
 	static bool SelectionContainsMultipleArmies();
+	static void LoadImage00(ctp2_Static * control);
 
 	UnitSelectionMode m_currentMode;
 
@@ -87,6 +90,7 @@ private:
 	ctp2_Static * m_singleSelectionIcon;
 	ctp2_Static * m_singleSelectionArmySymbol;
 	ctp2_Static * m_singleSelectionCargoSymbol;
+	ctp2_Static * m_singleSelectionStackSymbol;
 	ctp2_Static * m_singleSelectionAttack;
 	ctp2_Static * m_singleSelectionDefend;
 	ctp2_Static * m_singleSelectionMove;
@@ -105,6 +109,7 @@ private:
 	static const sint32 NUMBER_OF_ARMY_SELECTION_BUTTONS = 12;
 	ctp2_Static * m_armySelectionDisplay;
 	ctp2_Static * m_armySelectionIcon;
+	ctp2_Static * m_armySelectionStackSymbol;
 	ctp2_Button * m_armySelectionButton[NUMBER_OF_ARMY_SELECTION_BUTTONS];
 	ctp2_Static * m_armySelectionHealth[NUMBER_OF_ARMY_SELECTION_BUTTONS];
 	sint32        m_armySelectionUnit;

--- a/ctp2_code/ui/interface/UnitControlPanel.h
+++ b/ctp2_code/ui/interface/UnitControlPanel.h
@@ -133,7 +133,7 @@ private:
 
 	enum { NUMBER_OF_ARMY_SELECTION_BUTTONS = 12 };
 	ctp2_Static *m_armySelectionDisplay;
-	ctp2_Button *m_armySelectionIcon;
+	ctp2_Static *m_armySelectionIcon;
 	ctp2_Button *m_armySelectionButton[
 		NUMBER_OF_ARMY_SELECTION_BUTTONS];
 	ctp2_Static *m_armySelectionHealth[NUMBER_OF_ARMY_SELECTION_BUTTONS];

--- a/ctp2_code/ui/interface/UnitControlPanel.h
+++ b/ctp2_code/ui/interface/UnitControlPanel.h
@@ -112,6 +112,7 @@ private:
 
 	ctp2_Static *m_singleSelectionDisplay;
 	ctp2_Static *m_singleSelectionIcon;
+	ctp2_Static *m_singleSelectionSymbol;
 	ctp2_Static *m_singleSelectionAttack;
 	ctp2_Static *m_singleSelectionDefend;
 	ctp2_Static *m_singleSelectionMove;

--- a/ctp2_code/ui/interface/UnitControlPanel.h
+++ b/ctp2_code/ui/interface/UnitControlPanel.h
@@ -99,6 +99,7 @@ private:
 	static void TransportImageCallback(ctp2_Static *control,
 									   aui_MouseEvent *event,
 									   void *cookie);
+	static bool SelectionContainsMultipleArmies();
 
 	void UnsetCargoButtons();
 

--- a/ctp2_code/ui/interface/UnitControlPanel.h
+++ b/ctp2_code/ui/interface/UnitControlPanel.h
@@ -72,11 +72,13 @@ private:
 	static AUI_ERRCODE DrawCargoCallback(ctp2_Static * control, aui_Surface * surface, RECT & rect, void * cookie);
 
 	static void SingleSelectionArmySymbolImageCallback(ctp2_Static * control, aui_MouseEvent * event, void * cookie);
+	static void StackSymbolImageCallback(ctp2_Static * control, aui_MouseEvent * event, void * cookie);
 	static void TransportImageCallback(ctp2_Static * control, aui_MouseEvent * event, void * cookie);
 	static void TransportSelectionImageCallback(ctp2_Static * control, aui_MouseEvent * event, void * cookie);
 
 	static bool SelectionContainsMultipleArmies();
 	static void LoadImage00(ctp2_Static * control);
+	static void SetVisibilityStackSymbol(ctp2_Static * stackSymbol);
 
 	UnitSelectionMode m_currentMode;
 
@@ -104,7 +106,6 @@ private:
 	ctp2_Static * m_multipleSelectionDisplay;
 	ctp2_Button * m_multipleSelectionButton[NUMBER_OF_MULTIPLE_SELECTION_BUTTONS];
 	ctp2_Static * m_multipleSelectionHealth[NUMBER_OF_MULTIPLE_SELECTION_BUTTONS];
-	std::pair<UnitControlPanel*, uint32> m_multiPair[NUMBER_OF_MULTIPLE_SELECTION_BUTTONS];
 
 	static const sint32 NUMBER_OF_ARMY_SELECTION_BUTTONS = 12;
 	ctp2_Static * m_armySelectionDisplay;
@@ -137,10 +138,11 @@ private:
 	sint32 m_lastSelectionUnit;
 	sint32 m_lastSelectedArmyCount;
 
-    std::vector<Unit> m_cellUnitList;
-    std::vector<Army> m_cellArmyList;
+	std::vector<Unit> m_cellUnitList;
+	std::vector<Army> m_cellArmyList;
 
-    class SetSelectionAction;
+	class SetSelectionAction;
+	class SelectUnitAction;
 };
 
 #endif

--- a/ctp2_data/default/uidata/layouts/controlpanel.ldl
+++ b/ctp2_data/default/uidata/layouts/controlpanel.ldl
@@ -19,8 +19,8 @@
 #  Modifications from the original Activision code:
 #
 # - Added to the tileimp tracker popup window a construction time line.
-#   (Aug 15th 2005 Martin Gühmann)
-# - Made the special attack window work. (Aug 16th 2005 Martin Gühmann)
+#   (Aug 15th 2005 Martin GÃ¼hmann)
+# - Made the special attack window work. (Aug 16th 2005 Martin GÃ¼hmann)
 # - Added political map button - 6-Jul-2009 EPW
 # -Added view capital button -5-Jan-2009 EPW
 # -Added view relations button -7-Jan-10 EPW
@@ -340,10 +340,22 @@ template UNIT_LABEL_SPINNER:CTP2_STATIC_GROUP {
 		int		widthpix	124
 		int		heightpix	29
 
+		int		numberoflayers		2
+
 		# Background.
-		string	image00				"upsp01bl.tga"
-		string	image01				"upsp01bm.tga"
-		string	image02				"upsp01br.tga"
+		string	image00				"uppd02ax.tga"
+		string	image01				"uppd02bx.tga"
+		string	image02				"uppd02dx.tga"
+
+		# enabled
+		bool	layerenabled1				true
+		# Mark the middle images as stretchable.
+		bool	imagestretchx11			true
+		string	imageblttype11				"tile"
+
+		string	image10				"uppd02au.tga"
+		string	image11				"uppd02bu.tga"
+		string	image12				"uppd02du.tga"
 	}
 
 	# Previous.

--- a/ctp2_data/default/uidata/layouts/controlpanel.ldl
+++ b/ctp2_data/default/uidata/layouts/controlpanel.ldl
@@ -93,28 +93,35 @@ template ICON_VALUE_PAIR:CTP2_STATIC_GROUP {
 # 30x40 Image Button for Unit Tab.
 template UNIT_BUTTON_MEDIUM_SIZE:CTP2_BUTTON_BASE {
 	# Image layout.
-	int		numberoflayers		2
-	int		imagesperlayer		1
+	int    numberoflayers 1
+	int    imagesperlayer 1
 
-	string  imagebltflag10 "chromakey"
-	int xpix10 0
-	int ypix10 0
-	int widthpix10 20
-	int heightpix10 20
+	string imagebltflag10 "chromakey"
+
+	int    xpix10         0
+	int    ypix10         0
+	int    widthpix10     20
+	int    heightpix10    20
 
 	# Background.
-	bool	layeralways0		true
-	bool    layeralways1        true
+	bool   layeralways0   true
 
 	# Image size.
-	int		widthpix			32
-	int		heightpix			24
+	int    widthpix       32
+	int    heightpix      24
 
 	UnitHealth:CTP2_STATIC_BASE {
-		int xpix 2
-		int ypix 22
-		int widthpix 28
+		int xpix      2
+		int ypix      22
+		int widthpix  28
 		int heightpix 1
+	}
+
+	ArmySymbol:CTP2_STATIC_IMAGE {
+		int    xpix    0
+		int    ypix    0
+
+		string image00 "upic21.tga"
 	}
 }
 

--- a/ctp2_data/default/uidata/layouts/controlpanel.ldl
+++ b/ctp2_data/default/uidata/layouts/controlpanel.ldl
@@ -1125,6 +1125,15 @@ ControlPanelWindow:CTP2_WINDOW {
 								string imageblttype "stretch"
 								int widthpix 96
 								int heightpix 72
+
+								Symbol:CTP2_STATIC_IMAGE {
+									int xpix        3
+									int ypix        3
+
+									int chromared   0
+									int chromagreen 0
+									int chromablue  0
+								}
 							}
 
 							# Attack/Defense/Move/Range
@@ -1265,6 +1274,15 @@ ControlPanelWindow:CTP2_WINDOW {
 								bool   imagestretchx00 true
 								bool   imagestretchy00 true
 
+								ArmyLabel:CTP2_STATIC_BASE {
+									int    xpix      7
+									int    ypix      31
+									int    widthpix  54
+									int    heightpix 17
+									string just      "left"
+									string text      "str_ldl_Army"
+								}
+
 								Icon:CTP2_STATIC_IMAGE {
 									# Location.
 									int    xpix            7
@@ -1350,6 +1368,15 @@ ControlPanelWindow:CTP2_WINDOW {
 								string imageblttype00  "stretch"
 								bool   imagestretchx00 true
 								bool   imagestretchy00 true
+
+								CargoLabel:CTP2_STATIC_BASE {
+									int    xpix      7
+									int    ypix      31
+									int    widthpix  54
+									int    heightpix 17
+									string just      "left"
+									string text      "str_ldl_Cargo"
+								}
 
 								Icon:CTP2_STATIC_IMAGE {
 									# Location.

--- a/ctp2_data/default/uidata/layouts/controlpanel.ldl
+++ b/ctp2_data/default/uidata/layouts/controlpanel.ldl
@@ -1126,13 +1126,24 @@ ControlPanelWindow:CTP2_WINDOW {
 								int widthpix 96
 								int heightpix 72
 
-								Symbol:CTP2_STATIC_IMAGE {
-									int xpix        3
-									int ypix        3
+								ArmySymbol:CTP2_STATIC_IMAGE {
+									int    xpix       2
+									int    ypix       2
 
-									int chromared   0
-									int chromagreen 0
-									int chromablue  0
+									string image00    "upic21.tga"
+
+									string tipwindow  "str_ldl_Return"
+								}
+
+								CargoSymbol:CTP2_STATIC_IMAGE {
+									int    xpix        3
+									int    ypix        3
+
+									string image00     "upc045.tga"
+
+									int    chromared   0
+									int    chromagreen 0
+									int    chromablue  0
 								}
 							}
 
@@ -1294,12 +1305,6 @@ ControlPanelWindow:CTP2_WINDOW {
 									string imageblttype00  "stretch"
 									bool   imagestretchx00 true
 									bool   imagestretchy00 true
-
-									ArmySymbol:CTP2_STATIC_IMAGE {
-										int xpix 1
-										int ypix 1
-										string image00 "upic21.tga"
-									}
 								}
 							}
 
@@ -1389,6 +1394,15 @@ ControlPanelWindow:CTP2_WINDOW {
 									string imageblttype00  "stretch"
 									bool   imagestretchx00 true
 									bool   imagestretchy00 true
+
+									string tipwindow  "str_ldl_Return"
+
+									ArmySymbol:CTP2_STATIC_IMAGE {
+										int    xpix 2
+										int    ypix 2
+
+										string image00 "upic21.tga"
+									}
 								}
 							}
 

--- a/ctp2_data/default/uidata/layouts/controlpanel.ldl
+++ b/ctp2_data/default/uidata/layouts/controlpanel.ldl
@@ -1253,10 +1253,36 @@ ControlPanelWindow:CTP2_WINDOW {
 							# Background
 							string	image00	"upfg52.tga"
 
-							# Army icon.
-							Icon:UNIT_BUTTON_MEDIUM_SIZE {
-								int	xpix	18
-								int ypix	33
+							# Hide extra box
+							Background:CTP2_STATIC_IMAGE {
+								int    xpix            11
+								int    ypix            12
+								int    widthpix        66
+								int    heightpix       103
+
+								string image00         "uptg20e.tga"
+								string imageblttype00  "stretch"
+								bool   imagestretchx00 true
+								bool   imagestretchy00 true
+
+								Icon:CTP2_STATIC_IMAGE {
+									# Location.
+									int    xpix            7
+									int    ypix            48
+
+									int    widthpix        54
+									int    heightpix       51
+
+									string imageblttype00  "stretch"
+									bool   imagestretchx00 true
+									bool   imagestretchy00 true
+
+									ArmySymbol:CTP2_STATIC_IMAGE {
+										int xpix 1
+										int ypix 1
+										string image00 "upic21.tga"
+									}
+								}
 							}
 
 							# Unit buttons.

--- a/ctp2_data/default/uidata/layouts/controlpanel.ldl
+++ b/ctp2_data/default/uidata/layouts/controlpanel.ldl
@@ -358,31 +358,6 @@ template UNIT_LABEL_SPINNER:CTP2_STATIC_GROUP {
 		string	image12				"uppd02du.tga"
 	}
 
-	# Previous.
-	Previous:CTP2_GENERIC_ARROW_BUTTON {
-		# Location.
-#		int		xpix		0
-		int		xpix		24
-		int		ypix		0
-
-		# Background.
-		string	image00				"uptg20j.tga"
-		string	image10				"uptg20j.tga"
-		string	image20				"uptg20j.tga"
-		string	image30				"uptg20j.tga"
-
-#		string	image00				"upsp01au.tga"
-#		string	image10				"upsp01ah.tga"
-#		string	image20				"upsp01ad.tga"
-#		string	image30				"upsp01ax.tga"
-
-		# Tooltip
-#		string	tipwindow	"TOOLTIP_UNIT_PREV_UNIT_BUTTON"
-#		string	statustext	"STATUSBAR_UNIT_PREV_UNIT_BUTTON"
-		string	tipwindow	"TOOLTIP_UNIT_NEXT_UNIT_BUTTON"
-		string	statustext	"STATUSBAR_UNIT_NEXT_UNIT_BUTTON"
-	}
-
 	# Next.
 	Next:CTP2_GENERIC_ARROW_BUTTON {
 		# Location.

--- a/ctp2_data/default/uidata/layouts/controlpanel.ldl
+++ b/ctp2_data/default/uidata/layouts/controlpanel.ldl
@@ -1145,6 +1145,17 @@ ControlPanelWindow:CTP2_WINDOW {
 									int    chromagreen 0
 									int    chromablue  0
 								}
+
+								StackSymbol:CTP2_STATIC_IMAGE {
+									int    xpix        78
+									int    ypix        3
+
+									string image00     "upc006.tga"
+
+									int    chromared   0
+									int    chromagreen 0
+									int    chromablue  0
+								}
 							}
 
 							# Attack/Defense/Move/Range
@@ -1284,6 +1295,17 @@ ControlPanelWindow:CTP2_WINDOW {
 								string imageblttype00  "stretch"
 								bool   imagestretchx00 true
 								bool   imagestretchy00 true
+
+								StackSymbol:CTP2_STATIC_IMAGE {
+									int    xpix        45
+									int    ypix        27
+
+									string image00     "upc006.tga"
+
+									int    chromared   0
+									int    chromagreen 0
+									int    chromablue  0
+								}
 
 								ArmyLabel:CTP2_STATIC_BASE {
 									int    xpix      7

--- a/ctp2_data/default/uidata/layouts/controlpanel.ldl
+++ b/ctp2_data/default/uidata/layouts/controlpanel.ldl
@@ -1339,41 +1339,60 @@ ControlPanelWindow:CTP2_WINDOW {
 						TransportSelect:CTP2_STATIC_IMAGE {
 							string image00 "upfg53.tga"
 
-							# Transport icon.
-							Icon:UNIT_BUTTON_MEDIUM_SIZE {
-								int xpix 18
-								int ypix 33
+							# Hide extra box
+							Background:CTP2_STATIC_IMAGE {
+								int    xpix            11
+								int    ypix            12
+								int    widthpix        66
+								int    heightpix       103
+
+								string image00         "uptg20e.tga"
+								string imageblttype00  "stretch"
+								bool   imagestretchx00 true
+								bool   imagestretchy00 true
+
+								Icon:CTP2_STATIC_IMAGE {
+									# Location.
+									int    xpix            7
+									int    ypix            48
+
+									int    widthpix        54
+									int    heightpix       51
+
+									string imageblttype00  "stretch"
+									bool   imagestretchx00 true
+									bool   imagestretchy00 true
+								}
 							}
 
 							# Unit buttons
 							Cargo0:UNIT_TOGGLE_MEDIUM_SIZE {
-								int xpix 79
-								int ypix 33
+								int xpix 83
+								int ypix 36
 							}
 							Cargo1:UNIT_TOGGLE_MEDIUM_SIZE {
-								int xpix 114
-								int ypix 33
+								int xpix 118
+								int ypix 36
 							}
 
 							Cargo2:UNIT_TOGGLE_MEDIUM_SIZE {
-								int xpix 79
-								int ypix 58
+								int xpix 83
+								int ypix 61
 							}
 							Cargo3:UNIT_TOGGLE_MEDIUM_SIZE {
-								int xpix 114
-								int ypix 58
+								int xpix 118
+								int ypix 61
 							}
 
 							Cargo4:UNIT_TOGGLE_MEDIUM_SIZE {
-								int xpix 79
-								int ypix 83
+								int xpix 83
+								int ypix 86
 							}
 #							Cargo5:UNIT_TOGGLE_MEDIUM_SIZE {
-#								int xpix 114
-#								int ypix 83
+#								int xpix 118
+#								int ypix 86
 #							}
 						}
-
 					}
 
 					#UnitOrderButtonGrid:ORDER_BUTTON_PANEL {


### PR DESCRIPTION
This pull-request changes the unit control-panel in such way that next-button always goes to the next unmoved unit. The other displays can be showed by clicking on symbols, such as stack, army- and/or cargo-symbol. It also uses all the space of the background images.