### PR TITLE
Army manager look

### DIFF
--- a/ctp2_code/ui/interface/armymanagerwindow.cpp
+++ b/ctp2_code/ui/interface/armymanagerwindow.cpp
@@ -24,9 +24,9 @@
 //
 // Modifications from the original Activision code:
 //
-// - Initialized local variables. (Sep 9th 2005 Martin Gühmann)
-// - Standardized code (May 21st 2006 Martin Gühmann)
-// - Added army debug text to the army manager window. (Dec 24th 2006 Martin Gühmann)
+// - Initialized local variables. (Sep 9th 2005 Martin Gï¿½hmann)
+// - Standardized code (May 21st 2006 Martin Gï¿½hmann)
+// - Added army debug text to the army manager window. (Dec 24th 2006 Martin Gï¿½hmann)
 // - Changed occurances of UnitRecord::GetMaxHP to
 //   UnitData::CalculateTotalHP. (Aug 3rd 2009 Maq)
 //
@@ -314,8 +314,8 @@ void ArmyManagerWindow::Update()
 
 				inCellSwitch->Enable(TRUE);
 				inCellSwitch->SetState(0);
-				inCellSwitch->SetImage((char *)irec->GetIcon(), 0);
-				inCellSwitch->SetImage((char *)irec->GetIcon(), 1);
+				inCellSwitch->SetImage((char *)irec->GetLargeIcon(), 0);
+				inCellSwitch->SetImage((char *)irec->GetLargeIcon(), 1);
 				inCellSwitch->ShouldDraw(TRUE);
 			}
 		}
@@ -347,8 +347,8 @@ void ArmyManagerWindow::Update()
 			Assert(inArmySwitch);
 			if(inArmySwitch) {
 				inArmySwitch->SetState(0);
-				inArmySwitch->SetImage((char *)irec->GetIcon(), 0);
-				inArmySwitch->SetImage((char *)irec->GetIcon(), 1);
+				inArmySwitch->SetImage((char *)irec->GetLargeIcon(), 0);
+				inArmySwitch->SetImage((char *)irec->GetLargeIcon(), 1);
 				inArmySwitch->Enable(TRUE);
 				inArmySwitch->ShouldDraw(TRUE);
 			}

--- a/ctp2_code/ui/interface/armymanagerwindow.cpp
+++ b/ctp2_code/ui/interface/armymanagerwindow.cpp
@@ -407,7 +407,7 @@ void ArmyManagerWindow::UpdateArmyItem(ctp2_ListItem * item)
 	}
 
 	MBCHAR truncatedString[100];
-	strncpy(truncatedString, node->m_army->GetName(), 99);
+	strncpy(truncatedString, node->m_army.IsValid() ? node->m_army->GetName() : "---", 99);
 	truncatedString[99] = 0;
 	if (!box->GetTextFont()) {
 		box->TextReloadFont();

--- a/ctp2_code/ui/interface/armymanagerwindow.cpp
+++ b/ctp2_code/ui/interface/armymanagerwindow.cpp
@@ -406,14 +406,20 @@ void ArmyManagerWindow::UpdateArmyItem(ctp2_ListItem * item)
 		return;
 	}
 
+	ctp2_Static * name = (ctp2_Static *)box->GetChildByIndex(0);
 	MBCHAR truncatedString[100];
 	strncpy(truncatedString, node->m_army.IsValid() ? node->m_army->GetName() : "---", 99);
 	truncatedString[99] = 0;
-	if (!box->GetTextFont()) {
-		box->TextReloadFont();
+	if (!name->GetTextFont()) {
+		name->TextReloadFont();
 	}
-	box->GetTextFont()->TruncateString(truncatedString, box->Width());
-	box->SetText(truncatedString);
+	name->GetTextFont()->TruncateString(truncatedString, name->Width());
+	name->SetText(truncatedString);
+
+	ctp2_Static * numberOfUnits = (ctp2_Static *)box->GetChildByIndex(1);
+	MBCHAR numberOfUnitsText[20];
+	sprintf(numberOfUnitsText, "%d", (node->m_army.IsValid() ? node->m_army->Num() : 0));
+	numberOfUnits->SetText(numberOfUnitsText);
 }
 
 void ArmyManagerWindow::UpdateAllArmyItems()
@@ -429,6 +435,7 @@ void ArmyManagerWindow::UpdateAllArmyItems()
 			UpdateArmyItem(item);
 		}
 	}
