### PR TITLE
Fix crash when conquering nation with active franchises

### DIFF
--- a/ctp2_code/gs/gameobj/CityData.cpp
+++ b/ctp2_code/gs/gameobj/CityData.cpp
@@ -2259,7 +2259,7 @@ sint32 CityData::ProcessProduction(bool projectedOnly, sint32 &grossProduction, 
 
 	sint32 const shields			= grossProduction - (crimeLoss + franchiseLoss);
 
-	if (m_franchise_owner >= 0)
+	if (m_franchise_owner >= 0 && g_player[m_franchise_owner] != NULL)
 	{
 		if(!projectedOnly)
 			g_player[m_franchise_owner]->AddProductionFromFranchise(franchiseLoss);
@@ -6143,7 +6143,8 @@ void CityData::RemoveFranchise()
 	UnseenCellCarton ucell;
 
 	m_home_city.GetPos(pos);
-	if(g_player[m_franchise_owner]->GetLastSeen(pos, ucell)) // get un-seen cell of franchise owner
+	if(g_player[m_franchise_owner] != NULL 
+           && g_player[m_franchise_owner]->GetLastSeen(pos, ucell)) // get un-seen cell of franchise owner
 	{
 		ucell.m_unseenCell->SetIsFranchised(false); // remove franchise flag
 	}
@@ -6542,7 +6543,8 @@ void CityData::Unconvert(bool makeUnhappy)
 	UnseenCellCarton ucell;
 
 	m_home_city.GetPos(pos);
-	if(g_player[m_convertedTo]->GetLastSeen(pos, ucell)) // get un-seen cell of conversion owner
+	if(g_player[m_convertedTo]
+	   && g_player[m_convertedTo]->GetLastSeen(pos, ucell)) // get un-seen cell of conversion owner
 	{
 		ucell.m_unseenCell->SetIsConverted(false); // remove conversion flag
 	}


### PR DESCRIPTION
I ran into a bug where conquering a nation with active franchises would crash the game on the next AI turn.

It seems the city still tries to process the franchise. `CityData::ProcessProduction` and `CityData::RemoveFranchise` both deference `g_player[m_franchise_owner]` which is null after conquering. The franchises seem to be removed after these calculations.

I added null pointer checks to both those calls, which allowed me to get to the next turn. This turn took a lot longer than I thought it would!

The check was also missing from one of the analogous conversion functions (it was present in the other). I surprisingly couldn't reproduce the crash there, but thought it best to add the test anyway.