### PR TITLE
Update GL-CI yaml

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -28,6 +28,7 @@ variables:
                    --tag $IMAGE_TAG:system-latest
                    --target system
                    .
+                   | tee -a build.log
     - docker push $IMAGE_TAG:system-latest
     ## 2nd stage build using builder-latest for caching
     - docker pull $IMAGE_TAG:builder-latest-${CI_JOB_NAME} || true
@@ -38,6 +39,7 @@ variables:
                    --build-arg BTYP=${CI_JOB_NAME}
                    --target builder 
                    .
+                   | tee -a build.log
     - docker push $IMAGE_TAG:builder-latest-${CI_JOB_NAME}
     - mkdir -p deb/ # create artifacts folder
     - docker run --rm
@@ -60,11 +62,14 @@ variables:
                    --build-arg BTYP=${CI_JOB_NAME}
                    --target install
                    .
+                   | tee -a build.log
     - docker push $IMAGE_TAG:test-${CI_JOB_NAME}
   retry: 2
   artifacts:
+    when: always
     paths:
     - deb/*.deb
+    - build.log
 
 plain:
   <<: *build

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -28,7 +28,7 @@ variables:
                    --tag $IMAGE_TAG:system-latest
                    --target system
                    .
-                   | tee -a build.log
+                   | tee -a build.log | grep -v 'warning:'
     - docker push $IMAGE_TAG:system-latest
     ## 2nd stage build using builder-latest for caching
     - docker pull $IMAGE_TAG:builder-latest-${CI_JOB_NAME} || true
@@ -39,7 +39,7 @@ variables:
                    --build-arg BTYP=${CI_JOB_NAME}
                    --target builder 
                    .
-                   | tee -a build.log
+                   | tee -a build.log | grep -v 'warning:'
     - docker push $IMAGE_TAG:builder-latest-${CI_JOB_NAME}
     - mkdir -p deb/ # create artifacts folder
     - docker run --rm
@@ -62,7 +62,7 @@ variables:
                    --build-arg BTYP=${CI_JOB_NAME}
                    --target install
                    .
-                   | tee -a build.log
+                   | tee -a build.log | grep -v 'warning:'
     - docker push $IMAGE_TAG:test-${CI_JOB_NAME}
   retry: 2
   artifacts:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -28,7 +28,7 @@ variables:
                    --tag $IMAGE_TAG:system-latest
                    --target system
                    .
-                   | tee -a build.log | grep -v 'warning:'
+                   | tee -a build.log
     - docker push $IMAGE_TAG:system-latest
     ## 2nd stage build using builder-latest for caching
     - docker pull $IMAGE_TAG:builder-latest-${CI_JOB_NAME} || true
@@ -39,7 +39,7 @@ variables:
                    --build-arg BTYP=${CI_JOB_NAME}
                    --target builder 
                    .
-                   | tee -a build.log | grep -v 'warning:'
+                   | tee -a build.log
     - docker push $IMAGE_TAG:builder-latest-${CI_JOB_NAME}
     - mkdir -p deb/ # create artifacts folder
     - docker run --rm
@@ -62,7 +62,7 @@ variables:
                    --build-arg BTYP=${CI_JOB_NAME}
                    --target install
                    .
-                   | tee -a build.log | grep -v 'warning:'
+                   | tee -a build.log
     - docker push $IMAGE_TAG:test-${CI_JOB_NAME}
   retry: 2
   artifacts:


### PR DESCRIPTION
Apparently #385 hits an error during GL-CI which happens after the log limit of 4MB is reached (https://gitlab.com/civctp2/civctp2/-/jobs/2988749954), such that it is currently not possible to see what causes the problems. Since we built on the free GL-CI runners, it is not possible to increase this limit. This PR offers a workaround based on https://gitlab.com/gitlab-org/gitlab-runner/-/issues/2955#note_751981846.
It is possible to disabling warnings completely but that can cause serious problems like here: https://github.com/civctp2/civctp2/pull/312#issuecomment-6403127.