+	list->ShouldDraw();
 }
 
 ctp2_ListItem *ArmyManagerWindow::AddArmyItem(ctp2_ListBox *listBox, ArmyListNode *node)
@@ -745,16 +752,6 @@ void ArmyManagerWindow::AddSelectedUnits()
 		}
 	}
 
-
-
-
-
-
-
-
-
-
-
 	UpdateAllArmyItems();
 
 	RemoveDeadArmies();
@@ -831,10 +828,6 @@ void ArmyManagerWindow::RemoveSelectedUnits()
 		g_selected_item->Deselect(g_selected_item->GetVisiblePlayer());
 
 	NotifySelection();
-
-
-
-
 }
 
 void ArmyManagerWindow::InArmy(aui_Control *control, uint32 action, uint32 data, void *cookie)

--- a/ctp2_code/ui/interface/armymanagerwindow.h
+++ b/ctp2_code/ui/interface/armymanagerwindow.h
@@ -81,6 +81,7 @@ class ArmyManagerWindow {
 	static void RemoveAll(aui_Control *control, uint32 action, uint32 data, void *cookie);
 	static void InArmy(aui_Control *control, uint32 action, uint32 data, void *cookie);
 	static void OutOfArmy(aui_Control *control, uint32 action, uint32 data, void *cookie);
+	static void ArmyNameChanged(aui_Control *control, uint32 action, uint32 data, void *cookie);
 
 	static AUI_ERRCODE DrawHealthCallbackInArmy(ctp2_Static *control, aui_Surface *surface, RECT &rect, void *cookie);
 	static AUI_ERRCODE DrawHealthCallbackOutOfArmy(ctp2_Static *control, aui_Surface *surface, RECT &rect, void *cookie);

--- a/ctp2_data/chinese/gamedata/ldl_str.txt
+++ b/ctp2_data/chinese/gamedata/ldl_str.txt
@@ -2608,6 +2608,7 @@ str_ldl_MB_CANCEL					"取消"
 
 # Army Management
 str_ldl_ArmyManagement "军务官"
+str_ldl_ArmyManagementTitle "军务官"
 
 # Diplomacy wizard
 str_ldl_DiplomacyWizardTitle "外交提议"

--- a/ctp2_data/default/uidata/layouts/armymanager.ldl
+++ b/ctp2_data/default/uidata/layouts/armymanager.ldl
@@ -274,40 +274,13 @@ ArmyManagerItem:CTP2_LIST_ITEM {
 	int xpix      14
 	int widthpix  60
 	int heightpix 18
-	box {
+	box:CTP2_STANDARD_FONT {
 		string objecttype "ctp2_Static"
 
 		int xpix      12
 		int ypix      0
-		int widthpix  62
+		int widthpix  140
 		int heightpix 18
-
-		string pattern "uptg06e.tga"
-
-		icon {
-			string objecttype "ctp2_Static"
-
-			int xpix      10
-			int ypix      2
-			int widthpix  16
-			int heightpix 16
-
-			string imagebltflag "chromakey"
-		}
-		count:AM_LIST_ITEM_FONT {
-			string objecttype "ctp2_Static"
-
-			int xpix      30
-			int ypix      2
-			int widthpix  28
-			int heightpix 16
-
-			string text        "str_ldl_0"
-			bool   vertcenter  true
-			string textblttype "center"
-			string just        "center"
-			string pattern     "uptg06e.tga"
-		}
 	}
 }
 

--- a/ctp2_data/default/uidata/layouts/armymanager.ldl
+++ b/ctp2_data/default/uidata/layouts/armymanager.ldl
@@ -37,19 +37,20 @@ AM_LIST_ITEM_FONT:CTP2_STANDARD_FONT {
 ##                Data               ##
 ##-----------------------------------##
 ArmyManager:CTP2_DIALOG_WINDOW {
-	string title     "str_ldl_ArmyManagement"
+	string title     "str_ldl_ArmyManagementTitle"
 	int    xpix      200
 	int    ypix      30
 	int    widthpix  800
 	int    heightpix 384
 
 	ArmiesLabel:CTP2_STATIC_BASE:AM_TEXT_FONT {
-		int xpix      50
+		int xpix      80
 		int ypix      45
 		int widthpix  80
 		int heightpix 20
 
 		string pattern "uptg20e.tga"
+		string just    "left"
 		string text    "str_ldl_Armies"
 	}
 	ArmiesList:CTP2_LISTBOX {
@@ -178,12 +179,13 @@ ArmyManager:CTP2_DIALOG_WINDOW {
 		string statustext "STATUSBAR_ARMYMAN_REMOVE_ALL_BUTTON"
 	}
 	OutOfArmyLabel:CTP2_STATIC_BASE:AM_TEXT_FONT {
-		int xpix      535
+		int xpix      565
 		int ypix      60
 		int widthpix  116
-		int	heightpix 20
+		int heightpix 20
 
 		string pattern "uptg20e.tga"
+		string just    "left"
 		string text    "str_ldl_SingleUnits"
 	}
 	OutOfArmyBox {

--- a/ctp2_data/default/uidata/layouts/armymanager.ldl
+++ b/ctp2_data/default/uidata/layouts/armymanager.ldl
@@ -7,17 +7,21 @@
 ##             Templates             ##
 ##-----------------------------------##
 AM_UNIT_ICON:CTP2_SWITCH {
-	int	widthpix	36
-	int	heightpix	28
-	int	beveltype	1
-	int	bevelwidth	2
-	string	pattern	"uptg20e.tga"
-	string	image0	"upic15.tga"
-	string	image1	"upic15.tga"
+	int    widthpix   57
+	int    heightpix  44
+	int    beveltype  1
+	int    bevelwidth 2
+
+	string imageblttype "stretch"
+
+	string pattern "uptg20e.tga"
+	string image0  "upic15.tga"
+	string image1  "upic15.tga"
+
 	UnitHealth:CTP2_STATIC_BASE {
-		int xpix 2
-		int ypix 25
-		int widthpix 32
+		int xpix      2
+		int ypix      37
+		int widthpix  52
 		int heightpix 1
 	}
 }
@@ -26,318 +30,285 @@ AM_TEXT_FONT:CTP2_STANDARD_FONT {
 }
 
 AM_LIST_ITEM_FONT:CTP2_STANDARD_FONT {
-	#int	fontsize	9
 }
 
 
 ##-----------------------------------##
 ##                Data               ##
 ##-----------------------------------##
-ArmyManager:CTP2_TITLE_WINDOW {
-	int	xpix	211
-	int	ypix	67
-	int	widthpix	485
-	int	heightpix	225
-	string title "str_ldl_ArmyManagement"
+ArmyManager:CTP2_DIALOG_WINDOW {
+	string title     "str_ldl_ArmyManagement"
+	int    xpix      200
+	int    ypix      30
+	int    widthpix  800
+	int    heightpix 384
+
 	ArmiesLabel:CTP2_STATIC_BASE:AM_TEXT_FONT {
-		int	xpix		20
-		int	ypix		25
-		int	widthpix	80
-		string	pattern		"uptg20e.tga"
-		string	text		"str_ldl_Armies"
-		int	heightpix	20
+		int xpix      50
+		int ypix      45
+		int widthpix  80
+		int heightpix 20
+
+		string pattern "uptg20e.tga"
+		string text    "str_ldl_Armies"
 	}
 	ArmiesList:CTP2_LISTBOX {
-		int xpix      27
-		int ypix      58
-		int widthpix  71
-		int heightpix 110
+		int xpix      70
+		int ypix      75
+		int widthpix  140
+		int heightpix 188
 
+		bool alwaysranger false
 		rangery {
 		}
 	}
-#	CountLabel:CTP2_TEXT_BOX:AM_TEXT_FONT {
-#		string	fontname	"arial.ttf"
-#		int	fontcolorred	24
-#		int	fontcolorgreen	2
-#		int	fontcolorblue	2
-#		int	fontsize	8
-#		int	xpix		139
-#		int	ypix		30
-#		int	widthpix	116
-#		string	text		"str_ldl_ArmyCount"
-#		int	heightpix	20
-#	}
-	ArmyTextLabel:CTP2_STATIC_BASE:AM_TEXT_FONT {
-		int	xpix		130
-		int	ypix		190
-		string	text		""
-		string	just		"left"
-		int	widthpix	97
-		int	heightpix	24
+	Separator {
+		string objecttype "ctp2_static"
+
+		int xpix      232
+		int ypix      32
+		int widthpix  2
+		int heightpix 315
+
+		# Bevel for groove effect.
+		int beveltype  1
+		int bevelwidth 2
+
+		bool mouseblind true
 	}
 	ArmyName:CTP2_TEXT_FIELD {
-		int xpix 120
-		int ypix 28
-		int widthpix 116
+		int xpix      252
+		int ypix      53
+		int widthpix  171
 		int heightpix 20
 	}
 	InArmyBox {
-		string	objecttype	"ctp2_static"
-		int	xpix	120
-		int	ypix	50
-		int	heightpix	124
-		int	widthpix	116
-		int	bevelwidth	1
+		string objecttype "ctp2_static"
+
+		int xpix      250
+		int ypix      88
+		int widthpix  175
+		int heightpix 180
+
+		int bevelwidth 1
+
 		Unit0:AM_UNIT_ICON {
-			int	xpix	2
-			int	ypix	2
+			int xpix 2
+			int ypix 2
 		}
 		Unit1:AM_UNIT_ICON {
-			int	xpix	40
-			int	ypix	2
+			int xpix 59
+			int ypix 2
 		}
 		Unit2:AM_UNIT_ICON {
-			int	xpix	78
-			int	ypix	2
+			int xpix 116
+			int ypix 2
 		}
 		Unit3:AM_UNIT_ICON {
-			int	xpix	2
-			int	ypix	32
+			int xpix 2
+			int ypix 46
 		}
 		Unit4:AM_UNIT_ICON {
-			int	xpix	40
-			int	ypix	32
+			int xpix 59
+			int ypix 46
 		}
 		Unit5:AM_UNIT_ICON {
-			int	xpix	78
-			int	ypix	32
+			int xpix 116
+			int ypix 46
 		}
 		Unit6:AM_UNIT_ICON {
-			int	xpix	2
-			int	ypix	62
+			int xpix 2
+			int ypix 90
 		}
 		Unit7:AM_UNIT_ICON {
-			int	xpix	40
-			int	ypix	62
+			int xpix 59
+			int ypix 90
 		}
 		Unit8:AM_UNIT_ICON {
-			int	xpix	78
-			int	ypix	62
+			int xpix 116
+			int ypix 90
 		}
 		Unit9:AM_UNIT_ICON {
-			int	xpix	2
-			int	ypix	92
+			int xpix 2
+			int ypix 134
 		}
 		Unit10:AM_UNIT_ICON {
-			int xpix    40
-			int ypix    92
+			int xpix 59
+			int ypix 134
 		}
 		Unit11:AM_UNIT_ICON {
-			int xpix   78
-			int ypix   92
+			int xpix 116
+			int ypix 134
 		}
 	}
 	AddButton:CTP2_GENERIC_SIZABLE_TEXT_BUTTON {
-		int	xpix	240
-		int	ypix	60
-		#string image40 "upic13.tga"
-		#int xpix40 7
-		#int ypix40 10
-		int	widthpix	100
-		int	heightpix	0
-		string	text	"str_ldl_Add"
-		string	statustext	"STATUSBAR_ARMYMAN_ADD_BUTTON"
-	}
-	RemoveButton:CTP2_GENERIC_SIZABLE_TEXT_BUTTON {
-		int	xpix	240
-		int	ypix	112
-		#string image40 "upic14.tga"
-		#int xpix40 7
-		#int ypix40 10
-		int	widthpix	100
-		int	heightpix	0
-		string	text	"str_ldl_Remove"
-		string	statustext	"STATUSBAR_ARMYMAN_REMOVE_BUTTON"
+		int xpix      440
+		int ypix      100
+		int widthpix  100
+		int heightpix 0
+
+		string text       "str_ldl_Add"
+		string statustext "STATUSBAR_ARMYMAN_ADD_BUTTON"
 	}
 	AddAllButton:CTP2_GENERIC_SIZABLE_TEXT_BUTTON {
-		int	xpix	240
-		int	ypix	84
-		#string image40 "upic15.tga"
-		#int xpix40 7
-		#int ypix40 10
-		int	widthpix	100
-		int	heightpix	0
-		string	text	"str_ldl_AddAll"
-		string	statustext	"STATUSBAR_ARMYMAN_ADD_ALL_BUTTON"
+		int xpix      440
+		int ypix      125
+		int widthpix  100
+		int heightpix 0
+
+		string text       "str_ldl_AddAll"
+		string statustext "STATUSBAR_ARMYMAN_ADD_ALL_BUTTON"
+	}
+	RemoveButton:CTP2_GENERIC_SIZABLE_TEXT_BUTTON {
+		int xpix      440
+		int ypix      160
+		int widthpix  100
+		int heightpix 0
+
+		string text       "str_ldl_Remove"
+		string statustext "STATUSBAR_ARMYMAN_REMOVE_BUTTON"
 	}
 	RemoveAllButton:CTP2_GENERIC_SIZABLE_TEXT_BUTTON {
-		int	xpix	240
-		int	ypix	136
-		#string image40 "upic16.tga"
-		#int xpix40 7
-		#int ypix40 10
-		int	widthpix	100
-		int	heightpix	0
-		string	text	"str_ldl_RemoveAll"
-		string	statustext	"STATUSBAR_ARMYMAN_REMOVE_ALL_BUTTON"
+		int xpix      440
+		int ypix      185
+		int widthpix  100
+		int heightpix 0
+
+		string text       "str_ldl_RemoveAll"
+		string statustext "STATUSBAR_ARMYMAN_REMOVE_ALL_BUTTON"
 	}
 	OutOfArmyLabel:CTP2_STATIC_BASE:AM_TEXT_FONT {
-		int	xpix	346
-		int	ypix	28
-		int	widthpix	116
+		int xpix      535
+		int ypix      60
+		int widthpix  116
+		int	heightpix 20
+
 		string pattern "uptg20e.tga"
-		string	text	"str_ldl_SingleUnits"
-		int	heightpix	20
+		string text    "str_ldl_SingleUnits"
 	}
 	OutOfArmyBox {
-		string	objecttype	"ctp2_Static"
-		int	xpix	346
-		int	ypix	50
-		int	heightpix	124
-		int	widthpix	116
-		int	bevelwidth	1
+		string objecttype "ctp2_Static"
+
+		int xpix      555
+		int ypix      85
+		int widthpix  175
+		int heightpix 180
+
+		int	bevelwidth 1
+
 		Unit0:AM_UNIT_ICON {
-			int	xpix	2
-			int	ypix	2
+			int xpix 2
+			int ypix 2
 		}
 		Unit1:AM_UNIT_ICON {
-			int	xpix	40
-			int	ypix	2
+			int xpix 59
+			int ypix 2
 		}
 		Unit2:AM_UNIT_ICON {
-			int	xpix	78
-			int	ypix	2
+			int xpix 116
+			int ypix 2
 		}
 		Unit3:AM_UNIT_ICON {
-			int	xpix	2
-			int	ypix	32
+			int xpix 2
+			int ypix 46
 		}
 		Unit4:AM_UNIT_ICON {
-			int	xpix	40
-			int	ypix	32
+			int xpix 59
+			int ypix 46
 		}
 		Unit5:AM_UNIT_ICON {
-			int	xpix	78
-			int	ypix	32
+			int xpix 116
+			int ypix 46
 		}
 		Unit6:AM_UNIT_ICON {
-			int	xpix	2
-			int	ypix	62
+			int xpix 2
+			int ypix 90
 		}
 		Unit7:AM_UNIT_ICON {
-			int	xpix	40
-			int	ypix	62
+			int xpix 59
+			int ypix 90
 		}
 		Unit8:AM_UNIT_ICON {
-			int	xpix	78
-			int	ypix	62
+			int xpix 116
+			int ypix 90
 		}
 		Unit9:AM_UNIT_ICON {
-			int	xpix	2
-			int	ypix	92
+			int xpix 2
+			int ypix 134
 		}
 		Unit10:AM_UNIT_ICON {
-			int xpix    40
-			int ypix    92
+			int xpix 59
+			int ypix 134
 		}
 		Unit11:AM_UNIT_ICON {
-			int xpix   78
-			int ypix   92
+			int xpix 116
+			int ypix 134
 		}
 	}
 	NewArmyButton:CTP2_BUTTON_SMALL {
-		int	xpix	20
-		int	ypix	182
-		string	text	"str_ldl_NewArmy"
-		int	widthpix	97
-		int	heightpix	24
-		string	statustext	"STATUSBAR_ARMYMAN_NEW_ARMY_BUTTON"
+		int xpix      75
+		int ypix      280
+		int widthpix  130
+		int heightpix 24
+
+		string text       "str_ldl_NewArmy"
+		string statustext "STATUSBAR_ARMYMAN_NEW_ARMY_BUTTON"
 	}
 
 	CloseButton:CTP2_STANDARD_CLOSE {
-		int	xpix	380
-		int	ypix	182
-		string	statustext	"STATUSBAR_ARMYMAN_CLOSE_BUTTON"
+		string statustext "STATUSBAR_ARMYMAN_CLOSE_BUTTON"
+
+		int xpix 676
 	}
 
-	Background {
-		string	objecttype	"ctp2_Static"
-
-		int	xpix	0
-		int	ypix	0
-		int	widthpix	485
-		int	heightpix	225
-		int numberoflayers 1
-		int imagesperlayer 9
-
-
-		bool layeralways0 true
-		string imagebltflag00 "chromakey"
-		string image00 "uptg03a.tga"
-		bool imagestretchx01 true
-		string imageblttype01 "tile"
-		string image01 "uptg03b.tga"
-		string imagebltflag02 "chromakey"
-		string image02 "uptg03c.tga"
-		bool imagenextrow03 true
-		bool imagestretchy03 true
-		string imageblttype03 "tile"
-		string image03 "uptg03d.tga"
-		bool imagestretchx04 true
-		bool imagestretchy04 true
-		string imageblttype04 "tile"
-		string image04 "uptg20e.tga"
-		bool imagestretchy05 true
-		string imageblttype05 "tile"
-		string image05 "uptg03f.tga"
-		bool imagenextrow06 true
-		string imagebltflag06 "chromakey"
-		string image06 "uptg03g.tga"
-		bool imagestretchx07 true
-		string imageblttype07 "tile"
-		string image07 "uptg03h.tga"
-		string imagebltflag08 "chromakey"
-		string image08 "uptg03i.tga"
-
+	Background:CTP2_DIALOG_BG {
+		int    widthpix 800
+		string image00  "uptg21a.tga"
+		string image02  "uptg21c.tga"
+		string image03  "uptg21d.tga"
+		string image05  "uptg21f.tga"
 	}
 }
 
 ArmyManagerItem:CTP2_LIST_ITEM {
-	int xpix	14
-	int	widthpix	60
-	int	heightpix	18
+	int xpix      14
+	int widthpix  60
+	int heightpix 18
 	box {
-		string	objecttype	"ctp2_Static"
-		int	xpix	12
-		int	ypix	0
-		int	widthpix	62
-		int	heightpix	18
-		string	pattern	"uptg06e.tga"
+		string objecttype "ctp2_Static"
+
+		int xpix      12
+		int ypix      0
+		int widthpix  62
+		int heightpix 18
+
+		string pattern "uptg06e.tga"
 
 		icon {
-			string	objecttype	"ctp2_Static"
-			int	xpix	10
-			int	ypix	2
-			int	widthpix	16
-			int	heightpix	16
-			string imagebltflag "chromakey"	
+			string objecttype "ctp2_Static"
 
+			int xpix      10
+			int ypix      2
+			int widthpix  16
+			int heightpix 16
+
+			string imagebltflag "chromakey"
 		}
 		count:AM_LIST_ITEM_FONT {
-			string	objecttype	"ctp2_Static"
-			int	xpix	30
-			int	ypix	2
-			int	widthpix	28
-			int	heightpix	16
-			string	text	"str_ldl_0"
-			bool	vertcenter	TRUE
-			string	textblttype	"center"
-			string	just	"center"
-			string	pattern	"uptg06e.tga"
+			string objecttype "ctp2_Static"
+
+			int xpix      30
+			int ypix      2
+			int widthpix  28
+			int heightpix 16
+
+			string text        "str_ldl_0"
+			bool   vertcenter  true
+			string textblttype "center"
+			string just        "center"
+			string pattern     "uptg06e.tga"
 		}
 	}
 }
-
 
 $

--- a/ctp2_data/default/uidata/layouts/armymanager.ldl
+++ b/ctp2_data/default/uidata/layouts/armymanager.ldl
@@ -276,13 +276,25 @@ ArmyManagerItem:CTP2_LIST_ITEM {
 	int xpix      14
 	int widthpix  60
 	int heightpix 18
-	box:CTP2_STANDARD_FONT {
-		string objecttype "ctp2_Static"
+	box:CTP2_STATIC_BASE {
+		name:CTP2_STATIC_BASE {
+			int xpix      8
+			int ypix      0
+			int widthpix  120
+			int heightpix 18
 
-		int xpix      12
-		int ypix      0
-		int widthpix  140
-		int heightpix 18
+			string just "left"
+			bool vertcenter true
+		}
+		number:CTP2_STATIC_BASE {
+			int xpix      125
+			int ypix      0
+			int widthpix  10
+			int heightpix 18
+
+			string just "right"
+			bool vertcenter true
+		}
 	}
 }
 

--- a/ctp2_data/english/gamedata/ldl_str.txt
+++ b/ctp2_data/english/gamedata/ldl_str.txt
@@ -2609,6 +2609,7 @@ str_ldl_MB_CANCEL				"Cancel"
 
 # Army Management
 str_ldl_ArmyManagement				"Army Manager"
+str_ldl_ArmyManagementTitle			"A R M Y   M A N A G E R"
 
 # Diplomacy wizard
 str_ldl_DiplomacyWizardTitle			"D I P L O M A T I C   P R O P O S A L"

--- a/ctp2_data/french/gamedata/ldl_str.txt
+++ b/ctp2_data/french/gamedata/ldl_str.txt
@@ -2608,6 +2608,7 @@ str_ldl_MB_CANCEL				"Annuler"
 
 # Army Management
 str_ldl_ArmyManagement				"Gest. d'armée"
+str_ldl_ArmyManagementTitle			"GESTIONNAIRE D'ARMEE"
 
 # Diplomacy wizard
 str_ldl_DiplomacyWizardTitle			"PROPOSITION DIPLOMATIQUE"

--- a/ctp2_data/german/gamedata/ldl_str.txt
+++ b/ctp2_data/german/gamedata/ldl_str.txt
@@ -2608,6 +2608,7 @@ str_ldl_MB_CANCEL				"Abbrechen"
 
 # Army Management
 str_ldl_ArmyManagement				"Truppenmanager"
+str_ldl_ArmyManagementTitle			"T R U P P E N M A N A G E R"
 
 # Diplomacy wizard
 str_ldl_DiplomacyWizardTitle			"D I P L O M A T I S C H E S   G E S U C H"

--- a/ctp2_data/italian/gamedata/ldl_str.txt
+++ b/ctp2_data/italian/gamedata/ldl_str.txt
@@ -2608,6 +2608,7 @@ str_ldl_MB_CANCEL				"Annulla"
 
 # Army Management
 str_ldl_ArmyManagement				"Gestione armate"
+str_ldl_ArmyManagementTitle			"G E S T I O N E   A R M A T E"
 
 # Diplomacy wizard
 str_ldl_DiplomacyWizardTitle			"P R O P O S T A  D I P L O M A T I C A"

--- a/ctp2_data/japanese/gamedata/ldl_str.txt
+++ b/ctp2_data/japanese/gamedata/ldl_str.txt
@@ -2704,6 +2704,7 @@ str_ldl_MB_CANCEL					"ｷｬﾝｾﾙ"
 
 # 軍管理
 str_ldl_ArmyManagement "軍管理"
+str_ldl_ArmyManagementTitle "軍管理"
 
 # 外交ウィザード
 str_ldl_DiplomacyWizardTitle "外交上の提案"

--- a/ctp2_data/spanish/gamedata/ldl_str.txt
+++ b/ctp2_data/spanish/gamedata/ldl_str.txt
@@ -2608,6 +2608,7 @@ str_ldl_MB_CANCEL				"Cancelar"
 
 # Army Management
 str_ldl_ArmyManagement				"Administrador del ejército"
+str_ldl_ArmyManagementTitle			"A D M I N I S T R A C I Ó N   D E L   E J É R C I T O"
 
 # Diplomacy wizard
 str_ldl_DiplomacyWizardTitle			"E N V I A R   U N A   P R O P O S I C I Ó N"


### PR DESCRIPTION
This pull-request updates the army-manager-dialog look to be consistent with all the other manager-dialogs.

Before:
![Screenshot from 2021-06-06 11-46-03](https://user-images.githubusercontent.com/10560119/120921308-662bc900-c6c3-11eb-8283-9ea95791cf7f.png)

After:
![Screenshot from 2021-06-06 12-08-10](https://user-images.githubusercontent.com/10560119/120921315-6b891380-c6c3-11eb-9dca-574d3036fa5f.png)
