### PR TITLE
Flatpak Build support

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,22 @@ The executables these configurations generate are in [your source path]/ctp2_cod
 
 CTP2 can directly be run from Visual Studio, to do so press F5 if you want to run it on the debugger, which will be slow and does not make sense for a Final version. To run without debugging, press Ctrl F5. If necessary, CTP2 will be built, first. Some of the map plugins may fail to build the first time in a clean project. Just try compile those again.
 
-## Building on Linux
+## Building on Linux...
+
+**Using flatpak**
+
+Flatpak should streamline the process, as the libraries are managed by the manifest, and the commands are the same on all distros.
+
+To rehearse:
+
+1. Clone this repository and unzip it
+2. Paste the CD/GoG game data over the unziped directory, _without replacing_ the downloaded repo files
+3. Run `flatpak install org.flatpak.Builder org.freedesktop.Sdk/x86_64/24.08 org.freedesktop.Platform/x86_64/23.08` to satisfy the dependencies.
+4. Run `flatpak run org.flatpak.Builder --install --user --force-clean "build/" "net.apolyton.civctp2.yaml"`. This will take a while to compile everything.
+5. Finally, `flatpak run net.apolyton.civctp2` will run the game!
+
+
+**Using the autogen as-is**
 
 You will probably need GCC 5.x or later to build. The code doesn't seem to build on GCC 4.8.
 

--- a/net.apolyton.civctp2.yaml
+++ b/net.apolyton.civctp2.yaml
@@ -1,0 +1,73 @@
+app-id: net.apolyton.civctp2
+runtime: org.freedesktop.Platform
+runtime-version: '23.08'
+sdk: org.freedesktop.Sdk
+command: run-ctp
+finish-args:
+  - --share=ipc
+  - --socket=wayland
+  - --socket=fallback-x11
+  - --socket=pulseaudio
+  - --share=network
+
+modules:
+  - name: byacc
+    buildsystem: autotools
+    config-opts:
+      - --prefix=/app
+    sources:
+      - type: git
+        url: https://github.com/grandseiken/byacc.git
+    build-commands:
+      - ./configure --prefix=/app
+      - make
+      - make install
+      - mv /app/bin/yacc /app/bin/byacc
+    build-options:
+        env:
+            PATH: /app/bin:/usr/bin:/bin
+  - name: flex
+    buildsystem: autotools
+    sources:
+      - type: archive
+        url: https://github.com/westes/flex/releases/download/v2.6.4/flex-2.6.4.tar.gz
+        sha256: e87aae032bf07c26f85ac0ed3250998c37621d95f8bd748b31f15b33c45ee995
+    build-commands:
+      - ./configure --prefix=/app
+      - make
+      - make install
+  - name: civctp2
+    buildsystem: autotools
+    sources:
+      - type: dir
+        path: ./
+    build-options:
+      cflags: "-O3 -fuse-ld=gold"
+      cxxflags: "-fpermissive -O3 -fuse-ld=gold"
+    config-opts:
+      - --enable-silent-rules
+  - name: game-data
+    buildsystem: simple
+    sources:
+      - type: dir
+        path: ./
+    build-commands:
+      - echo "Running additional setup..."
+      - echo "Copying game data to app"
+      # Copy game data to app
+      - mkdir /app/game && cp -r ctp2_code ctp2_data ctp2_program help Scenarios Advance-Graph ModTools /app/game/
+      # Copy music and saves to game directory
+      - cp -r build/files/game/ctp2_program/ctp/music build/files/game/ctp2_code/ctp/
+      - cp -r build/files/game/ctp2_program/ctp/save build/files/game/ctp2_code/ctp/
+
+      # Copy executable to game directory
+      - cp /app/bin/ctp2 /app/game/ctp2_code/ctp/
+      # Copy missing libraries
+      - mkdir /app/game/ctp2_code/ctp/dll/map/ && cp /app/lib/ctp2/*.so /app/game/ctp2_code/ctp/dll/map/
+  - name: runner
+    buildsystem: simple
+    build-commands:
+      - install -Dm755 flatpak-runner.sh /app/bin/run-ctp
+    sources:
+      - type: file
+        path: tools/flatpak-runner.sh

--- a/tools/flatpak-runner.sh
+++ b/tools/flatpak-runner.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+cd /app/game/ctp2_code/ctp/
+./ctp2
+

--- a/tools/flatpak-runner.sh
+++ b/tools/flatpak-runner.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 cd /app/game/ctp2_code/ctp/
-./ctp2
+./ctp2 -fullscreen
 


### PR DESCRIPTION
This PR adds a flatpak manifest and runner script,  and instructions to build the game using flatpak. This should allow to streamline the building process across Linux distributions and avoid a mismatch between libraries. 