### PR TITLE
increase trade route value based on squared distance

### DIFF
--- a/ctp2_code/gs/gameobj/CityData.cpp
+++ b/ctp2_code/gs/gameobj/CityData.cpp
@@ -9453,8 +9453,6 @@ void CityData::FindGoodDistances()
 		m_distanceToGood[i] = 0 + specialdistance;
 	}
 
-//	g_theWorld->FindDistances(m_owner, m_home_city.RetPos(), goodsToFind,
-//	                          FindGoodDistancesCallback, this);
 	g_theWorld->FindDistances(m_owner, m_pos, goodsToFind,
 	                          FindGoodDistancesCallback, this);
 }

--- a/ctp2_code/gs/gameobj/Player.cpp
+++ b/ctp2_code/gs/gameobj/Player.cpp
@@ -2996,14 +2996,14 @@ TradeRoute Player::CreateTradeRoute(Unit sourceCity,
 			if(!sourceCity.HasResource(sourceResource) &&
 				sourceCity.CD()->IsLocalResource(sourceResource)) {
 				if(sourceCity.AccessData()->GetCityData()->BreakOneSourceRoute(sourceType, sourceResource)) {
-					g_gevManager->AddEvent(GEV_INSERT_Tail, GEV_SendGood,
+				    g_gevManager->AddEvent(GEV_INSERT_Tail, GEV_SendGood, // resent GEV_SendGood if an existing route had to be broken to make the good available for the new route
 										   GEA_Int, sourceResource,
 										   GEA_City, sourceCity,
 										   GEA_City, destCity,
 										   GEA_End);
 				}
 				return TradeRoute();
-			}
+			} // if good is not bound to an existing route, just continue!
 			break;
 		case ROUTE_TYPE_FOOD:
 		case ROUTE_TYPE_GOLD:

--- a/ctp2_code/gs/gameobj/PlayerEvent.cpp
+++ b/ctp2_code/gs/gameobj/PlayerEvent.cpp
@@ -556,7 +556,7 @@ STDEHANDLER(SendGoodEvent)
 	} else {
 		g_player[sourceCity.GetOwner()]->CreateTradeRoute(sourceCity, ROUTE_TYPE_RESOURCE, // apparently the only active source for the creation of trade routes
 		                                                  resIndex, destCity,
-		                                                  sourceCity.GetOwner(), 0);
+		                                                  sourceCity.GetOwner(), 0); // 0 is for gold_in_return which seems to be a ctp1 remainder where this was used to account for trade bids (https://github.com/civctp2/civctp2/blob/67532c1338ad8c0f8e943a6e04633782543fa06a/ctp2_code/gs/gameobj/Player.cpp#L3418-L3422), in ctp2 the values seems to be determined only by tradeutil_GetTradeValue e.g. in TradeRouteData::GetValue()
 	}
 	return GEV_HD_Continue;
 }

