### PR TITLE
Randomize target city when freeing slaves

### DIFF
--- a/ctp2_code/gs/gameobj/ArmyData.cpp
+++ b/ctp2_code/gs/gameobj/ArmyData.cpp
@@ -3322,7 +3322,7 @@ ORDER_RESULT ArmyData::UndergroundRailway(const MapPoint &point)
 
 	if(c.GetOwner() == m_array[0].GetOwner())
 	{
-		DPRINTF(k_DBG_GAMESTATE, ("You can't free your own slaves with an abolitionist.  In fact, you shouldn't even be able to have both slaves and an abolitionist.  Stop cheating!\n"));
+		DPRINTF(k_DBG_GAMESTATE, ("You can't free your own slaves with an abolitionist.\n"));
 		return ORDER_RESULT_ILLEGAL;
 	}
 

--- a/ctp2_code/gs/gameobj/ArmyData.cpp
+++ b/ctp2_code/gs/gameobj/ArmyData.cpp
@@ -2966,7 +2966,7 @@ ORDER_RESULT ArmyData::SlaveRaid(const MapPoint &point)
 	Unit home_city; // city where slaves are put to work
 
 	if (!IsSlaveRaidPossible(point, success, death, timer, amount, uindex,
-	    target_is_city, target_city, home_city))
+	    target_is_city, target_city, home_city)) // determines home_city (with Player::GetSlaveCity)
 	{
 		DPRINTF(k_DBG_GAMESTATE, ("!IsSlaveRaidPossible()\n"));
 		return ORDER_RESULT_ILLEGAL;
@@ -2989,7 +2989,7 @@ ORDER_RESULT ArmyData::SlaveRaid(const MapPoint &point)
 		// InformAI(UNIT_ORDER_ENSLAVE_SETTLER, point); //does nothing here but could be implemented
 
 		DPRINTF(k_DBG_GAMESTATE, ("Doing EnslaveSettler instead of SlaveRaid\n"));
-		return EnslaveSettler(point, uindex, home_city); //redetermines home_city?
+		return EnslaveSettler(point, uindex, home_city); // redetermines home_city (with Player::GetSlaveCity) but does not return it
 	}
 
 	double slaveryReduction = target_city.IsProtectedFromSlavery();
@@ -3240,7 +3240,7 @@ bool ArmyData::CanEnslaveSettler(sint32 &uindex) const
 ORDER_RESULT ArmyData::EnslaveSettler(const MapPoint &point, const sint32 uindex,
                               Unit home_city)
 {
-	sint32 r = g_player[m_owner]->GetSlaveCity(m_pos, home_city);
+	sint32 r = g_player[m_owner]->GetSlaveCity(m_pos, home_city);  // could be removed, already checked in ArmyData::SlaveRaid -> check if ArmyData::EnslaveSettler is called from elsewhere
 	if(!r)
 		return ORDER_RESULT_ILLEGAL;
 

--- a/ctp2_code/gs/gameobj/unitevent.cpp
+++ b/ctp2_code/gs/gameobj/unitevent.cpp
@@ -266,8 +266,7 @@ STDEHANDLER(UndergroundRailwayUnitEvent)
 	c.RemoveOneSlave(u.GetOwner());
 
 	Unit hc;
-	double distance;
-	sint32 r = g_player[u.GetOwner()]->GetNearestCity(u.RetPos(), hc, distance);
+	sint32 r = g_player[u.GetOwner()]->GetSlaveCity(u.RetPos(), hc); // use GetSlaveCity instead of GetNearestCity to include randomness for determining the target city (to avoid accumulation in border cities)
 	Assert(r);
 
 	if(!r)


### PR DESCRIPTION
So far the nearest city is the target when freeing slaves. This leads to oversized cities on the border of the empire. This PR randomizes the target city (like it is done when doing slave raids) as a simple measure to avoid this.