### PR TITLE
Great Library: Sort advances based on age

### DIFF
--- a/ctp2_code/ctp/civapp.cpp
+++ b/ctp2_code/ctp/civapp.cpp
@@ -1721,6 +1721,10 @@ sint32 CivApp::InitializeGame(CivArchive *archive)
 		return FALSE;
 	}
 
+	if (archive) { // Ensure that SlicEngine's strings have correct numbering
+		SlicEngine::Reload(g_slic_filename);
+	}
+
 	g_theProgressWindow->StartCountingTo( 610 );
 
 	if(g_isScenario && archive &&

--- a/ctp2_code/ctp/civapp.cpp
+++ b/ctp2_code/ctp/civapp.cpp
@@ -1721,10 +1721,6 @@ sint32 CivApp::InitializeGame(CivArchive *archive)
 		return FALSE;
 	}
 
-	if (archive) { // Ensure that SlicEngine's strings have correct numbering
-		SlicEngine::Reload(g_slic_filename);
-	}
-
 	g_theProgressWindow->StartCountingTo( 610 );
 
 	if(g_isScenario && archive &&

--- a/ctp2_code/ui/aui_common/aui_listbox.cpp
+++ b/ctp2_code/ui/aui_common/aui_listbox.cpp
@@ -25,8 +25,8 @@
 // Modifications from the original Activision code:
 //
 // - Always focus on the latest message.
-// - Initialized local variables. (Sep 9th 2005 Martin Gühmann)
-// - Standardized code (May 21st 2006 Martin Gühmann)
+// - Initialized local variables. (Sep 9th 2005 Martin Gï¿½hmann)
+// - Standardized code (May 21st 2006 Martin Gï¿½hmann)
 //
 //----------------------------------------------------------------------------
 
@@ -1189,6 +1189,10 @@ AUI_ERRCODE aui_ListBox::DragSelect( sint32 y )
 		if ( itemIndex >= m_numRows ) itemIndex = m_numRows - 1;
 	}
 
