### PR TITLE
Compensate for SDL 2.x bug and prevent a double free

### DIFF
--- a/ctp2_code/sound/civsound.cpp
+++ b/ctp2_code/sound/civsound.cpp
@@ -77,14 +77,13 @@ CivSound::CivSound(const uint32 &associatedObject, const sint32 &soundID)
     if (!fname) {
         return;
     }
-#if defined(USE_SDL)
+
 	// "NULL.WAV" contains no audio data, and with this file SDL 2.x
 	// returns a pointer that it has already freed, which it later
 	// tries to free again in Mix_FreeChunk.
 	if (strcasecmp(fname, "NULL.WAV") == 0) {
 		return;
 	}
-#endif
 
     size_t      l_dataSize = 0;
     m_dataptr   = g_SoundPF->getData(fname, l_dataSize);

--- a/ctp2_code/sound/civsound.cpp
+++ b/ctp2_code/sound/civsound.cpp
@@ -59,6 +59,11 @@ CivSound::CivSound(const uint32 &associatedObject, const sint32 &soundID)
     m_associatedObject(associatedObject)
 
 {
+	// Initialize fields in case of early return.
+	m_soundFilename[0] = 0;
+	m_dataptr = NULL;
+	m_datasize = 0;
+
     const char *fname;
 	if(soundID < 0)
 		fname = NULL;
@@ -70,9 +75,6 @@ CivSound::CivSound(const uint32 &associatedObject, const sint32 &soundID)
     m_isLooping = FALSE;
 
     if (!fname) {
-        m_soundFilename[0] = 0;
-        m_dataptr = NULL;
-        m_datasize = 0;
         return;
     }
 #if defined(USE_SDL)
@@ -80,18 +82,18 @@ CivSound::CivSound(const uint32 &associatedObject, const sint32 &soundID)
 	// returns a pointer that it has already freed, which it later
 	// tries to free again in Mix_FreeChunk.
 	if (strcasecmp(fname, "NULL.WAV") == 0) {
-		m_soundFilename[0] = 0;
-		m_dataptr = NULL;
-		m_datasize = 0;
 		return;
 	}
 #endif
 
-    strcpy(m_soundFilename, fname);
-
     size_t      l_dataSize = 0;
-    m_dataptr   = g_SoundPF->getData(m_soundFilename, l_dataSize);
-    m_datasize  = static_cast<sint32>(l_dataSize);
+    m_dataptr   = g_SoundPF->getData(fname, l_dataSize);
+	if (!m_dataptr) {
+		return;
+	}
+
+    strcpy(m_soundFilename, fname);
+    m_datasize = static_cast<sint32>(l_dataSize);
 
 #if !defined(USE_SDL)
 	m_hAudio = AIL_quick_load_mem(m_dataptr, m_datasize);

--- a/ctp2_code/sound/civsound.cpp
+++ b/ctp2_code/sound/civsound.cpp
@@ -87,7 +87,14 @@ CivSound::CivSound(const uint32 &associatedObject, const sint32 &soundID)
     // Argh, audio format mismatch!!!
 	m_Audio = Mix_QuickLoad_RAW((Uint8 *) m_dataptr, (Uint32) m_datasize);
 # else
-    m_Audio = Mix_LoadWAV_RW(SDL_RWFromMem(m_dataptr, static_cast<int>(m_datasize)), 1);
+	m_Audio = Mix_LoadWAV_RW(SDL_RWFromMem(m_dataptr, static_cast<int>(m_datasize)), 1);
+	// Compensate for possible SDL bug: if alen=0, then abuf may have been freed by
+	// realloc inside SDL. Since the behavior of realloc(ptr, 0) is implementation
+	// dependent, conservatively assume that realloc has freed the memory, and set abuf
+	// to NULL to prevent it from being freed again by SDL's Mix_FreeChunk.
+	if (!m_Audio->alen) {
+		m_Audio->abuf = NULL;
+	}
 # endif
 #endif
 }

--- a/ctp2_code/sound/civsound.cpp
+++ b/ctp2_code/sound/civsound.cpp
@@ -36,8 +36,6 @@
 //
 //----------------------------------------------------------------------------
 
-#include <strings.h>
-
 #include "c3.h"
 
 #include "civsound.h"
