### PR TITLE
Build ubuntu arm

### DIFF
--- a/ctp2_code/Makefile.am
+++ b/ctp2_code/Makefile.am
@@ -55,7 +55,8 @@ ctp_ctp2_LDADD = \
 	sound/libsound.la \
 	$(CTP2_LIBANET_LDADD) \
 	$(CTP2_LIBOSNOWIN32_LDADD) \
-	$(CTP2_LIBTTF_LDADD)
+	$(CTP2_LIBTTF_LDADD) \
+	$(CTP2_LDADD)
 
 ctp_ctp2_LDFLAGS = \
 	$(CTP2_LDFLAGS)

--- a/ctp2_code/os/autoconf/Makefile.common
+++ b/ctp2_code/os/autoconf/Makefile.common
@@ -6,9 +6,13 @@ CTP2_LDFLAGS = \
 	$(DIRECTX_LDFLAGS) \
 	$(DXMEDIA_LDFLAGS) \
 	$(SDL_LDFLAGS) \
-	-ltiff -lz -lSDL2 -lSDL2_image -lSDL2_mixer $(SDL_FFMPEG_LDFLAGS) -ldl -lpthread \
+        $(SDL_FFMPEG_LDFLAGS) \
 	$(X_PRE_LIBS) \
-	$(X_LIBS) -lX11 -ldl
+	$(X_LIBS)
+
+CTP2_LDADD = \
+	-ltiff -lz -lSDL2 -lSDL2_image -lSDL2_mixer -ldl -lpthread -lX11
+
 
 CTP2_CFLAGS=\
 	$(SDL_CFLAGS) \

--- a/ctp2_code/os/autoconf/os_defs.m4
+++ b/ctp2_code/os/autoconf/os_defs.m4
@@ -17,6 +17,13 @@ AC_DEFUN([AC_OS_DEFINES],[
 	 AC_DEFINE(__USE_GNU,1,[Use GNU extensions of glibc])
 	 CTP2_NOWIN32_INC='-I$(ctp2_code)/os/nowin32'
          ac_OpSystem="LINUX"
+         ;;
+   esac
+
+   case "${host}" in
+     aarch64-*)
+       AC_DEFINE(__arm__,1,[Define to 1 if you are compiling on ARM])
+       ;;
    esac
 
    AC_SUBST(CTP2_NOWIN32_INC)


### PR DESCRIPTION
1) Set arm flag

Use existing but unused define to Ignore assmebly in c3blitter.cpp (See #361). Define is only used in that file, and only for hiding assembly.

Left open for future architecture checks if needed.

2) Reorder linker arguments. 
`ld` expects libraries after objects, while currently they are before. This caused problems for me when trying to compile with debugging symbols. The current instructions suggest using `gold` if `ld` fails, which I suspect is at least in part because `gold` is more permissive with the order of linker arguments.

Actually it might be a good idea to clean up the libraries here in general. Libraries are defined several times in a few places, and some of them seem to be unused. Is it even possible to use autotools on a system with DirectX? This task migh turn into a bigger refactor, however, which sound dangerous. Especially since I just got here and am very much learning on the job :)