### PR TITLE
WIP: Fix Crashes in ListBox Mouse Event Handling

### DIFF
--- a/ctp2_code/ui/aui_common/aui_listbox.h
+++ b/ctp2_code/ui/aui_common/aui_listbox.h
@@ -333,7 +333,8 @@ protected:
 
 private:
 	sint32 CalculateRelativeY(sint32 y) const {
-		return y - m_y - (m_pane ? m_pane->Y() : 0);
+		sint32 relativeY = y - m_y - (m_pane ? m_pane->Y() : 0);
+		return (relativeY > 0 ? relativeY : 0);
 	}
 
 	sint32 CalculateItemIndexByRelativeY(sint32 relativeY) const {


### PR DESCRIPTION
Fixes crash caused by clicking on the top border of an empty listbox. See #402 

RelativeY is negative in this case, which bypasses sanity checks which assume a non-negative value. This becomes a negative index, which causes a segfault later upon attempted deference.

Might be nice if some of the assumptions on paramters in this class were more explicit.

After this PR I'll put these small fixes into a single PR.