@@ -78,10 +76,13 @@ CivSound::CivSound(const uint32 &associatedObject, const sint32 &soundID)
         return;
     }
 
-	// "NULL.WAV" contains no audio data, and with this file SDL 2.x
-	// returns a pointer that it has already freed, which it later
-	// tries to free again in Mix_FreeChunk.
-	if (strcasecmp(fname, "NULL.WAV") == 0) {
+	// "NULL.WAV" contains no audio data, and for this file SDL 2.x
+	// returns a pointer that it has already freed. It later tries to
+	// free it again in Mix_FreeChunk.
+	// The file is located inside an archive, and archive look-up is
+	// case-insensitive, however "NULL.WAV" is what appears in the
+	// sound configuration files, so that is what we check here.
+	if (strcmp(fname, "NULL.WAV") == 0) {
 		return;
 	}
 

--- a/ctp2_code/sound/civsound.cpp
+++ b/ctp2_code/sound/civsound.cpp
@@ -36,6 +36,8 @@
 //
 //----------------------------------------------------------------------------
 
+#include <strings.h>
+
 #include "c3.h"
 
 #include "civsound.h"
@@ -59,7 +61,7 @@ CivSound::CivSound(const uint32 &associatedObject, const sint32 &soundID)
 {
     const char *fname;
 	if(soundID < 0)
-		fname = 0;
+		fname = NULL;
 	else
 		fname = g_theSoundDB->Get(soundID)->GetValue();
 
@@ -67,12 +69,23 @@ CivSound::CivSound(const uint32 &associatedObject, const sint32 &soundID)
     m_isPlaying = FALSE;
     m_isLooping = FALSE;
 
-    if (0 == fname) {
+    if (!fname) {
         m_soundFilename[0] = 0;
         m_dataptr = NULL;
         m_datasize = 0;
         return;
     }
+#if defined(USE_SDL)
+	// "NULL.WAV" contains no audio data, and with this file SDL 2.x
+	// returns a pointer that it has already freed, which it later
+	// tries to free again in Mix_FreeChunk.
+	if (strcasecmp(fname, "NULL.WAV") == 0) {
+		m_soundFilename[0] = 0;
+		m_dataptr = NULL;
+		m_datasize = 0;
+		return;
+	}
+#endif
 
     strcpy(m_soundFilename, fname);
 
@@ -88,13 +101,8 @@ CivSound::CivSound(const uint32 &associatedObject, const sint32 &soundID)
 	m_Audio = Mix_QuickLoad_RAW((Uint8 *) m_dataptr, (Uint32) m_datasize);
 # else
 	m_Audio = Mix_LoadWAV_RW(SDL_RWFromMem(m_dataptr, static_cast<int>(m_datasize)), 1);
-	// Compensate for possible SDL bug: if alen=0, then abuf may have been freed by
-	// realloc inside SDL. Since the behavior of realloc(ptr, 0) is implementation
-	// dependent, conservatively assume that realloc has freed the memory, and set abuf
-	// to NULL to prevent it from being freed again by SDL's Mix_FreeChunk.
-	if (!m_Audio->alen) {
-		m_Audio->abuf = NULL;
-	}
+	// If alen=0, then abuf may have been freed by realloc inside SDL 2.x.
+	Assert(m_Audio->alen);
 # endif
 #endif
 }


### PR DESCRIPTION
The `CivSound` constructor has SDL load an audio file into an SDL `Mix_Chunk`. After loading the audio data, SDL 2.8.2 resizes the chunk buffer with `realloc()`. If the audio content is zero length, then `realloc(ptr, 0)` may be equivalent to `free(ptr)`. As a result, the `Mix_Chunk` returned to `CivSound` has 0 in the `alen` field and a pointer to free memory in the `abuf` field. Later, the freed pointer is incorrectly freed again by SDL's `Mix_FreeChunk`.

To prevent SDL from freeing twice, this commit sets `abuf` to `NULL` when `alen = 0`.

The behavior of `realloc(ptr, 0)` is implementation dependent. `realloc(ptr, 0)` may be implemented to return a valid pointer, in which case this commit will result in a memory leak; or, it may return `NULL` and _not_ free `ptr`. While we can distinguish between some of these behaviors in the configure script, determining SDL's behavior is challenging. Setting `abuf` to NULL is the conservative approach: a memory leak is better than a double free.