+	if (GetItemByIndex(itemIndex)->IsDisabled()) {
+		return AUI_ERRCODE_OK;
+	}
+
 	ListPos position = m_visualSelectedList->Find( itemIndex );
 	if ( position )
 	{
@@ -1255,6 +1259,10 @@ AUI_ERRCODE aui_ListBox::SelectItem( sint32 index, uint32 data )
 {
 	if ( index < 0 || index >= (sint32)m_pane->ChildList()->L() )
 		return AUI_ERRCODE_INVALIDPARAM;
+
+	if (GetItemByIndex(index)->IsDisabled()) {
+		return AUI_ERRCODE_INVALIDPARAM;
+	}
 
 	if ( m_multiSelect )
 	{
@@ -1505,8 +1513,11 @@ void aui_ListBox::MouseLGrabInside( aui_MouseEvent *mouseData )
 
 		if ( y < maxY )
 		{
-			sint32 itemIndex =
-				y / (m_maxItemHeight != 0 ? m_maxItemHeight : 1) + m_verticalRanger->GetValueY();
+			sint32 itemIndex = y / (m_maxItemHeight != 0 ? m_maxItemHeight : 1) + m_verticalRanger->GetValueY();
+
+			if (GetItemByIndex(itemIndex)->IsDisabled()) {
+				return;
+			}
 
 			ListPos position = m_selectedList->Find( itemIndex );
 			if ( position )
@@ -1638,8 +1649,11 @@ void aui_ListBox::MouseRGrabInside( aui_MouseEvent *mouseData )
 
 		if ( y < maxY )
 		{
-			sint32 itemIndex =
-				y / m_maxItemHeight + m_verticalRanger->GetValueY();
+			sint32 itemIndex = y / m_maxItemHeight + m_verticalRanger->GetValueY();
+
+			if (GetItemByIndex(itemIndex)->IsDisabled()) {
+				return;
+			}
 
 			ListPos position = m_selectedList->Find( itemIndex );
 			if ( position )
@@ -1873,12 +1887,11 @@ void aui_ListBox::MouseLDoubleClickInside( aui_MouseEvent *mouseData )
 
 		if ( y < maxY )
 		{
-			sint32 itemIndex =
-				y / m_maxItemHeight + m_verticalRanger->GetValueY();
+			sint32 itemIndex = y / m_maxItemHeight + m_verticalRanger->GetValueY();
 
-			SendSelectCallback(
-				AUI_LISTBOX_ACTION_DOUBLECLICKSELECT,
-				(uint32)itemIndex );
+			if (!GetItemByIndex(itemIndex)->IsDisabled()) {
+				SendSelectCallback(AUI_LISTBOX_ACTION_DOUBLECLICKSELECT, (uint32) itemIndex);
+			}
 		}
 
 		m_selectStatus = AUI_LISTBOX_SELECTSTATUS_NONE;

--- a/ctp2_code/ui/aui_ctp2/ctp2_listitem.cpp
+++ b/ctp2_code/ui/aui_ctp2/ctp2_listitem.cpp
@@ -24,7 +24,7 @@
 //
 // Modifications from the original Activision code:
 //
-// - Added own Draw method. (2-Jan-2008 Martin Gühmann)
+// - Added own Draw method. (2-Jan-2008 Martin Gï¿½hmann)
 //
 //----------------------------------------------------------------------------
 
@@ -57,9 +57,8 @@ AUI_ERRCODE ctp2_ListItem::Draw(aui_Surface *surface, sint32 x, sint32 y)
 {
 	AUI_ERRCODE errcode = AUI_ERRCODE_OK;
 
-	if(!IsHidden()
-	&& !IsDisabled()
-	){
+	if(!IsHidden())
+	{
 		errcode = DrawThis(surface, x, y);
 
 		if(errcode == AUI_ERRCODE_OK)

--- a/ctp2_code/ui/interface/greatlibrary.cpp
+++ b/ctp2_code/ui/interface/greatlibrary.cpp
@@ -2093,6 +2093,7 @@ void GreatLibrary::Add_Item_To_Topics_List
 	if(!box) return;
 
 	box->SetText(name);
+	item->Enable(index != CTPRecord::INDEX_INVALID);
 	item->SetUserData((void *) index);
 	m_topics_list->AddItem(item);
 }
@@ -2209,6 +2210,7 @@ void GreatLibrary::AddTopics(CTPDatabase<T> * database)
 		}
 
 		if (m_sortByAgeButton->GetToggleState() && ageSortRecord.GetAge() != currentAge) {
+			Add_Item_To_Topics_List("", CTPRecord::INDEX_INVALID);
 			Add_Item_To_Topics_List(g_theAgeDB->GetNameStr(ageSortRecord.GetAge()), CTPRecord::INDEX_INVALID);
 			currentAge = ageSortRecord.GetAge();
 		}

--- a/ctp2_code/ui/interface/greatlibrary.cpp
+++ b/ctp2_code/ui/interface/greatlibrary.cpp
@@ -741,7 +741,6 @@ GreatLibrary::GreatLibrary(sint32 theMode)
 	m_database               (DATABASE_UNITS),
 	m_listDatabase           (DATABASE_UNITS),
 	m_selectedIndex          (CTPRecord::INDEX_INVALID),
-	m_maxIndex               (0),
 	m_sci                    (false),
 	m_itemLabel              (NULL),
 	m_search_results         (),
@@ -1757,8 +1756,6 @@ bool GreatLibrary::IsHidden(sint32 index, DATABASE theDatabase) const
 //----------------------------------------------------------------------------
 void GreatLibrary::UpdateList( DATABASE database )
 {
-	sint32 index;
-
 	m_topics_list->Clear();
 	m_listDatabase = database;
 
@@ -1773,7 +1770,7 @@ void GreatLibrary::UpdateList( DATABASE database )
 		m_sortByAgeButton->Enable(false);
 		Search_Great_Library();
 
-		for (index = 0; index < static_cast<sint32>(m_search_results.size()); index++)
+		for (sint32 index = 0; index < static_cast<sint32>(m_search_results.size()); index++)
 		{
 
 			int real_index = m_search_results[index].m_item;
@@ -1791,7 +1788,7 @@ void GreatLibrary::UpdateList( DATABASE database )
 
 	case DATABASE_ORDERS:
 		m_sortByAgeButton->Enable(false);
-		for (index = 0; index < g_theOrderDB->NumRecords(); index++)
+		for (sint32 index = 0; index < g_theOrderDB->NumRecords(); index++)
 		{
 			if(HIDE(g_theOrderDB, index)) continue;
 
@@ -1804,7 +1801,7 @@ void GreatLibrary::UpdateList( DATABASE database )
 
 	case DATABASE_RESOURCE:
 		m_sortByAgeButton->Enable(false);
-		for (index = 0; index < g_theResourceDB->NumRecords(); index++)
+		for (sint32 index = 0; index < g_theResourceDB->NumRecords(); index++)
 		{
 			if(HIDE(g_theResourceDB, index)) continue;
 
@@ -1829,7 +1826,7 @@ void GreatLibrary::UpdateList( DATABASE database )
 
 	case DATABASE_TERRAIN:
 		m_sortByAgeButton->Enable(false);
-		for (index = 0; index < g_theTerrainDB->NumRecords(); index++)
+		for (sint32 index = 0; index < g_theTerrainDB->NumRecords(); index++)
 		{
 			if(HIDE(g_theTerrainDB, index)) continue;
 
@@ -1842,7 +1839,7 @@ void GreatLibrary::UpdateList( DATABASE database )
 
 	case DATABASE_CONCEPTS:
 		m_sortByAgeButton->Enable(false);
-		for (index = 0; index < g_theConceptDB->NumRecords(); index++)
+		for (sint32 index = 0; index < g_theConceptDB->NumRecords(); index++)
 		{
 
 			if(HIDE(g_theConceptDB, index)) continue;
@@ -1866,8 +1863,6 @@ void GreatLibrary::UpdateList( DATABASE database )
         return;
 
 	}
-
-	m_maxIndex = index;
 }
 
 //----------------------------------------------------------------------------

--- a/ctp2_code/ui/interface/greatlibrary.h
+++ b/ctp2_code/ui/interface/greatlibrary.h
@@ -29,7 +29,7 @@
 // - Increased maximum library text size to support the German version.
 // - Exported database name size max.
 // - Added function to look up an item name on creation index.
-// - Added alpha <-> index functions. (Sep 13th 2005 Martin Gühmann)
+// - Added alpha <-> index functions. (Sep 13th 2005 Martin GÃ¼hmann)
 //
 //----------------------------------------------------------------------------
 //
@@ -237,10 +237,11 @@ public:
 	bool IsHidden(sint32 index, DATABASE theDatabase) const;
 
 private:
-    void Initialize(MBCHAR const * windowBlock);
+	void Initialize(MBCHAR const * windowBlock);
+	void AddAdvancesBasedOnAge();
 
-    friend void TechListItem::Update(void);
-    friend bool greatlibrary_Initialize(sint32 theMode, bool sci);
+	friend void TechListItem::Update(void);
+	friend bool greatlibrary_Initialize(sint32 theMode, bool sci);
 
 	ctp2_Button		*m_setGoalButton;
 

--- a/ctp2_code/ui/interface/greatlibrary.h
+++ b/ctp2_code/ui/interface/greatlibrary.h
@@ -48,6 +48,7 @@
 //----------------------------------------------------------------------------
 
 #include <vector>	// std::vector
+#include "CTPDatabase.h"
 
 //----------------------------------------------------------------------------
 // Export overview
@@ -238,7 +239,8 @@ public:
 
 private:
 	void Initialize(MBCHAR const * windowBlock);
-	void AddAdvancesBasedOnAge();
+	template <class T>
+	void AddTopicsBasedOnAge(CTPDatabase<T> * database);
 
 	friend void TechListItem::Update(void);
 	friend bool greatlibrary_Initialize(sint32 theMode, bool sci);

--- a/ctp2_code/ui/interface/greatlibrary.h
+++ b/ctp2_code/ui/interface/greatlibrary.h
@@ -238,9 +238,11 @@ public:
 	bool IsHidden(sint32 index, DATABASE theDatabase) const;
 
 private:
+	static void SortByAgeCallback(aui_Control * control, uint32 action, uint32 data, void * cookie);
+
 	void Initialize(MBCHAR const * windowBlock);
 	template <class T>
-	void AddTopicsBasedOnAge(CTPDatabase<T> * database);
+	void AddTopics(CTPDatabase<T> * database);
 
 	friend void TechListItem::Update(void);
 	friend bool greatlibrary_Initialize(sint32 theMode, bool sci);
@@ -292,6 +294,7 @@ private:
 	ctp2_Button		*m_conceptButton;
 	ctp2_Button		*m_goodsButton;
 	ctp2_Button		*m_ordersButton;
+	ctp2_Button		*m_sortByAgeButton;
 
 	ctp2_ListBox	*m_topics_list;
 	ctp2_Static		*m_indexLeft;

--- a/ctp2_code/ui/interface/greatlibrary.h
+++ b/ctp2_code/ui/interface/greatlibrary.h
@@ -306,7 +306,6 @@ private:
 	DATABASE		m_database;
 	DATABASE    m_listDatabase;
 	sint32			m_selectedIndex;
-	sint32			m_maxIndex;
 
 	bool			m_sci;
 

--- a/ctp2_data/chinese/gamedata/ldl_str.txt
+++ b/ctp2_data/chinese/gamedata/ldl_str.txt
@@ -2743,6 +2743,7 @@ str_ldl_GreatLibraryNoGoalPossible		"%s 尚未研发。"
 str_ldl_SEARCH_WORD "搜索："
 str_ldl_TECH_TREE "科技树"
 str_ldl_SET_GOAL	"设定目标"
+str_ldl_SORT_BY_AGE "按时代排序"
 
 
 

--- a/ctp2_data/default/uidata/layouts/greatlibrary.ldl
+++ b/ctp2_data/default/uidata/layouts/greatlibrary.ldl
@@ -650,7 +650,7 @@ LibraryStrings {
 
 GreatLibraryTopicItem:CTP2_LIST_ITEM {
 	int widthpix 160
-	int heighpix 20
+	int heightpix 20
 
 	box:CTP2_STANDARD_FONT {
 		string objecttype "ctp2_static"
@@ -662,7 +662,7 @@ GreatLibraryTopicItem:CTP2_LIST_ITEM {
 
 GreatLibraryHeaderItem:CTP2_LIST_ITEM {
 	int widthpix 160
-	int heighpix 20
+	int heightpix 20
 
 	box:CTP_GREY_TITLE_FONT {
 		string objecttype    "ctp2_static"

--- a/ctp2_data/default/uidata/layouts/greatlibrary.ldl
+++ b/ctp2_data/default/uidata/layouts/greatlibrary.ldl
@@ -266,9 +266,9 @@ GreatLibrary:CTP2_WINDOW {
 
 	OkButton:CTP2_GENERIC_SIZABLE_TEXT_BUTTON {
 
-		int	xpix	650
+		int	xpix	630
 
-		int	ypix	525
+		int	ypix	528
 
 		int		widthpix	124
 
@@ -311,9 +311,9 @@ GreatLibrary:CTP2_WINDOW {
 	# shows how to get there
 	SetGoalButton:CTP2_BUTTON_SMALL {
 
-		int	xpix	500
+		int	xpix	480
 
-		int	ypix	525
+		int	ypix	528
 
 		int	widthpix	124
 
@@ -611,7 +611,30 @@ GreatLibrary:CTP2_WINDOW {
 		bool	alwaysranger TRUE
 	}
 
+	SortByAgeButton:CTP2_GENERIC_SIZABLE_TEXT_BUTTON {
+		int    xpix            107
+		int    ypix            528
 
+		int    widthpix        140
+
+		bool   togglebutton    true
+		int    numberoflayers  5
+		bool   layerupon4      true
+		string imageblttype41  "tile"
+		bool   imagestretchx41 true
+
+
+		string image00         "upbt16aX.tga"
+		string image10         "upbt16aU.tga"
+		string image20         "upbt16aD.tga"
+		string image30         "upbt16aH.tga"
+		string image40         "upbt16aD.tga"
+		string image41         "upbt01bD.tga"
+		string image42         "upbt01cD.tga"
+
+		# Label
+		string text            "str_ldl_SORT_BY_AGE"
+	}
 }
 
 

--- a/ctp2_data/default/uidata/layouts/greatlibrary.ldl
+++ b/ctp2_data/default/uidata/layouts/greatlibrary.ldl
@@ -654,12 +654,25 @@ GreatLibraryTopicItem:CTP2_LIST_ITEM {
 
 	box:CTP2_STANDARD_FONT {
 		string objecttype "ctp2_static"
-		int widthpix 160
-		int heightpix 20
+
+		int    widthpix   160
+		int    heightpix  20
 	}
 }
 
+GreatLibraryHeaderItem:CTP2_LIST_ITEM {
+	int widthpix 160
+	int heighpix 20
 
+	box:CTP_GREY_TITLE_FONT {
+		string objecttype    "ctp2_static"
+
+		int    widthpix      160
+		int    heightpix     20
+
+		int    underlinefont 1
+	}
+}
 
 $
 

--- a/ctp2_data/english/gamedata/ldl_str.txt
+++ b/ctp2_data/english/gamedata/ldl_str.txt
@@ -2744,8 +2744,7 @@ str_ldl_GreatLibraryNoGoalPossible		"%s cannot be researched."
 str_ldl_SEARCH_WORD				"Search:"
 str_ldl_TECH_TREE				"Tech Tree"
 str_ldl_SET_GOAL				"Set Goal"
-
-
+str_ldl_SORT_BY_AGE				"Sort by Age"
 
 
 # Ranking Tab

--- a/ctp2_data/french/gamedata/ldl_str.txt
+++ b/ctp2_data/french/gamedata/ldl_str.txt
@@ -2743,6 +2743,7 @@ str_ldl_GreatLibraryNoGoalPossible		"%s ne peut pas être recherché."
 str_ldl_SEARCH_WORD				"Recherche :"
 str_ldl_TECH_TREE				"ARBORESCENCE"
 str_ldl_SET_GOAL				"Fixer objectif"
+str_ldl_SORT_BY_AGE				"Trier par âge"
 
 
 

--- a/ctp2_data/german/gamedata/ldl_str.txt
+++ b/ctp2_data/german/gamedata/ldl_str.txt
@@ -2743,6 +2743,7 @@ str_ldl_GreatLibraryNoGoalPossible		"%s kann nicht erforscht werden."
 str_ldl_SEARCH_WORD				"Suchen:"
 str_ldl_TECH_TREE				"Technologiebaum"
 str_ldl_SET_GOAL				"Projekt festlegen"
+str_ldl_SORT_BY_AGE				"Sortieren nach Ära"
 
 
 

--- a/ctp2_data/italian/gamedata/ldl_str.txt
+++ b/ctp2_data/italian/gamedata/ldl_str.txt
@@ -2743,7 +2743,7 @@ str_ldl_GreatLibraryNoGoalPossible		"%s cannot be researched."
 str_ldl_SEARCH_WORD				"Ricerca:"
 str_ldl_TECH_TREE				"Albero delle tecnologie"
 str_ldl_SET_GOAL				"Scegli obiettivo"
-
+str_ldl_SORT_BY_AGE				"Ordina per età"
 
 
 

--- a/ctp2_data/japanese/gamedata/ldl_str.txt
+++ b/ctp2_data/japanese/gamedata/ldl_str.txt
@@ -2832,6 +2832,7 @@ str_ldl_GreatLibraryGoalSetTo "目標の設定: %s"
 str_ldl_SEARCH_WORD "検索:"
 str_ldl_TECH_TREE "技術系統樹"
 str_ldl_SET_GOAL	"目標の設定"
+str_ldl_SORT_BY_AGE "エポックで並べ替え"
 
 
 

--- a/ctp2_data/spanish/gamedata/ldl_str.txt
+++ b/ctp2_data/spanish/gamedata/ldl_str.txt
@@ -2743,6 +2743,7 @@ str_ldl_GreatLibraryNoGoalPossible		"%s cannot be researched."
 str_ldl_SEARCH_WORD				"Búsqueda:"
 str_ldl_TECH_TREE				"Árbol tecnológico"
 str_ldl_SET_GOAL				"Fijar objetivo"
+str_ldl_SORT_BY_AGE				"Ordenar por edad"
 
 
 


### PR DESCRIPTION
As there are so many advances I have difficulty to determine which advance I would like to research next. I sorted the advances based on age, and added a small header for each age.

This result in the list below:
![Screenshot from 2021-05-23 19-20-40](https://user-images.githubusercontent.com/10560119/119270241-041b9000-bbfc-11eb-9826-7f060ffac9c7.png)

Clicking the age-description will select the first element of that age.

Let me know your opinion about this. Any suggestion/improvement is welcome.