### PR TITLE
Removing X11 from Linux build

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,21 +1,21 @@
 dnl $Id: configure.ac 966 2009-04-11 11:23:43Z ctplinuxfan $
 dnl
-AC_INIT(ctp2,1.2)
-AC_PREREQ(2.54)
+AC_INIT([ctp2],[1.2])
+AC_PREREQ([2.71])
 
 AC_CONFIG_AUX_DIR(ctp2_code/os/autoconf/config)
 AC_CANONICAL_HOST
 AC_CANONICAL_TARGET
 
 AM_INIT_AUTOMAKE([subdir-objects])
-AM_CONFIG_HEADER(ctp2_code/os/include/config.h)
+AC_CONFIG_HEADERS(ctp2_code/os/include/config.h)
 AM_MAINTAINER_MODE
 AC_PROG_MAKE_SET
 
 AC_PROG_CC(cl gcc cc KCC CC egcs)
 AC_PROG_CXX(cl g++ gcc cxx c++ cc++ KCC CC egcs)
 AX_CXX_COMPILE_STDCXX_11(noext, mandatory)
-AC_PROG_LIBTOOL
+LT_INIT
 AC_LANG(C++)
 AM_PROG_LEX
 dnl AC_PROG_YACC
@@ -50,7 +50,7 @@ then
 fi
 AC_SUBST(UNZIP)
 
-dnl AC_PROG_LIBTOOL
+dnl LT_INIT
 
 AM_PATH_DIRECTX
 AM_PATH_DXMEDIA
@@ -60,7 +60,7 @@ AC_PATH_X
 AC_PATH_XTRA
 AC_DEFINE(USE_SDL,1,[Use the SDL-library])
 
-AC_WORDS_BIGENDIAN
+AC_C_BIGENDIAN
 AC_OS_DEFINES
 AC_OS_PATHNAMES
 
@@ -105,9 +105,6 @@ AC_SUBST(CPPFLAGS)
 AC_SUBST(CXXFLAGS)
 
 AC_DEFINE(_TIFF_DATA_TYPEDEFS_,1,[Tiff uint{16,32} datatype collision prevention])
-if test x$have_x=xyes; then
-	AC_DEFINE(HAVE_X11,1,[System with X11R6 present])
-fi
 
 if test x$prefix == xNONE; then
 	if test x$ac_default_prefix == x; then