--- a/ctp2_code/gs/gameobj/tradeutil.cpp
+++ b/ctp2_code/gs/gameobj/tradeutil.cpp
@@ -63,7 +63,8 @@ sint32 tradeutil_GetTradeValue(const sint32 owner, const Unit & destination, sin
 
     PLAYER_INDEX const  tradePartner = destination.GetOwner();
 
-    sint32 totalValue= sint32(baseValue * destination.GetCityData()->GetDistanceToGood(resource));
+    double tmpValue= baseValue * destination.GetCityData()->GetDistanceToGood(resource);
+    sint32 totalValue= static_cast<sint32>(std::min<double>(tmpValue, std::numeric_limits<int>::max())); // limit totalValue to max value of sint32 before casting
     
     if (owner == tradePartner) // reduce value to good in case of domestic trade (good is within territory then)
 	{

--- a/ctp2_code/gs/gameobj/tradeutil.cpp
+++ b/ctp2_code/gs/gameobj/tradeutil.cpp
@@ -59,15 +59,16 @@ sint32 tradeutil_GetTradeValue(const sint32 owner, const Unit & destination, sin
     if(resource < 0 || resource >= g_theResourceDB->NumRecords())
 	return 0;
 
-    double baseValue = g_theWorld->GetGoodValue(resource); // good value varies between a min and a map depening on its frequency on the map
+    double baseValue = g_theWorld->GetGoodValue(resource); // good value varies between MIN_GOOD_VALUE and MAX_GOOD_VALUE (Const.txt) depening on its frequency on the map
 
     PLAYER_INDEX const  tradePartner = destination.GetOwner();
 
-    sint32 totalValue= sint32( // do not count distance to good in case of domestic trade (good is within territory then)
-	(owner != tradePartner) ?
-	baseValue * destination.GetCityData()->GetDistanceToGood(resource) :
-	baseValue * destination.GetCityData()->GetDistanceToGood(resource) * g_theConstDB->Get(0)->GetDomesticTradeReduction()
-	);
+    sint32 totalValue= sint32(baseValue * destination.GetCityData()->GetDistanceToGood(resource));
+    
+    if (owner == tradePartner) // reduce value to good in case of domestic trade (good is within territory then)
+	{
+	totalValue *= g_theConstDB->Get(0)->GetDomesticTradeReduction();
+	}
 
     if ((owner != tradePartner)	&& AgreementMatrix::s_agreements.HasAgreement(owner, tradePartner, PROPOSAL_TREATY_TRADE_PACT))
 	{

--- a/ctp2_code/gs/gameobj/tradeutil.cpp
+++ b/ctp2_code/gs/gameobj/tradeutil.cpp
@@ -60,12 +60,13 @@ sint32 tradeutil_GetTradeValue(const sint32 owner, const Unit & destination, sin
 	return 0;
 
     double baseValue = g_theWorld->GetGoodValue(resource); // good value varies between MIN_GOOD_VALUE and MAX_GOOD_VALUE (Const.txt) depening on its frequency on the map
+    double baseValue2 = baseValue * (10.0*g_theConstDB->Get(0)->GetTradeCoef() - 10) / (100 - 10.0*g_theConstDB->Get(0)->GetTradeCoef()); // TradeCoef is the factor that the VPC (valuePerCaravan) should be increased in case a good needs not just 1 caravan but 10 caravans for creating the trade route, i.e. if TradeCoef= 1 the dependency is just linear (as before), if TradeCoef= 1.002 then the VPC is about 2 times for a good that needs 2 Caravans to trade (in comparison as if the good would only need 1 Caravan to trade)
 
-    PLAYER_INDEX const  tradePartner = destination.GetOwner();
-
-    double tmpValue= baseValue * destination.GetCityData()->GetDistanceToGood(resource);
+    sint32 distToGood= destination.GetCityData()->GetDistanceToGood(resource);
+    double tmpValue= baseValue * distToGood + baseValue2 * distToGood * distToGood; // linear + quadratic dependency
     sint32 totalValue= static_cast<sint32>(std::min<double>(tmpValue, std::numeric_limits<int>::max())); // limit totalValue to max value of sint32 before casting
     
+    PLAYER_INDEX const  tradePartner = destination.GetOwner();
     if (owner == tradePartner) // reduce value to good in case of domestic trade (good is within territory then)
 	{
 	totalValue *= g_theConstDB->Get(0)->GetDomesticTradeReduction();

--- a/ctp2_code/gs/newdb/Const.cdb
+++ b/ctp2_code/gs/newdb/Const.cdb
@@ -327,7 +327,8 @@ Const : alsire {
 
 	Float  CaravanCoef                            aka CARAVAN_COEF
 	Float  DomesticTradeReduction   =    0.5      aka DOMESTIC_TRADE_COEF
-	Float  TradePactCoef            =    1.5     aka PACT_TRADE_COEF
+	Float  TradeCoef            	=    1.002    aka TRADE_COEF
+	Float  TradePactCoef            =    1.5      aka PACT_TRADE_COEF
 
 	Int    PollutionCausedByNuke                  aka POLLUTION_CAUSED_BY_NUKE
 

--- a/ctp2_code/gs/newdb/Const.cdb
+++ b/ctp2_code/gs/newdb/Const.cdb
@@ -327,7 +327,7 @@ Const : alsire {
 
 	Float  CaravanCoef                            aka CARAVAN_COEF
 	Float  DomesticTradeReduction   =    0.5      aka DOMESTIC_TRADE_COEF
-	Float  TradePactCoef            =    1.05     aka PACT_TRADE_COEF
+	Float  TradePactCoef            =    1.5     aka PACT_TRADE_COEF
 
 	Int    PollutionCausedByNuke                  aka POLLUTION_CAUSED_BY_NUKE
 

--- a/ctp2_code/ui/interface/trademanager.cpp
+++ b/ctp2_code/ui/interface/trademanager.cpp
@@ -446,7 +446,7 @@ void TradeManager::UpdateCreateList(const PLAYER_INDEX & player_id)
 						data->m_source = city;
 						data->m_resource = g;
 						data->m_destination = maxCity[i];
-						data->m_price = maxValuePerCaravan[i];
+						data->m_price = tradeutil_GetTradeValue(player_id, maxCity[i], g); // # of gold
 						data->m_caravans = tradeutil_GetTradeDistance(city, maxCity[i]);
 						data->m_curDestination.m_id = curDestCity.m_id;
 
@@ -454,67 +454,67 @@ void TradeManager::UpdateCreateList(const PLAYER_INDEX & player_id)
 						item->SetUserData(data);
 
 						if (ctp2_Static * origin = (ctp2_Static *)item->GetChildByIndex(k_CITY_COL_INDEX))
-                        {
+						    {
 							MBCHAR name[k_MAX_NAME_LEN + 1];
 							strncpy(name, city.GetName(), k_MAX_NAME_LEN);
 							name[k_MAX_NAME_LEN] = 0;
 							origin->TextReloadFont();
 							origin->GetTextFont()->TruncateString(name, origin->Width());
 							origin->SetText(name);
-						}
+						    }
 
 						if (ctp2_Static * icon = (ctp2_Static *)item->GetChildByIndex(k_GOODICON_COL_INDEX))
-                        {
+						    {
 							const char *iconname = g_theResourceDB->Get(g)->GetIcon()->GetIcon();
 							if (stricmp(iconname, "NULL") == 0)
-                            {
+							    {
 								iconname = NULL;
-							}
+							    }
 							icon->SetImage(iconname);
-						}
+						    }
 
 						if (ctp2_Static * good = (ctp2_Static *)item->GetChildByIndex(k_GOOD_COL_INDEX))
-                        {
+						    {
 							good->SetText(g_theResourceDB->Get(g)->GetNameText());
 							if (curDestCity.m_id != 0)
-                            {
+							    {
 								good->SetTextColor(g_colorSet->GetColorRef(COLOR_RED));
-							}
-						}
+							    }
+						    }
 
 						if (ctp2_Static * dest = (ctp2_Static *)item->GetChildByIndex(k_TOCITY_COL_INDEX))
-                        {
+						    {
 							MBCHAR name[k_MAX_NAME_LEN + 1];
 							strncpy(name, maxCity[i].GetName(), k_MAX_NAME_LEN);
 							name[k_MAX_NAME_LEN] = 0;
 							dest->TextReloadFont();
 							dest->GetTextFont()->TruncateString(name, dest->Width());
 							dest->SetText(name);
-						}
+						    }
 
 						MBCHAR buf[20];
-						sprintf(buf, "%d", maxValuePerCaravan[i]);
+						sprintf(buf, "%d", data->m_price);
 						if (ctp2_Static * price = (ctp2_Static *)item->GetChildByIndex(k_PRICE_COL_INDEX))
-                        {
+						    {
 							price->SetText(buf);
-						}
+						    }
 
 						if (ctp2_Static * count = (ctp2_Static *)item->GetChildByIndex(k_CARAVANS_COL_INDEX))
-                        {
+						    {
 							sprintf(buf, "%d", data->m_caravans);
 							count->SetText(buf);
-						}
+						    }
 
 						if (ctp2_Static * nation = (ctp2_Static *)item->GetChildByIndex(k_NATION_COL_INDEX))
-                        {
+						    {
 							nation->SetDrawCallbackAndCookie
                                 (DrawNationColumn, (void *)data->m_destination.GetOwner());
-						}
+						    }
 
 						item->SetCompareCallback(CompareCreateItems);
 
 						m_createList->AddItem(item);
-					}
+					} // if(maxValuePerCaravan[i] > 0)
 				}
 			}
 		}

--- a/ctp2_data/default/gamedata/Const.txt
+++ b/ctp2_data/default/gamedata/Const.txt
@@ -393,4 +393,5 @@ COMBAT_ELITE_CHANCE 0.00
 COMBAT_LEADER_CHANCE 0.00 
 CITY_ON_TRADE_ROUTE_BONUS  0.3   # if a trade route passes through a city and the desination and source is not the same as the city owner then you get this percentage of the trade route value
 DOMESTIC_TRADE_COEF 0.5 # coefficient for the reduction of trade route value in case of domestic trade (value < 1.0 promotes foreign trade)
+TRADE_COEF 1.002 # factor for trade route value depending on squared distance to good, if TradeCoef= 1.002 then the VPC is 2 times for a good that needs 2 Caravans to trade (in comparison as if the good would only need 1 Caravan to trade), if TradeCoef= 1 then there is only a linear dependency (as it used to be)
 PACT_TRADE_COEF  1.5  # surplus in trade route values in case of a standing trade pact

--- a/ctp2_data/default/gamedata/Const.txt
+++ b/ctp2_data/default/gamedata/Const.txt
@@ -393,4 +393,4 @@ COMBAT_ELITE_CHANCE 0.00
 COMBAT_LEADER_CHANCE 0.00 
 CITY_ON_TRADE_ROUTE_BONUS  0.3   # if a trade route passes through a city and the desination and source is not the same as the city owner then you get this percentage of the trade route value
 DOMESTIC_TRADE_COEF 0.5 # coefficient for the reduction of trade route value in case of domestic trade (value < 1.0 promotes foreign trade)
-PACT_TRADE_COEF  1.05  # surplus in trade route values in case of a standing trade pact
+PACT_TRADE_COEF  1.5  # surplus in trade route values in case of a standing trade pact


### PR DESCRIPTION
This PR increases trade route values based on squared distances such that long trade routes become more precious in regard to their `valuePerCaravan`. This promotes longer trade routes, which in turn are more interesting concering the updated tiles along the route (since #256) and allows the AI to acquire more gold so it is can be more capable of affording special attacks and other cost. The PR also resolves a bug in #323.