### PR TITLE
Fix implicit function decl warnings in yacc code

### DIFF
--- a/ctp2_code/gs/slic/slic.y
+++ b/ctp2_code/gs/slic/slic.y
@@ -64,6 +64,9 @@
 #ifdef _MSC_VER
 #pragma warning( disable : 4013 )
 #endif
+#ifdef __GNUC__
+#pragma GCC diagnostic ignored "-Wimplicit-function-declaration"
+#endif
 #define lint
 
 void yyerror(const char* err);

--- a/ctp2_code/gs/slic/sliccmd.y
+++ b/ctp2_code/gs/slic/sliccmd.y
@@ -42,9 +42,12 @@
 #include "slicif.h"
 #include <math.h>
 
-#if defined(_MSC_VER)
 /* Avoid silly warnings */
+#if defined(_MSC_VER)
 #pragma warning( disable : 4013 )
+#endif
+#if defined(__GNUC__)
+#pragma GCC diagnostic ignored "-Wimplicit-function-declaration"
 #endif
 
 #define lint

--- a/ctp2_code/ui/ldl/ldl.y
+++ b/ctp2_code/ui/ldl/ldl.y
@@ -10,6 +10,9 @@
 #ifdef _MSC_VER
 #pragma warning( disable : 4013 )
 #endif
+#ifdef __GNUC__
+#pragma GCC diagnostic ignored "-Wimplicit-function-declaration"
+#endif
 #define lint
 
 void yyerror(const char* err);


### PR DESCRIPTION
lex and yacc do not declare all of their external functions, and this wasn't a problem with old C compilers. Modern compilers are pickier.

The implicit function warning was disabled for the MS compiler in the relevant files; however, gcc considers this an error. This commit disables the error for gcc.