### PR TITLE
Fix regressions

### DIFF
--- a/ctp2_code/ui/interface/UnitControlPanel.cpp
+++ b/ctp2_code/ui/interface/UnitControlPanel.cpp
@@ -822,7 +822,23 @@ void UnitControlPanel::NextUnitButtonActionCallback(aui_Control * control, uint3
 		return;
 	}
 
-	g_selected_item->NextUnmovedUnit();
+	UnitControlPanel * panel = static_cast<UnitControlPanel*>(cookie);
+	switch (panel->m_currentMode)
+	{
+		case SINGLE_SELECTION:
+		case ARMY_SELECTION:
+			if (SelectionContainsMultipleArmies()) {
+				panel->SetSelectionMode(MULTIPLE_SELECTION);
+			} else {
+				g_selected_item->NextUnmovedUnit();
+			}
+			break;
+
+		case MULTIPLE_SELECTION:
+		default:
+			g_selected_item->NextUnmovedUnit();
+			break;
+	}
 }
 
 bool UnitControlPanel::SelectionContainsMultipleArmies()

--- a/ctp2_code/ui/interface/armymanagerwindow.cpp
+++ b/ctp2_code/ui/interface/armymanagerwindow.cpp
@@ -375,6 +375,37 @@ void ArmyManagerWindow::Update()
 	}
 
 	UpdateArmyName();
+
+	ctp2_Static *armyTextlabel = (ctp2_Static *)aui_Ldl::GetObject(s_armyWindowBlock, "ArmyTextLabel");
+	if(armyTextlabel)
+	{
+		if((g_graphicsOptions
+		&&  g_graphicsOptions->IsArmyTextOn()
+		||  g_theProfileDB->GetDebugAI())
+		&&  m_army.IsValid()
+		&&  m_army->GetDebugString()
+		){
+			armyTextlabel->SetText(m_army->GetDebugString());
+
+			sint32 r, g, b;
+			uint8  col = m_army.GetData()->GetDebugStringColor();
+
+			g_tiledMap->ColorMagnitudeToRGB(col, &r, &g, &b);
+
+			COLORREF fgColor = RGB(r, g, b);
+			// not used COLORREF	bgColor = RGB(0,0,0);
+
+			armyTextlabel->SetTextColor(fgColor);
+			armyTextlabel->SetTextShadow(true);
+			armyTextlabel->SetTextShadowColor(fgColor); /// @todo bgColor?
+		}
+		else
+		{
+			armyTextlabel->SetText("");
+		}
+		armyTextlabel->ShouldDraw(true);
+	}
+
 	updating = false;
 }
 

--- a/ctp2_data/default/uidata/layouts/armymanager.ldl
+++ b/ctp2_data/default/uidata/layouts/armymanager.ldl
@@ -77,6 +77,14 @@ ArmyManager:CTP2_DIALOG_WINDOW {
 
 		bool mouseblind true
 	}
+	ArmyTextLabel:CTP2_STATIC_BASE:AM_TEXT_FONT {
+		int xpix      250
+		int ypix      280
+		string text   ""
+		string just   "left"
+		int	widthpix  97
+		int	heightpix 24
+	}
 	ArmyName:CTP2_TEXT_FIELD {
 		int xpix      252
 		int ypix      53


### PR DESCRIPTION
Fix two regressions:

The army manager used to have a text field for the order the AI gave to the army when that debugging option is on. There is might be better visible than on the terrain.

The next unit button shows again the other units. It was not obvious that you get there by clicking onto the shield icon. It just does not look like a clickable button.