### PR TITLE
Update Dockerfile to use newest stable Ubuntu as base DI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ################################################################################
 # base system
 ################################################################################
-FROM ubuntu:18.04 as system
+FROM ubuntu as system
 
 ENV USERNAME diUser
 RUN useradd -m $USERNAME && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ FROM system as builder
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     libsdl2-dev libsdl2-mixer-dev libsdl2-image-dev libtiff-dev libavcodec-dev libavformat-dev libswscale-dev \
-    byacc gcc g++ automake libtool unzip flex git ca-certificates
+    byacc gcc g++ automake make libtool unzip flex git ca-certificates
 
 ### set default compilers
 RUN cc --version && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,8 +38,8 @@ ARG BTYP
 
 RUN cd /ctp2 \
     && ./autogen.sh && \
-    CFLAGS="$CFLAGS $( [ "${BTYP##*debug*}" ] && echo -O3 || echo -g -rdynamic ) -fuse-ld=gold" \
-    CXXFLAGS="$CXXFLAGS -fpermissive $( [ "${BTYP##*debug*}" ] && echo -O3 || echo -g -rdynamic ) -fuse-ld=gold" \
+    CFLAGS="$CFLAGS -Wno-misleading-indentation $( [ "${BTYP##*debug*}" ] && echo -O3 || echo -g -rdynamic ) -fuse-ld=gold" \
+    CXXFLAGS="$CXXFLAGS -Wno-misleading-indentation -fpermissive $( [ "${BTYP##*debug*}" ] && echo -O3 || echo -g -rdynamic ) -fuse-ld=gold" \
     ./configure --prefix=/opt/ctp2 --bindir=/opt/ctp2/ctp2_program/ctp --enable-silent-rules $( [ "${BTYP##*debug*}" ] || echo --enable-debug ) \
     && make -j"$(nproc)" \
     && make -j"$(nproc)" install \

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,8 +37,8 @@ ARG BTYP
 
 RUN cd /ctp2 \
     && ./autogen.sh && \
-    CFLAGS="$CFLAGS $( [ "${BTYP##*debug*}" ] && echo -O3 || echo -g -rdynamic ) -fuse-ld=gold" \
-    CXXFLAGS="$CXXFLAGS -fpermissive $( [ "${BTYP##*debug*}" ] && echo -O3 || echo -g -rdynamic ) -fuse-ld=gold" \
+    CFLAGS="$CFLAGS -w $( [ "${BTYP##*debug*}" ] && echo -O3 || echo -g -rdynamic ) -fuse-ld=gold" \
+    CXXFLAGS="$CXXFLAGS -fpermissive -w $( [ "${BTYP##*debug*}" ] && echo -O3 || echo -g -rdynamic ) -fuse-ld=gold" \
     ./configure --prefix=/opt/ctp2 --bindir=/opt/ctp2/ctp2_program/ctp --enable-silent-rules $( [ "${BTYP##*debug*}" ] || echo --enable-debug ) \
     && make -j"$(nproc)" \
     && make -j"$(nproc)" install \

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,8 @@ RUN useradd -m $USERNAME && \
 ################################################################################
 FROM system as builder
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get install -y --no-install-recommends \
     libsdl2-dev libsdl2-mixer-dev libsdl2-image-dev libtiff-dev libavcodec-dev libavformat-dev libswscale-dev \
     byacc gcc g++ automake make libtool unzip flex git ca-certificates
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,8 +37,8 @@ ARG BTYP
 
 RUN cd /ctp2 \
     && ./autogen.sh && \
-    CFLAGS="$CFLAGS -w $( [ "${BTYP##*debug*}" ] && echo -O3 || echo -g -rdynamic ) -fuse-ld=gold" \
-    CXXFLAGS="$CXXFLAGS -fpermissive -w $( [ "${BTYP##*debug*}" ] && echo -O3 || echo -g -rdynamic ) -fuse-ld=gold" \
+    CFLAGS="$CFLAGS $( [ "${BTYP##*debug*}" ] && echo -O3 || echo -g -rdynamic ) -fuse-ld=gold" \
+    CXXFLAGS="$CXXFLAGS -fpermissive $( [ "${BTYP##*debug*}" ] && echo -O3 || echo -g -rdynamic ) -fuse-ld=gold" \
     ./configure --prefix=/opt/ctp2 --bindir=/opt/ctp2/ctp2_program/ctp --enable-silent-rules $( [ "${BTYP##*debug*}" ] || echo --enable-debug ) \
     && make -j"$(nproc)" \
     && make -j"$(nproc)" install \

--- a/ctp2_code/gs/gameobj/gaiacontroller.cpp
+++ b/ctp2_code/gs/gameobj/gaiacontroller.cpp
@@ -108,7 +108,6 @@ void GaiaController::InitializeStatics()
 		g_theEndGameObjectDB->FindRecordNameIndex("ENDGAME_PROCESSING_TOWER");
 
 	Assert(sm_towerEndgameIndex >= 0);
-	Assert(g_theEndGameObjectDB->Get(sm_towerEndgameIndex) >= 0);
 	if (sm_towerEndgameIndex >= 0 && g_theEndGameObjectDB->Get(sm_towerEndgameIndex))
 	{
 		terr_rec = g_theEndGameObjectDB->Get(sm_towerEndgameIndex)->
@@ -120,7 +119,6 @@ void GaiaController::InitializeStatics()
 		g_theEndGameObjectDB->FindRecordNameIndex("ENDGAME_POWER_SATELLITE");
 
 	Assert(sm_satelliteEndgameIndex >= 0);
-	Assert(g_theEndGameObjectDB->Get(sm_satelliteEndgameIndex) >= 0);
 	if (sm_satelliteEndgameIndex >= 0 && g_theEndGameObjectDB->Get(sm_satelliteEndgameIndex))
 	{
 		building_rec = g_theEndGameObjectDB->Get(sm_satelliteEndgameIndex)->
@@ -132,7 +130,6 @@ void GaiaController::InitializeStatics()
 		g_theEndGameObjectDB->FindRecordNameIndex("ENDGAME_GAIA_COMPUTER");
 
 	Assert(sm_mainframeEndgameIndex >= 0);
-	Assert(g_theEndGameObjectDB->Get(sm_mainframeEndgameIndex) >= 0);
 	if (sm_mainframeEndgameIndex >= 0 && g_theEndGameObjectDB->Get(sm_mainframeEndgameIndex))
 	{
 		building_rec = g_theEndGameObjectDB->Get(sm_mainframeEndgameIndex)->

--- a/ctp2_code/libs/freetype-1.3.1/test/fttimer.c
+++ b/ctp2_code/libs/freetype-1.3.1/test/fttimer.c
@@ -74,7 +74,7 @@
   int             cur_point;
   unsigned short  cur_contour;
 
-  TT_Raster_Map  Bit;
+  extern TT_Raster_Map  Bit;
 
   int  Fail;
   int  Num;

--- a/ctp2_code/libs/freetype-1.3.1/test/ftzoom.c
+++ b/ctp2_code/libs/freetype-1.3.1/test/ftzoom.c
@@ -105,7 +105,7 @@
   int        xoffset;
   int        yoffset;
 
-  TT_Raster_Map  Bit;
+  extern TT_Raster_Map  Bit;
 
   int  Fail;
   int  Num;

--- a/debian/DEBIAN/control
+++ b/debian/DEBIAN/control
@@ -3,7 +3,7 @@ Version: 1.0-0
 Section: base
 Priority: optional
 Architecture: all
-Depends: libsdl2-2.0-0, libsdl2-mixer-2.0-0, libsdl2-image-2.0-0, libavcodec57, libavformat57, libswscale4
+Depends: libsdl2-2.0-0 (>= 2), libsdl2-mixer-2.0-0 (>= 2), libsdl2-image-2.0-0 (>= 2), libavcodec58 (>= 3), libavformat58 (>= 3), libswscale5 (>= 3)
 Maintainer: Maintainer of civctp2 (https://github.com/civctp2/civctp2)
 Description: Linux version of Call to Power II (ctp2) without game files
   The game files need to be provided before the installation of the dep-package

--- a/tools/run-DI.sh
+++ b/tools/run-DI.sh
@@ -23,6 +23,15 @@
 ##     -v $HOME/ctp2CD/ctp2_program/ctp/videos/:opt/ctp2/ctp2_data/default/videos/:ro \
 ##     --env="ALSA_CARD=1" \
 ##     registry.gitlab.com/civctp2/civctp2/master:latest ./ctp2 fullscreen
+## 
+## some sound cards apparently cannot be chosesn by ALSA env-vars (e.g. --env="ALSA_PCM_CARD=0" --env="ALSA_PCM_DEVICE=3) but work with SDL env-var
+## ./run-DI.sh \
+##     -v $HOME/ctp2CD/ctp2_program/ctp/music/:/opt/ctp2/ctp2_program/ctp/music/:ro \
+##     -v $HOME/ctp2CD/ctp2_program/ctp/videos/:opt/ctp2/ctp2_data/default/videos/:ro \
+##     --env="AUDIODEV=hw:0,3" \
+##     registry.gitlab.com/civctp2/civctp2/master:latest ./ctp2 fullscreen
+
+
 
 
 XSOCK=/tmp/.X11-unix


### PR DESCRIPTION
This PR updates the Dockerfile to use newest stable Ubuntu as base DI.
With this we can detect if changes to the newest stable Ubuntu cause build/run problems, especially if setting up a monthly schedule in the GL-CI for the master branch.
General problems are updates to gcc (being more strict about the code consistency) and to packages that include a version number in their name (e.g. libswscale5)