@@ -122,14 +119,14 @@ AC_DEFINE_UNQUOTED(PACKAGE_DATADIR,"${package_datadir}",[read-only architecture-
 AC_DEFINE_UNQUOTED(PACKAGE_SYSCONFDIR,"${package_sysconfdir}",[read-only single-machine data [PREFIX/etc]])
 
 AC_ARG_ENABLE([logging],
-              AC_HELP_STRING([--enable-logging],[enable logging]),,
+              AS_HELP_STRING([--enable-logging],[enable logging]),,
 	      [enable_logging=no])
 if test x$enable_logging = xyes  || test x$enable_logging = xfull; then
 	AC_DEFINE(USE_LOGGING,1,[Enable logging])
 fi
 
 AC_ARG_ENABLE([debug],
-              AC_HELP_STRING([--enable-debug],[enable debugging]),,
+              AS_HELP_STRING([--enable-debug],[enable debugging]),,
 	      [enable_debug=no])
 if test x$enable_debug = xyes  || test x$enable_debug = xfull; then
 	AC_DEFINE(_DEBUG,1,[Enable debugging code])
@@ -144,7 +141,7 @@ if test 0 -eq 1; then
 fi
 enable_anet=no
 AC_ARG_ENABLE([anet],
-              AC_HELP_STRING([--enable-anet],[enable external anet library]),,
+              AS_HELP_STRING([--enable-anet],[enable external anet library]),,
 	      [enable_anet=no])
 AC_MSG_CHECKING([whether to build with internal anet library])
 if test x$enable_anet == xno; then
@@ -166,7 +163,7 @@ fi
 AC_DEFINE(CTP2_ENABLE_SLICDEBUG,1,[In every version])
 AC_SUBST(CTP2_ENABLE_SLICDEBUG) # What is this good for?
 
-AC_OUTPUT([
+AC_CONFIG_FILES([
    GNUmakefile
    ctp2_code/Makefile
    ctp2_code/gfx/Makefile
@@ -193,3 +190,4 @@ AC_OUTPUT([
    ctp2_code/ui/Makefile
    ctp2_code/ui/interface/Makefile
 ])
+AC_OUTPUT

--- a/ctp2_code/ctp/civ3_main.cpp
+++ b/ctp2_code/ctp/civ3_main.cpp
@@ -172,9 +172,6 @@
 #include <SDL2/SDL_mixer.h>
 #include "aui_sdlkeyboard.h"
 #endif
-#ifdef HAVE_X11
-#include <X11/Xlib.h>
-#endif
 
 #if defined(_DEBUG)
 #include "debug.h"          // Os::SetThreadName
@@ -482,59 +479,7 @@ int ui_Initialize(void)
 	}
 	strcat(s, FILE_SEP "fonts");
 	g_c3ui->AddBitmapFontSearchPath(s);
-#elif defined(HAVE_X11)
-	Display *display = g_c3ui->getDisplay();
-	int ndirs;
-	bool noPath = true;
-	char **fontpaths = XGetFontPath(display, &ndirs);
-	if (fontpaths)
-	{
-		struct stat st = { 0 };
-		for (int i = 0; i < ndirs; i++)
-		{
-			int rc = stat(fontpaths[i], &st);
-			if ((rc == 0) && (S_ISDIR(st.st_mode)))
-			{
-				g_c3ui->AddBitmapFontSearchPath(fontpaths[i]);
-				// Make some default paths get added, too
-				//noPath = false;
-			}
-		}
-		XFreeFontPath(fontpaths);
-	}
-	// Fontpath just contains server(s)?
-	if (noPath)
-	{
-		const int maxPaths = 3;
-		const char* fontPaths[maxPaths] = {
-			"/usr/share/fonts",
-			"/usr/X11R6/lib/X11/fonts",
-			"/usr/lib/X11/fonts"
-		};
-		const int maxDirs = 4;
-		const char* fontDirs[maxDirs] = {
-			"TTF",
-			"corefonts",
-			"truetype",
-			"truetype/msttcorefonts"
-		};
-		for (int pIdx = 0; pIdx < maxPaths; pIdx++)
-		{
-			for (int dIdx = 0; dIdx < maxDirs; dIdx++)
-			{
-				struct stat st = { 0 };
-				snprintf(s, sizeof(s), "%s/%s",
-					fontPaths[pIdx], fontDirs[dIdx]);
-				int rc = stat(s, &st);
-				if ((rc == 0) && (S_ISDIR(st.st_mode)))
-				{
-					g_c3ui->AddBitmapFontSearchPath(s);
-				}
-			}
-		}
-	}
 #endif
-
 	for (i = 0; g_civPaths->FindPath(C3DIR_VIDEOS, i, s); ++i)
 	{
 		if (s[0])
@@ -1600,7 +1545,6 @@ int WINAPI CivMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PSTR szCmdLine,
 #endif
 
 #ifdef __GNUC__
-	XInitThreads();
 	ParseCommandLine(iCmdShow, pSzCmdLine);
 #else
 	ParseCommandLine(szCmdLine);

--- a/ctp2_code/meson.build
+++ b/ctp2_code/meson.build
@@ -39,11 +39,7 @@ if not win32
 	tiff = dependency('libtiff-4')
 	zlib = dependency('zlib')
 
-	x11 = dependency('x11', required: false)
-	if x11.found()
-		conf.set('HAVE_X11', 1, description : 'System with X11 present')
-	endif
-	main_dependencies += [tiff, zlib, sdl, x11]
+	main_dependencies += [tiff, zlib, sdl]
 	
 	incdir += include_directories('os/nowin32')
 

--- a/ctp2_code/os/autoconf/Makefile.common
+++ b/ctp2_code/os/autoconf/Makefile.common
@@ -11,7 +11,7 @@ CTP2_LDFLAGS = \
 	$(X_LIBS)
 
 CTP2_LDADD = \
-	-ltiff -lz -lSDL2 -lSDL2_image -lSDL2_mixer -ldl -lpthread -lX11
+	-ltiff -lz -lSDL2 -lSDL2_image -lSDL2_mixer -ldl -lpthread
 
 
 CTP2_CFLAGS=\

--- a/ctp2_code/ui/aui_sdl/aui_sdlui.cpp
+++ b/ctp2_code/ui/aui_sdl/aui_sdlui.cpp
@@ -70,7 +70,6 @@ aui_SDLUI::aui_SDLUI
 )
 :   aui_UI              (),
     aui_SDL             (),
-    m_X11Display        (0),
     m_SDLWindow         (0),
     m_SDLRenderer       (0),
     m_SDLTexture        (0)
@@ -94,22 +93,6 @@ aui_SDLUI::aui_SDLUI
 	*retval = CreateNativeScreen( useExclusiveMode );
 	Assert( AUI_SUCCESS(*retval) );
 	if ( !AUI_SUCCESS(*retval) ) return;
-
-	/**retval = aui_UI::CreateScreen();
-	Assert( AUI_SUCCESS(*retval) );
-	if ( !AUI_SUCCESS(*retval) ) return;*/
-
-#if defined(HAVE_X11)
-	char *dispname = getenv("DISPLAY");
-	if (dispname) {
-		m_X11Display = XOpenDisplay(dispname);
-	} else {
-		m_X11Display = XOpenDisplay(":0.0");
-	}
-	if (!m_X11Display) {
-		*retval = AUI_ERRCODE_NOUI;
-	}
-#endif
 }
 
 AUI_ERRCODE aui_SDLUI::InitCommon()
@@ -171,22 +154,8 @@ AUI_ERRCODE aui_SDLUI::CreateNativeScreen( BOOL useExclusiveMode )
 	return AUI_ERRCODE_OK;
 }
 
-#ifdef HAVE_X11
-Display *
-aui_SDLUI::getDisplay()
-{
-	return m_X11Display;
-}
-#endif
-
 aui_SDLUI::~aui_SDLUI( void )
 {
-#ifdef HAVE_X11
-	if (m_X11Display) {
-		XCloseDisplay(m_X11Display);
-		m_X11Display = 0;
-	}
-#endif
 	if (m_SDLTexture) {
 		SDL_DestroyTexture(m_SDLTexture);
 		m_SDLTexture = NULL;

--- a/ctp2_code/ui/aui_sdl/aui_sdlui.h
+++ b/ctp2_code/ui/aui_sdl/aui_sdlui.h
@@ -34,9 +34,6 @@
 
 #include "aui_ui.h"
 #include "aui_sdl.h"
-#if defined(HAVE_X11)
-#include <X11/Xlib.h>
-#endif
 
 class aui_SDLUI : public aui_UI, public aui_SDL
 {
@@ -72,17 +69,10 @@ public:
 	void SetWidth(sint32 width) { m_width = width; }
 	void SetHeight(sint32 height) { m_height = height; }
 
-#if defined(HAVE_X11)
-	Display *getDisplay();
-#endif
-
 	aui_MovieManager* CreateMovieManager( void );
 protected:
 	virtual AUI_ERRCODE SDLDrawScreen( void );
 
-#if defined(HAVE_X11)
-	Display *           m_X11Display;
-#endif
 	SDL_Window *m_SDLWindow;
 	SDL_Renderer *m_SDLRenderer;
 	SDL_Texture *m_SDLTexture;


### PR DESCRIPTION
X11 on Linux is now legacy and many distributions no longer provide X11 on a default system install.  This completely removes the dependency and allows CTP2 on Linux to use SDL2 for everything, this of course is still cross-platform for BSD systems since SDL2 is available there as well.

This PR also updates the configure.ac file as some content was using a very old version of AutoConf.

All these changes were tested and verified on Ubuntu 22.10.