### PR TITLE
Fix scheduler/pathfinding thrashing and stuck-flag bugs found via /rnd stress-testing and chasing asserts

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,8 @@ CFLAGS="$CFLAGS -O0 -fuse-ld=gold" CXXFLAGS="$CXXFLAGS -O0 -fuse-ld=gold" ./conf
 make -j$(nproc)
 ```
 
+Movie playback (e.g. the intro movie) requires passing `--enable-ffmpeg4movies` to `configure`, in addition to having the ffmpeg libraries installed - it is off by default because the FFmpeg API still changes a lot. Without it, the game builds and runs fine, it just won't play any movies.
+
 If you want to build a debug version it is:
 
 ```

--- a/ctp2_code/ai/ctpai.cpp
+++ b/ctp2_code/ai/ctpai.cpp
@@ -2196,21 +2196,21 @@ void CtpAi::ExecuteOpportunityActions(const PLAYER_INDEX player)
 		if (army->NumOrders() > 0)
 			continue;
 
-	//	if(army.CanEntrench())
-	//	{
+		if(army.CanEntrench())
+		{
 			// We need to find something more interesting to do here
 			g_gevManager->AddEvent( GEV_INSERT_AfterCurrent,
 									GEV_EntrenchOrder,
 									GEA_Army, army.m_id,
 									GEA_End);
-	/*	}
-		else
-		{
-			g_gevManager->AddEvent( GEV_INSERT_AfterCurrent,
-									GEV_SleepOrder,
-									GEA_Army, army.m_id,
-									GEA_End);
-		}*/
+		}
+		// No sleep fallback here: this function only ever runs for robot
+		// players (see the IsRobot() check above), and sleeping is purely
+		// a human-UI convenience (skip this unit in the "next unmoved
+		// unit" cycle) that also hides the unit on the map. The scheduler
+		// re-evaluates every army's goals every turn regardless of sleep
+		// state, so it buys the AI nothing - just leave a non-entrenching
+		// idle army without a new order.
 	}
 
 	CtpAi::SpendGoldToRushBuy(player);

--- a/ctp2_code/ai/ctpai.cpp
+++ b/ctp2_code/ai/ctpai.cpp
@@ -1059,6 +1059,18 @@ void CtpAi::RemovePlayer(const PLAYER_INDEX deadPlayerId)
 	}
 
 	AgreementMatrix::s_agreements.ClearAgreementsInvolving(deadPlayerId);
+
+	// The agreement-matrix clear above can change what ComputeDesireWarWith
+	// returns for deadPlayerId; refresh every survivor's cached entry so it
+	// isn't left stale for whoever reuses this player slot next.
+	for (PLAYER_INDEX player = 0; player < s_maxPlayers; ++player)
+	{
+		if (g_player[player] && (player != deadPlayerId))
+		{
+			Diplomat::GetDiplomat(player).UpdateDesireWarWith(deadPlayerId);
+		}
+	}
+
 	Diplomat::GetDiplomat(deadPlayerId).Cleanup();
 
 	if (deadPlayerId + 1 >= s_maxPlayers)
@@ -1098,8 +1110,21 @@ void CtpAi::AddPlayer(const PLAYER_INDEX newPlayerId)
 			// Also true for embassies
 			g_player[player]->ContactKilled(newPlayerId);
 			g_player[player]->CloseEmbassy(newPlayerId);
+
+			// A reused player slot can leave a stale desire-war-with cache
+			// entry behind (from whoever previously occupied it, or the
+			// default from Resize()); refresh it now that newPlayerId is
+			// a real, initialized player.
+			if (player != newPlayerId)
+			{
+				Diplomat::GetDiplomat(player).UpdateDesireWarWith(newPlayerId);
+			}
 		}
 	}
+
+	// newPlayerId's own cache, for every foreigner, is equally stale after
+	// Initialize()/Resize() above - refresh it the same way BeginTurn() does.
+	Diplomat::GetDiplomat(newPlayerId).ComputeAllDesireWarWith();
 }
 
 void CtpAi::BeginMapAnalysis(const PLAYER_INDEX player)

--- a/ctp2_code/ai/ctpai.cpp
+++ b/ctp2_code/ai/ctpai.cpp
@@ -966,6 +966,15 @@ void CtpAi::Initialize(bool initDiplomat)
 	CtpAiDebug::SetDebugPlayer(1);
 	CtpAiDebug::SetDebugGoalType(-1); // GOAL_SIEGE = 1, all goals = -1
 	CtpAiDebug::SetDebugArmies(unit_list);
+
+	// Use this if you need to debug a single army in RobotAstar2
+	// or a city as starting pint for a trade route or road for
+	// TradeAstar or CityAstar.
+	// The ID you get for instance from Astar::FindPath, it will
+	// be in the log before the Assert there fires. Then just
+	// replace the ID here.
+//	CtpAiDebug::SetDebugArmy(0xd00020ed);
+
 #endif
 }
 

--- a/ctp2_code/ai/ctpai.cpp
+++ b/ctp2_code/ai/ctpai.cpp
@@ -531,6 +531,9 @@ STDEHANDLER(CtpAi_BeginSchedulerEvent)
 
 	sint32 round = g_player[playerId]->GetCurRound();
 
+	DPRINTF(k_DBG_SCHEDULER, ("DIAG: CtpAi_BeginSchedulerEvent(%d), curPlayer=%d\n",
+	                          playerId, g_selected_item->GetCurPlayer()));
+
 #ifdef _DEBUG
 	static bool s_allOk = true;
 	if(s_allOk)
@@ -1104,6 +1107,9 @@ void CtpAi::BeginMapAnalysis(const PLAYER_INDEX player)
 	if(s_maxPlayers <= 0)
 		return;
 
+	DPRINTF(k_DBG_SCHEDULER, ("DIAG: BeginMapAnalysis(%d), curPlayer=%d\n",
+	                          player, g_selected_item->GetCurPlayer()));
+
 	Assert(player < s_maxPlayers);
 	Assert(player == g_selected_item->GetCurPlayer());
 	Player * player_ptr = g_player[player];
@@ -1127,6 +1133,9 @@ void CtpAi::BeginTurn(const PLAYER_INDEX player)
 {
 	if(s_maxPlayers <= 0)
 		return;
+
+	DPRINTF(k_DBG_SCHEDULER, ("DIAG: BeginTurn(%d), curPlayer=%d\n",
+	                          player, g_selected_item->GetCurPlayer()));
 
 	Assert(player < s_maxPlayers);
 	Assert(player == g_selected_item->GetCurPlayer());

--- a/ctp2_code/ai/ctpai.cpp
+++ b/ctp2_code/ai/ctpai.cpp
@@ -531,7 +531,7 @@ STDEHANDLER(CtpAi_BeginSchedulerEvent)
 
 	sint32 round = g_player[playerId]->GetCurRound();
 
-	DPRINTF(k_DBG_SCHEDULER, ("DIAG: CtpAi_BeginSchedulerEvent(%d), curPlayer=%d\n",
+	DPRINTF(k_DBG_SCHEDULER, ("PLAYER_SYNC: CtpAi_BeginSchedulerEvent(%d), curPlayer=%d\n",
 	                          playerId, g_selected_item->GetCurPlayer()));
 
 #ifdef _DEBUG
@@ -1107,7 +1107,7 @@ void CtpAi::BeginMapAnalysis(const PLAYER_INDEX player)
 	if(s_maxPlayers <= 0)
 		return;
 
-	DPRINTF(k_DBG_SCHEDULER, ("DIAG: BeginMapAnalysis(%d), curPlayer=%d\n",
+	DPRINTF(k_DBG_SCHEDULER, ("PLAYER_SYNC: BeginMapAnalysis(%d), curPlayer=%d\n",
 	                          player, g_selected_item->GetCurPlayer()));
 
 	Assert(player < s_maxPlayers);
@@ -1134,7 +1134,7 @@ void CtpAi::BeginTurn(const PLAYER_INDEX player)
 	if(s_maxPlayers <= 0)
 		return;
 
-	DPRINTF(k_DBG_SCHEDULER, ("DIAG: BeginTurn(%d), curPlayer=%d\n",
+	DPRINTF(k_DBG_SCHEDULER, ("PLAYER_SYNC: BeginTurn(%d), curPlayer=%d\n",
 	                          player, g_selected_item->GetCurPlayer()));
 
 	Assert(player < s_maxPlayers);

--- a/ctp2_code/ai/ctpaidebug.cpp
+++ b/ctp2_code/ai/ctpaidebug.cpp
@@ -110,4 +110,18 @@ void CtpAiDebug::SetDebugArmies(const CellUnitList & unit_list)
 	}
 }
 
+void CtpAiDebug::SetDebugArmy(const sint32 & armyID)
+{
+	// Add the army ID to the first slot
+	s_debugArmies[0] = armyID;
+	// Set the other slots to invalid
+	for (sint32 i = 1; i < k_MAX_ARMY_SIZE; i++)
+	{
+		s_debugArmies[i] = -1;
+	}
+	DPRINTF(k_DBG_FIX,
+	    ("Set army 0x%x as debug army 0x%x\n",
+	     armyID, s_debugArmies[0]));
+}
+
 #endif // _DEBUG

--- a/ctp2_code/ai/ctpaidebug.h
+++ b/ctp2_code/ai/ctpaidebug.h
@@ -32,7 +32,7 @@
 //
 // Modifications from the original Activision code:
 //
-// - USE_LOGGING now works in a final version. (30-Jun-2008 Martin Gühmann)
+// - USE_LOGGING now works in a final version. (30-Jun-2008 Martin Gï¿½hmann)
 //
 //----------------------------------------------------------------------------
 #ifdef HAVE_PRAGMA_ONCE
@@ -66,6 +66,7 @@ public:
 	static void SetDebugGoalType(const sint32 goal_type);
 
 	static void SetDebugArmies(const CellUnitList & unit_list);
+	static void SetDebugArmy(const sint32 & armyID);
 
 private:
 

--- a/ctp2_code/ai/diplomacy/diplomat.cpp
+++ b/ctp2_code/ai/diplomacy/diplomat.cpp
@@ -2873,7 +2873,7 @@ void Diplomat::ContinueDiplomacy(const PLAYER_INDEX & foreignerId) {
 			if(!g_network.IsActive() ||
 			   (g_network.IsHost() && g_network.IsLocalPlayer(m_playerId)))
 			{
-				DPRINTF(k_DBG_SCHEDULER, ("DIAG: ContinueDiplomacy(%d) with foreigner %d concluding, curPlayer=%d\n",
+				DPRINTF(k_DBG_SCHEDULER, ("PLAYER_SYNC: ContinueDiplomacy(%d) with foreigner %d concluding, curPlayer=%d\n",
 				                          m_playerId, foreignerId, g_selected_item->GetCurPlayer()));
 				g_director->AddBeginScheduler(m_playerId);
 			}

--- a/ctp2_code/ai/diplomacy/diplomat.cpp
+++ b/ctp2_code/ai/diplomacy/diplomat.cpp
@@ -2873,6 +2873,8 @@ void Diplomat::ContinueDiplomacy(const PLAYER_INDEX & foreignerId) {
 			if(!g_network.IsActive() ||
 			   (g_network.IsHost() && g_network.IsLocalPlayer(m_playerId)))
 			{
+				DPRINTF(k_DBG_SCHEDULER, ("DIAG: ContinueDiplomacy(%d) with foreigner %d concluding, curPlayer=%d\n",
+				                          m_playerId, foreignerId, g_selected_item->GetCurPlayer()));
 				g_director->AddBeginScheduler(m_playerId);
 			}
 		}

--- a/ctp2_code/ai/strategy/agents/agent.cpp
+++ b/ctp2_code/ai/strategy/agents/agent.cpp
@@ -275,7 +275,7 @@ void Agent::Log_Debug_Info(const int & log, const Goal * const goal) const
 	            g_theUnitDB->GetNameStr(m_army->Get(0).GetType()),
 	            m_army->Num(),
 	            m_army->GetCargoNum(),
-	            (g_theWorld->HasCity(pos) ? g_theWorld->GetCity(pos).GetName() : "field")
+	            Goal::GetTargetName(pos)
 	           )
 	          );
 
@@ -678,7 +678,7 @@ void Agent::Group_With( Agent_ptr second_army )
 
 	MapPoint dest_pos = m_goal->Get_Target_Pos();
 
-	sprintf(myString, "Grouping at (%d,%d) to %s %s (%d,%d)", pos.x, pos.y, goalString, (g_theWorld->HasCity(m_goal->Get_Target_Pos()) ? g_theWorld->GetCity(m_goal->Get_Target_Pos()).GetName() : "field"), dest_pos.x, dest_pos.y);
+	sprintf(myString, "Grouping at (%d,%d) to %s %s (%d,%d)", pos.x, pos.y, goalString, m_goal->GetTargetName(), dest_pos.x, dest_pos.y);
 	g_graphicsOptions->AddTextToArmy(m_army, myString, 220, m_goal->Get_Goal_Type());
 
 	delete[] goalString;
@@ -916,7 +916,7 @@ void Agent::WaitHere(const MapPoint & goal_pos)
 		MapPoint pos;
 		m_army->GetPos(pos);
 		MBCHAR * myString = new MBCHAR[255];
-		sprintf(myString, "Waiting GROUP @ (%d,%d) to %s GO (%d,%d)", pos.x, pos.y, (g_theWorld->HasCity(Get_Target_Pos()) ? g_theWorld->GetCity(Get_Target_Pos()).GetName() : "field"), goal_pos.x, goal_pos.y);
+		sprintf(myString, "Waiting GROUP @ (%d,%d) to %s GO (%d,%d)", pos.x, pos.y, Goal::GetTargetName(Get_Target_Pos()), goal_pos.x, goal_pos.y);
 		g_graphicsOptions->AddTextToArmy(m_army, myString, 220, Get_Goal_Type());
 		delete[] myString;
 	}

--- a/ctp2_code/ai/strategy/agents/agent.cpp
+++ b/ctp2_code/ai/strategy/agents/agent.cpp
@@ -283,7 +283,7 @@ void Agent::Log_Debug_Info(const int & log, const Goal * const goal) const
 		("\t\t   -------\n"));
 }
 
-bool Agent::FindPathToBoard(const uint32 & move_intersection, const MapPoint & dest_pos, const bool & check_dest, Path & found_path, sint32 additionalUnits)
+bool Agent::FindPathForTransportTasks(const uint32 & move_intersection, const MapPoint & dest_pos, const bool & check_dest, Path & found_path, sint32 additionalUnits)
 {
 	MapPoint start_pos;
 	m_army->GetPos(start_pos);

--- a/ctp2_code/ai/strategy/agents/agent.h
+++ b/ctp2_code/ai/strategy/agents/agent.h
@@ -123,7 +123,36 @@ public:
 
 	bool CanMove() const { return m_army.IsValid() && m_army->CanMove(); };
 
-	bool FindPathToBoard( const uint32 & move_intersection, const MapPoint & dest_pos, const bool & check_dest, Path & found_path, sint32 additionalUnits = 0);
+	// Shared A* solver (PATH_TYPE_TRANSPORT) behind all transport-related
+	// task pathfinding below - it doesn't itself know or care whether the
+	// mover is empty, being picked up, or already loaded.
+	bool FindPathForTransportTasks( const uint32 & move_intersection, const MapPoint & dest_pos, const bool & check_dest, Path & found_path, sint32 additionalUnits = 0);
+
+	// The three wrappers below exist purely so each call site gets a name
+	// that actually describes what it's doing there, since the three
+	// scenarios that need this pathing are conceptually different even
+	// though they share the same underlying solver.
+
+	// An empty transport moving to rendezvous with cargo waiting to be
+	// picked up (SUB_TASK_TRANSPORT_TO_BOARD).
+	bool FindPathToPickUpCargo( const uint32 & move_intersection, const MapPoint & dest_pos, const bool & check_dest, Path & found_path, sint32 additionalUnits = 0)
+	{
+		return FindPathForTransportTasks(move_intersection, dest_pos, check_dest, found_path, additionalUnits);
+	}
+
+	// A land army moving to rendezvous with a transport in order to board
+	// it (SUB_TASK_CARGO_TO_BOARD).
+	bool FindPathToBoard( const uint32 & move_intersection, const MapPoint & dest_pos, const bool & check_dest, Path & found_path)
+	{
+		return FindPathForTransportTasks(move_intersection, dest_pos, check_dest, found_path);
+	}
+
+	// An already-loaded transport moving toward its actual destination,
+	// cargo staying aboard the whole way (SUB_TASK_TRANSPORT_TO_GOAL).
+	bool FindPathToGoalWhileLoaded( const uint32 & move_intersection, const MapPoint & dest_pos, const bool & check_dest, Path & found_path)
+	{
+		return FindPathForTransportTasks(move_intersection, dest_pos, check_dest, found_path);
+	}
 
 	static bool FindPath(const Army & army, const MapPoint & target_pos, const bool & check_dest, Path & found_path );
 	static bool FindPath(const Army & army, const MapPoint & target_pos, const bool & check_dest, Path & found_path, float & total_cost);

--- a/ctp2_code/ai/strategy/goals/Goal.cpp
+++ b/ctp2_code/ai/strategy/goals/Goal.cpp
@@ -142,6 +142,11 @@ const Utility Goal::MAX_UTILITY =  99999999;
 #include "gstypes.h"
 #include "gfx_options.h"
 #include "World.h"
+#include "SelItem.h"
+#include "MessageBoxDialog.h"
+#include "GameEventManager.h"
+#include "tiledmap.h"
+#include "director.h"
 
 #include "ctpaidebug.h"
 
@@ -4154,16 +4159,59 @@ bool Goal::GotoTransportTaskSolution(Agent_ptr the_army, Agent_ptr the_transport
 #if defined(_DEBUG)
 namespace
 {
-	// "Inspect" (left button, response == true): stay paused so the
-	// selected army/player can be looked at freely.
-	// "Continue" (right button, response == false): resume event
-	// processing immediately.
-	void GotoGoalTaskSolution_InspectOrContinue(bool response, Cookie)
+	struct GotoGoalTaskSolution_InspectContext
 	{
-		if (!response)
+		GotoGoalTaskSolution_InspectContext(PLAYER_INDEX p, const Army & a)
+		: playerId(p), army(a) {}
+
+		PLAYER_INDEX playerId;
+		Army army;
+	};
+
+	// Processing is halted the instant the failure is detected (before the
+	// message box even appears) - otherwise the game keeps running while
+	// the box sits unanswered, and by the time a choice is made the
+	// moment being inspected has already passed.
+	//
+	// "Inspect" (left button, response == true): bring the affected
+	// player on screen (they stay a robot - this only changes who is
+	// shown, not who is in control), select the stuck army, and center
+	// the map on it, so it can be looked at freely. Stays paused.
+	// "Continue" (right button, response == false): resume immediately,
+	// no screen changes.
+	void GotoGoalTaskSolution_InspectOrContinue(bool response, Cookie userData)
+	{
+		GotoGoalTaskSolution_InspectContext * context =
+		    static_cast<GotoGoalTaskSolution_InspectContext *>(userData.m_voidPtr);
+
+		if (response)
+		{
+			sint32 const oldVisiblePlayer = g_selected_item->GetVisiblePlayer();
+			g_selected_item->SetPlayerOnScreen(context->playerId);
+			if (oldVisiblePlayer != g_selected_item->GetVisiblePlayer())
+			{
+				// SetPlayerOnScreen only updates game-logic state (who's
+				// selected, UI panels); the renderer's cached vision
+				// pointer is separate and needs this to actually redraw
+				// the new player's tiles/units/cities instead of the old
+				// player's.
+				g_tiledMap->CopyVision();
+			}
+			g_selected_item->ForceDirectorSelect(context->army);
+
+			// Other ForceDirectorSelect callers piggyback on a unit-selection
+			// action that's already about to run as part of normal turn
+			// processing. There isn't one here, so queue it ourselves.
+			g_director->AddSelectUnit(0);
+
+			g_director->AddCenterMap(context->army->RetPos());
+		}
+		else
 		{
 			g_gevManager->GotUserInput();
 		}
+
+		delete context;
 	}
 }
 #endif
@@ -4261,6 +4309,26 @@ bool Goal::GotoGoalTaskSolution(Agent_ptr the_army, MapPoint & goal_pos)
 		}
 
 		Assert(found); // Problem
+
+#if defined(_DEBUG)
+		if (!found)
+		{
+			// Halt immediately so the game doesn't keep running out from
+			// under the message box while it sits unanswered. Screen
+			// switch/selection/centering stay deferred to "Inspect"; see
+			// GotoGoalTaskSolution_InspectOrContinue.
+			g_gevManager->SetNeedUserInput();
+			MessageBoxDialog::Query
+			(
+			    "GotoGoalTaskSolution: FindPathToGoalWhileLoaded failed - see log for details.",
+			    "GotoGoalTaskSolutionFindPathToGoalWhileLoadedFailed",
+			    &GotoGoalTaskSolution_InspectOrContinue,
+			    new GotoGoalTaskSolution_InspectContext(m_playerId, the_army->Get_Army()),
+			    "str_ldl_MB_Inspect",
+			    "str_ldl_MB_Continue"
+			);
+		}
+#endif
 
 		if (found)
 		{

--- a/ctp2_code/ai/strategy/goals/Goal.cpp
+++ b/ctp2_code/ai/strategy/goals/Goal.cpp
@@ -4213,10 +4213,10 @@ bool Goal::GotoGoalTaskSolution(Agent_ptr the_army, MapPoint & goal_pos)
 		// Check if is single squad
 		// Return true if we are a transporter and we need transporters
 		// SUB_TASK_TRANSPORT_TO_GOAL
-		uint32 move_intersection =
+		uint32 move_union =
 		        the_army->Get_Army()->GetMovementType() | the_army->Get_Army()->GetCargoMovementType();
 
-		found = the_army->FindPathToBoard(move_intersection, goal_pos, false, found_path);
+		found = the_army->FindPathToBoard(move_union, goal_pos, false, found_path);
 
 		Assert(found); // Problem
 

--- a/ctp2_code/ai/strategy/goals/Goal.cpp
+++ b/ctp2_code/ai/strategy/goals/Goal.cpp
@@ -4025,6 +4025,25 @@ bool Goal::GotoTransportTaskSolution(Agent_ptr the_army, Agent_ptr the_transport
 				pos = dest_pos;
 			}
 
+			const GoalRecord *goal_rec = g_theGoalDB->Get(m_goal_type);
+			Utility val = Compute_Agent_Matching_Value(the_transport);
+			uint8 magnitude = (uint8) (((5000000 - val)* 255.0) / 5000000);
+			const char * myText = goal_rec->GetNameText();
+			MBCHAR * myString   = new MBCHAR[strlen(myText) + 80];
+			MBCHAR * goalString = new MBCHAR[strlen(myText) + 40];
+			memset(goalString, 0, strlen(myText) + 40);
+			memset(myString,   0, strlen(myText) + 80);
+
+			for (uint8 myComp = 0; myComp < strlen(myText) - 5; myComp++)
+			{
+				goalString[myComp] = myText[myComp + 5];
+			}
+
+			sprintf(myString, "Boat waiting at (%d,%d) to board %s for %s", dest_pos.x, dest_pos.y, GetTargetName(), goalString);
+			g_graphicsOptions->AddTextToArmy(the_transport->Get_Army(), myString, magnitude, m_goal_type);
+			delete[] myString;
+			delete[] goalString;
+
 			the_transport->Set_Target_Pos(dest_pos);
 			the_transport->Set_Can_Be_Executed(false);
 			return true;
@@ -4041,11 +4060,27 @@ bool Goal::GotoTransportTaskSolution(Agent_ptr the_army, Agent_ptr the_transport
 			        ("GOAL %x (%d):GotoTransportTaskSolution:: No path found from army to destination (x=%d,y=%d) (SUB_TASK_TRANSPORT_TO_BOARD):\n",
 			        this, m_goal_type, dest_pos.x, dest_pos.y));
 			the_transport->Log_Debug_Info(k_DBG_SCHEDULER, this);
-			        uint8 magnitude = 220;
-			        MBCHAR * myString = new MBCHAR[256];
-			        sprintf(myString, "NO PATH -> BOARD (%d,%d)", dest_pos.x, dest_pos.y);
-			        g_graphicsOptions->AddTextToArmy(the_army->Get_Army(), myString, magnitude, m_goal_type);
-			        delete[] myString;
+
+			const GoalRecord *goal_rec = g_theGoalDB->Get(m_goal_type);
+			Utility val = Compute_Agent_Matching_Value(the_transport);
+			uint8 magnitude = (uint8) (((5000000 - val)* 255.0) / 5000000);
+			const char * myText = goal_rec->GetNameText();
+			MBCHAR * myString   = new MBCHAR[strlen(myText) + 80];
+			MBCHAR * goalString = new MBCHAR[strlen(myText) + 40];
+			memset(goalString, 0, strlen(myText) + 40);
+			memset(myString,   0, strlen(myText) + 80);
+
+			for (uint8 myComp = 0; myComp < strlen(myText) - 5; myComp++)
+			{
+				goalString[myComp] = myText[myComp + 5];
+			}
+
+			sprintf(myString, "NO PATH -> BOARD (%d,%d) %s for %s", dest_pos.x, dest_pos.y, GetTargetName(), goalString);
+			g_graphicsOptions->AddTextToArmy(the_army->Get_Army(), myString, magnitude, m_goal_type);
+
+			delete[] myString;
+			delete[] goalString;
+
 			Set_Cannot_Be_Used(the_transport, true);
 		}
 		else
@@ -4063,6 +4098,28 @@ bool Goal::GotoTransportTaskSolution(Agent_ptr the_army, Agent_ptr the_transport
 
 			if(found_path.GetMovesRemaining() == 0)
 			{
+				// FollowPathToTask above is skipped whenever there are no
+				// moves left to make, so this is the only place left to
+				// report that the transport is in position and waiting.
+				const GoalRecord *goal_rec = g_theGoalDB->Get(m_goal_type);
+				Utility val = Compute_Agent_Matching_Value(the_transport);
+				uint8 magnitude = (uint8) (((5000000 - val)* 255.0) / 5000000);
+				const char * myText = goal_rec->GetNameText();
+				MBCHAR * myString   = new MBCHAR[strlen(myText) + 80];
+				MBCHAR * goalString = new MBCHAR[strlen(myText) + 40];
+				memset(goalString, 0, strlen(myText) + 40);
+				memset(myString,   0, strlen(myText) + 80);
+
+				for (uint8 myComp = 0; myComp < strlen(myText) - 5; myComp++)
+				{
+					goalString[myComp] = myText[myComp + 5];
+				}
+
+				sprintf(myString, "Boat waiting at (%d,%d) to board %s for %s", pos.x, pos.y, GetTargetName(), goalString);
+				g_graphicsOptions->AddTextToArmy(the_transport->Get_Army(), myString, magnitude, m_goal_type);
+				delete[] myString;
+				delete[] goalString;
+
 				the_transport->Set_Can_Be_Executed(false);
 				the_transport->Set_Target_Pos(pos);
 			}

--- a/ctp2_code/ai/strategy/goals/Goal.cpp
+++ b/ctp2_code/ai/strategy/goals/Goal.cpp
@@ -4028,7 +4028,7 @@ bool Goal::GotoTransportTaskSolution(Agent_ptr the_army, Agent_ptr the_transport
 		uint32 move_intersection =
 			the_transport->Get_Army().GetMovementType() | the_army->Get_Army().GetMovementType();
 
-		found = the_transport->FindPathToBoard(move_intersection, dest_pos, check_dest, found_path, the_army->Get_Army()->Num());
+		found = the_transport->FindPathToPickUpCargo(move_intersection, dest_pos, check_dest, found_path, the_army->Get_Army()->Num());
 
 		if (!found)
 		{
@@ -4151,6 +4151,23 @@ bool Goal::GotoTransportTaskSolution(Agent_ptr the_army, Agent_ptr the_transport
 	return false;
 }
 
+#if defined(_DEBUG)
+namespace
+{
+	// "Inspect" (left button, response == true): stay paused so the
+	// selected army/player can be looked at freely.
+	// "Continue" (right button, response == false): resume event
+	// processing immediately.
+	void GotoGoalTaskSolution_InspectOrContinue(bool response, Cookie)
+	{
+		if (!response)
+		{
+			g_gevManager->GotUserInput();
+		}
+	}
+}
+#endif
+
 bool Goal::GotoGoalTaskSolution(Agent_ptr the_army, MapPoint & goal_pos)
 {
 	if(the_army->Get_Army()->CheckValidDestination(goal_pos)) // If we are already moving along a path
@@ -4215,7 +4232,7 @@ bool Goal::GotoGoalTaskSolution(Agent_ptr the_army, MapPoint & goal_pos)
 		uint32 move_union =
 		        the_army->Get_Army()->GetMovementType() | the_army->Get_Army()->GetCargoMovementType();
 
-		found = the_army->FindPathToBoard(move_union, goal_pos, false, found_path);
+		found = the_army->FindPathToGoalWhileLoaded(move_union, goal_pos, false, found_path);
 
 		if (!found)
 		{
@@ -4228,7 +4245,7 @@ bool Goal::GotoGoalTaskSolution(Agent_ptr the_army, MapPoint & goal_pos)
 			bool const targetHasAdjacentFreeLand =
 			    g_theWorld->HasAdjacentFreeLand(goal_pos, m_playerId);
 			DPRINTF(k_DBG_SCHEDULER,
-			        ("GOAL %x (%s): GotoGoalTaskSolution: FindPathToBoard failed for army 0x%lx, unit type %d (%s), from (x=%d,y=%d) to (x=%d,y=%d) - %s, %d units there, %s, %s, %s\n",
+			        ("GOAL %x (%s): GotoGoalTaskSolution: FindPathToGoalWhileLoaded failed for army 0x%lx, unit type %d (%s), from (x=%d,y=%d) to (x=%d,y=%d) - %s, %d units there, %s, %s, %s\n",
 			         this,
 			         g_theGoalDB->Get(m_goal_type)->GetNameText(),
 			         the_army->Get_Army().m_id,

--- a/ctp2_code/ai/strategy/goals/Goal.cpp
+++ b/ctp2_code/ai/strategy/goals/Goal.cpp
@@ -479,9 +479,8 @@ const Squad_Strength Goal::Get_Strength_Needed() const // Rename to missing stre
 	return needed_strength;
 }
 
-const char* Goal::GetTargetName() const
+const char* Goal::GetTargetName(const MapPoint & pos)
 {
-	MapPoint pos = Get_Target_Pos();
 	return g_theWorld->HasCity(pos) ? g_theWorld->GetCity(pos).GetName() : (pos.IsValid() ? "field" : "invalid");
 }
 
@@ -2194,7 +2193,7 @@ Utility Goal::Compute_Agent_Matching_Value(const Agent_ptr agent_ptr) const
 	tieBreaker,
 	g_theUnitDB->GetNameStr(agent_ptr->Get_Army()->Get(0).GetType()),
 	agent_ptr->Get_Army()->GetName(),
-	(g_theWorld->HasCity(curr_pos) ? g_theWorld->GetCity(curr_pos).GetName() : "field"),
+	Goal::GetTargetName(curr_pos),
 	GetTargetName()
 	));
 #endif //_DEBUG

--- a/ctp2_code/ai/strategy/goals/Goal.cpp
+++ b/ctp2_code/ai/strategy/goals/Goal.cpp
@@ -4220,15 +4220,27 @@ bool Goal::GotoGoalTaskSolution(Agent_ptr the_army, MapPoint & goal_pos)
 		if (!found)
 		{
 			const Unit & first_unit = the_army->Get_Army()->Get(0);
+			// Same "is land" definition HasAdjacentFreeLand uses.
+			bool const targetIsLand =
+			    g_theWorld->IsLand(goal_pos) || g_theWorld->IsMountain(goal_pos);
+			bool const targetIsNextToWater =
+			    g_theWorld->IsNextToWater(goal_pos.x, goal_pos.y);
+			bool const targetHasAdjacentFreeLand =
+			    g_theWorld->HasAdjacentFreeLand(goal_pos, m_playerId);
 			DPRINTF(k_DBG_SCHEDULER,
-			        ("GOAL %x: GotoGoalTaskSolution: FindPathToBoard failed for army 0x%lx, unit type %d (%s), from (x=%d,y=%d) to (x=%d,y=%d) - %s\n",
+			        ("GOAL %x (%s): GotoGoalTaskSolution: FindPathToBoard failed for army 0x%lx, unit type %d (%s), from (x=%d,y=%d) to (x=%d,y=%d) - %s, %d units there, %s, %s, %s\n",
 			         this,
+			         g_theGoalDB->Get(m_goal_type)->GetNameText(),
 			         the_army->Get_Army().m_id,
 			         first_unit.GetType(),
 			         g_theUnitDB->GetNameStr(first_unit.GetType()),
 			         the_army->Get_Pos().x, the_army->Get_Pos().y,
 			         goal_pos.x, goal_pos.y,
-			         GetTargetName()));
+			         GetTargetName(),
+			         g_theWorld->GetCell(goal_pos)->GetNumUnits(),
+			         targetIsLand ? "land" : "not land",
+			         targetIsNextToWater ? "next to water" : "not next to water",
+			         targetHasAdjacentFreeLand ? "has adjacent free land" : "has no adjacent free land"));
 		}
 
 		Assert(found); // Problem

--- a/ctp2_code/ai/strategy/goals/Goal.cpp
+++ b/ctp2_code/ai/strategy/goals/Goal.cpp
@@ -4218,6 +4218,20 @@ bool Goal::GotoGoalTaskSolution(Agent_ptr the_army, MapPoint & goal_pos)
 
 		found = the_army->FindPathToBoard(move_union, goal_pos, false, found_path);
 
+		if (!found)
+		{
+			const Unit & first_unit = the_army->Get_Army()->Get(0);
+			DPRINTF(k_DBG_SCHEDULER,
+			        ("GOAL %x: GotoGoalTaskSolution: FindPathToBoard failed for army 0x%lx, unit type %d (%s), from (x=%d,y=%d) to (x=%d,y=%d) - %s\n",
+			         this,
+			         the_army->Get_Army().m_id,
+			         first_unit.GetType(),
+			         g_theUnitDB->GetNameStr(first_unit.GetType()),
+			         the_army->Get_Pos().x, the_army->Get_Pos().y,
+			         goal_pos.x, goal_pos.y,
+			         GetTargetName()));
+		}
+
 		Assert(found); // Problem
 
 		if (found)

--- a/ctp2_code/ai/strategy/goals/Goal.h
+++ b/ctp2_code/ai/strategy/goals/Goal.h
@@ -152,7 +152,8 @@ public:
     Utility Get_Matching_Value() const;
     void    Set_Matching_Value(Utility combinedUtility);
     Utility Mark_For_Garrison(Plan_List & matches);
-    const char* GetTargetName() const;
+    const char* GetTargetName() const { return GetTargetName(Get_Target_Pos()); }
+    static const char* GetTargetName(const MapPoint & pos);
 
     bool Add_Match(const Agent_ptr & agent, const bool update_match_value = true, const bool needsCargo = false);
     bool Add_Transport_Match(const Agent_ptr & agent) { return Add_Match(agent, true, true); };

--- a/ctp2_code/ai/strategy/scheduler/scheduler.cpp
+++ b/ctp2_code/ai/strategy/scheduler/scheduler.cpp
@@ -663,7 +663,7 @@ void Scheduler::Match_Resources(const bool move_armies)
 		AI_DPRINTF(k_DBG_SCHEDULER, m_playerId, goal_ptr->Get_Goal_Type(), -1, ("\n"));
 		AI_DPRINTF(k_DBG_SCHEDULER, m_playerId, goal_ptr->Get_Goal_Type(), -1,
 				("[%d] Starting to match resources to %s: %x (x=%d,y=%d), match %d, %s\n",
-					count, g_theGoalDB->Get(goal_ptr->Get_Goal_Type())->GetNameText(), goal_ptr, pos.x, pos.y, oldMatchValue, (g_theWorld->HasCity(pos) ? g_theWorld->GetCity(pos).GetName() : "field")));
+					count, g_theGoalDB->Get(goal_ptr->Get_Goal_Type())->GetNameText(), goal_ptr, pos.x, pos.y, oldMatchValue, Goal::GetTargetName(pos)));
 		count++;
 #endif
 
@@ -2287,7 +2287,7 @@ void Scheduler::Assign_Garrison()
 		AI_DPRINTF(k_DBG_SCHEDULER, m_playerId, goal_ptr->Get_Goal_Type(), -1, ("\n"));
 		AI_DPRINTF(k_DBG_SCHEDULER, m_playerId, goal_ptr->Get_Goal_Type(), -1,
 			("[%d] Starting to match garrison resources with %s: %x (x=%d,y=%d), match %d, %s\n",
-				count, g_theGoalDB->Get(goal_ptr->Get_Goal_Type())->GetNameText(), goal_ptr, pos.x, pos.y, goal_ptr->Get_Matching_Value(), (g_theWorld->HasCity(pos) ? g_theWorld->GetCity(pos).GetName() : "field")));
+				count, g_theGoalDB->Get(goal_ptr->Get_Goal_Type())->GetNameText(), goal_ptr, pos.x, pos.y, goal_ptr->Get_Matching_Value(), Goal::GetTargetName(pos)));
 		count++;
 #endif
 		if (goal_ptr->Get_Matches_Num() > 0)

--- a/ctp2_code/ai/strategy/scheduler/scheduler.cpp
+++ b/ctp2_code/ai/strategy/scheduler/scheduler.cpp
@@ -628,6 +628,20 @@ void Scheduler::Sort_Goals()
 //     excess agents to donor agents.
 //
 //////////////////////////////////////////////////////////////////////////
+
+namespace
+{
+	// Re-matching recomputes every goal's value each cycle purely from
+	// which agents are still free, so two near-tied goals sharing the same
+	// one or two agents can otherwise evict each other's already-committed
+	// agent over noise-level score changes (observed: two
+	// GOAL_ESTABLISH_EMBASSY goals endlessly swapping the same two
+	// diplomats back and forth on <0.2% deltas, with neither unit ever
+	// actually moving). Require a decisive lead before a competing goal is
+	// allowed to bump an already-committed agent.
+	double const k_MatchValueReprioritizeMargin = 0.02;
+}
+
 void Scheduler::Match_Resources(const bool move_armies)
 {
 	bool out_of_transports = false; // this tells us if we have run out of available transports or not
@@ -710,7 +724,10 @@ void Scheduler::Match_Resources(const bool move_armies)
 			if(tmp_goal_iter != m_goals.end())
 			{
 				Utility nextMatchValue = static_cast<Goal_ptr>(*tmp_goal_iter)->Get_Matching_Value();
-				if(newMatchValue < nextMatchValue)
+				Utility const oldMatchValueAbs = (oldMatchValue < 0) ? -oldMatchValue : oldMatchValue;
+				Utility const margin =
+				    static_cast<Utility>(oldMatchValueAbs * k_MatchValueReprioritizeMargin);
+				if(newMatchValue < nextMatchValue - margin)
 				{
 					AI_DPRINTF(k_DBG_SCHEDULER, m_playerId, goal_ptr->Get_Goal_Type(), -1,
 					    ("\t\tGOAL (goal: %x)(agent count: %d) -- Match value change (old: %d, new: %d): Rollback agents and reprioritize goal.\n",

--- a/ctp2_code/ctp/civapp.cpp
+++ b/ctp2_code/ctp/civapp.cpp
@@ -2785,6 +2785,39 @@ void CivApp::AutoSave(sint32 player, bool isQuickSave)
 		strcat(fullpath, FILE_SEP);
 		strcat(fullpath, filename);
 
+		if (!isQuickSave && c3files_PathIsValid(fullpath))
+		{
+			// Keep the previous turn's autosave around as a debugging aid.
+			// Not needed for crashes (the previous autosave is still there
+			// at that point), but for issues that get merely logged (e.g.
+			// an Assert) while the turn completes normally: by the time
+			// they're noticed, the autosave has already moved past the
+			// state where they happened. Having the turn before still
+			// available lets that state be reproduced.
+			MBCHAR const *  previousAutosaveName =
+			    g_theStringDB->GetNameStr("AUTOSAVE_NAME_PREVIOUS");
+
+			MBCHAR			previousAutosaveNameBuf[_MAX_PATH];
+			if (!previousAutosaveName)
+			{
+				// GetNameStr(char const*) returns NULL, not a placeholder,
+				// when the key is missing (e.g. an incomplete mod locale) -
+				// fall back to appending "2" to the regular autosave name
+				// so the previous-turn backup still happens.
+				sprintf(previousAutosaveNameBuf, "%s2", autosaveName);
+				previousAutosaveName = previousAutosaveNameBuf;
+			}
+
+			MBCHAR			previousFilename[_MAX_PATH];
+			sprintf(previousFilename, "%s-%s", previousAutosaveName, leaderName);
+
+			MBCHAR			previousFullpath[_MAX_PATH];
+			sprintf(previousFullpath, "%s%s%s%s%s", path, FILE_SEP, leaderName, FILE_SEP, previousFilename);
+
+			remove(previousFullpath);
+			rename(fullpath, previousFullpath);
+		}
+
 		g_isScenario = FALSE;
 		GameFile().Save(fullpath, NULL);
 	}

--- a/ctp2_code/ctp/ctp2_utils/c3debug.h
+++ b/ctp2_code/ctp/ctp2_utils/c3debug.h
@@ -85,6 +85,7 @@ typedef void (* CivExceptionFunction) (void);
 #define k_DBG_SCHEDULER         0x00000400 // For the scheduler
 #define k_DBG_SCHEDULER_DETAIL  0x00000800 // For stuff from the scheduler that really fills up the logs.
 #define k_DBG_SCHEDULER_ALL     0x00000c00 // Get everything from the scheduler, combine the two above. Don't use for DPRINT, but the ones from above.
+#define k_DBG_SPECIAL_ACTION    0x00001000 // Diagnostics for army/unit special-action bookkeeping (e.g. k_UDF_USED_SPECIAL_ACTION_*). Not in the default mask; enable with "debugmask"/"dm".
 #define k_DBG_DIPLOMACY         0x00002000
 #define k_DBG_MAPANALYSIS       0x00004000
 #define k_DBG_ASTAR             0x00008000

--- a/ctp2_code/gfx/spritesys/director.cpp
+++ b/ctp2_code/gfx/spritesys/director.cpp
@@ -3087,7 +3087,7 @@ void DirectorImpl::AddBeginScheduler(sint32 player)
 {
 	if (player != g_selected_item->GetCurPlayer())
 	{
-		DPRINTF(k_DBG_SCHEDULER, ("DIAG: AddBeginScheduler(%d) deferred, curPlayer=%d\n",
+		DPRINTF(k_DBG_SCHEDULER, ("PLAYER_SYNC: AddBeginScheduler(%d) deferred, curPlayer=%d\n",
 		                          player, g_selected_item->GetCurPlayer()));
 
 		// A diplomacy negotiation (or other deferred event) can conclude
@@ -3113,7 +3113,7 @@ void DirectorImpl::FlushPendingBeginScheduler()
 	sint32 const player = g_selected_item->GetCurPlayer();
 	if (player >= 0 && player < k_MAX_PLAYERS && m_pendingBeginScheduler[player])
 	{
-		DPRINTF(k_DBG_SCHEDULER, ("DIAG: FlushPendingBeginScheduler firing deferred AddBeginScheduler(%d)\n", player));
+		DPRINTF(k_DBG_SCHEDULER, ("PLAYER_SYNC: FlushPendingBeginScheduler firing deferred AddBeginScheduler(%d)\n", player));
 		m_pendingBeginScheduler[player] = false;
 		AddBeginScheduler(player);
 	}

--- a/ctp2_code/gfx/spritesys/director.cpp
+++ b/ctp2_code/gfx/spritesys/director.cpp
@@ -700,6 +700,7 @@ public:
 	virtual void AddInvokeThroneRoom();
 	virtual void AddInvokeResearchAdvance(const MBCHAR *text);
 	virtual void AddBeginScheduler(sint32 player);
+	virtual void FlushPendingBeginScheduler();
 
 	// Animations
 	virtual void AddTradeRouteAnimation(const TradeRoute &tradeRoute);
@@ -759,6 +760,12 @@ private:
 
 	sint32                            m_lastPlayer;
 	sint32                            m_lastRound;
+
+	// Set for a player when AddBeginScheduler(player) is called while
+	// player isn't the currently active one (e.g. a diplomacy negotiation
+	// concludes for them during a different player's turn). Consumed by
+	// FlushPendingBeginScheduler() once that player's turn becomes current.
+	bool                              m_pendingBeginScheduler[k_MAX_PLAYERS];
 };
 
 Director* Director::CreateDirector() {
@@ -2247,6 +2254,7 @@ DirectorImpl::DirectorImpl()
 		m_lastRound          (-1)
 {
 	std::fill(m_timeLog, m_timeLog + k_TIME_LOG_SIZE, 0);
+	std::fill(m_pendingBeginScheduler, m_pendingBeginScheduler + k_MAX_PLAYERS, false);
 
 	delete m_instance;
 	m_instance = this;
@@ -3077,8 +3085,20 @@ void DirectorImpl::AddInvokeResearchAdvance(const MBCHAR *message)
 
 void DirectorImpl::AddBeginScheduler(sint32 player)
 {
-	Assert(player == g_selected_item->GetCurPlayer());
-	if (player != g_selected_item->GetCurPlayer()) {
+	if (player != g_selected_item->GetCurPlayer())
+	{
+		DPRINTF(k_DBG_SCHEDULER, ("DIAG: AddBeginScheduler(%d) deferred, curPlayer=%d\n",
+		                          player, g_selected_item->GetCurPlayer()));
+
+		// A diplomacy negotiation (or other deferred event) can conclude
+		// for a player after the currently active player has already
+		// moved on. Defer the request instead of dropping it - it fires
+		// once FlushPendingBeginScheduler() sees this player become the
+		// active one.
+		if (player >= 0 && player < k_MAX_PLAYERS)
+		{
+			m_pendingBeginScheduler[player] = true;
+		}
 		return;
 	}
 
@@ -3086,6 +3106,17 @@ void DirectorImpl::AddBeginScheduler(sint32 player)
 
 	DQActionBeginScheduler *action = new DQActionBeginScheduler(player);
 	m_actionQueue->AddTail(action);
+}
+
+void DirectorImpl::FlushPendingBeginScheduler()
+{
+	sint32 const player = g_selected_item->GetCurPlayer();
+	if (player >= 0 && player < k_MAX_PLAYERS && m_pendingBeginScheduler[player])
+	{
+		DPRINTF(k_DBG_SCHEDULER, ("DIAG: FlushPendingBeginScheduler firing deferred AddBeginScheduler(%d)\n", player));
+		m_pendingBeginScheduler[player] = false;
+		AddBeginScheduler(player);
+	}
 }
 
 

--- a/ctp2_code/gfx/spritesys/director.h
+++ b/ctp2_code/gfx/spritesys/director.h
@@ -132,6 +132,7 @@ public:
 	virtual void AddInvokeThroneRoom() = 0;
 	virtual void AddInvokeResearchAdvance(const MBCHAR *text) = 0;
 	virtual void AddBeginScheduler(sint32 player) = 0;
+	virtual void FlushPendingBeginScheduler() = 0;
 
 	// Animations
 	virtual void AddTradeRouteAnimation(const TradeRoute &tradeRoute) = 0;

--- a/ctp2_code/gs/gameobj/ArmyData.cpp
+++ b/ctp2_code/gs/gameobj/ArmyData.cpp
@@ -2487,6 +2487,8 @@ ORDER_RESULT ArmyData::Sue(const MapPoint &point)
 		return ORDER_RESULT_ILLEGAL;
 	}
 
+	AddSpecialActionUsed(m_array[uindex]);
+
 	g_gevManager->AddEvent(GEV_INSERT_AfterCurrent, GEV_Lawsuit,
 	                       GEA_Army, m_id,
 	                       GEA_Unit, m_array[uindex].m_id,
@@ -3585,6 +3587,8 @@ ORDER_RESULT ArmyData::UndergroundRailway(const MapPoint &point)
 
 	if(g_rand->Next(100) < sint32(success * 100.0))
 	{
+		AddSpecialActionUsed(m_array[uindex]);
+
 		g_gevManager->AddEvent(GEV_INSERT_AfterCurrent, GEV_UndergroundRailwayUnit,
 		                       GEA_Unit, m_array[uindex].m_id,
 		                       GEA_City, c,
@@ -9826,6 +9830,11 @@ bool ArmyData::ExecuteSpecialOrder(Order *order, bool &keepGoing)
 		for(sint32 i = m_nElements - 1; i >= 0; i--)
 		{
 			Assert(!m_array[i].Flag(k_UDF_USED_SPECIAL_ACTION_JUST_NOW));
+			if(m_array[i].Flag(k_UDF_USED_SPECIAL_ACTION_JUST_NOW))
+			{
+				DPRINTF(k_DBG_SPECIAL_ACTION, ("DIAG: clearing JUST_NOW (illegal branch, order %d) on unit id 0x%lx\n",
+				                          (sint32) order->m_order, m_array[i].m_id));
+			}
 			m_array[i].ClearFlag(k_UDF_USED_SPECIAL_ACTION_JUST_NOW);
 		}
 		return true;
@@ -9930,6 +9939,8 @@ bool ArmyData::ExecuteSpecialOrder(Order *order, bool &keepGoing)
 		{
 			if(m_array[i].Flag(k_UDF_USED_SPECIAL_ACTION_JUST_NOW))
 			{
+				DPRINTF(k_DBG_SPECIAL_ACTION, ("DIAG: clearing JUST_NOW (deduct branch, order %d) on unit id 0x%lx\n",
+				                          (sint32) order->m_order, m_array[i].m_id));
 				m_array[i].ClearFlag(k_UDF_USED_SPECIAL_ACTION_JUST_NOW);
 				if(order_rec)
 				{
@@ -9946,6 +9957,9 @@ bool ArmyData::ExecuteSpecialOrder(Order *order, bool &keepGoing)
 
 void ArmyData::AddSpecialActionUsed(Unit &who)
 {
+	DPRINTF(k_DBG_SPECIAL_ACTION, ("DIAG: AddSpecialActionUsed on unit id 0x%lx, type %s, owner %d\n%s\n",
+	                          who.m_id, g_theStringDB->GetIdStr(g_theUnitDB->GetName(who.GetType())),
+	                          who.GetOwner(), c3debug_StackTrace()));
 	who.SetFlag(k_UDF_USED_SPECIAL_ACTION_THIS_TURN);
 	who.SetFlag(k_UDF_USED_SPECIAL_ACTION_JUST_NOW);
 }

--- a/ctp2_code/gs/gameobj/ArmyData.cpp
+++ b/ctp2_code/gs/gameobj/ArmyData.cpp
@@ -9832,7 +9832,7 @@ bool ArmyData::ExecuteSpecialOrder(Order *order, bool &keepGoing)
 			Assert(!m_array[i].Flag(k_UDF_USED_SPECIAL_ACTION_JUST_NOW));
 			if(m_array[i].Flag(k_UDF_USED_SPECIAL_ACTION_JUST_NOW))
 			{
-				DPRINTF(k_DBG_SPECIAL_ACTION, ("DIAG: clearing JUST_NOW (illegal branch, order %d) on unit id 0x%lx\n",
+				DPRINTF(k_DBG_SPECIAL_ACTION, ("SPECIAL_ACTION: clearing JUST_NOW (illegal branch, order %d) on unit id 0x%lx\n",
 				                          (sint32) order->m_order, m_array[i].m_id));
 			}
 			m_array[i].ClearFlag(k_UDF_USED_SPECIAL_ACTION_JUST_NOW);
@@ -9939,7 +9939,7 @@ bool ArmyData::ExecuteSpecialOrder(Order *order, bool &keepGoing)
 		{
 			if(m_array[i].Flag(k_UDF_USED_SPECIAL_ACTION_JUST_NOW))
 			{
-				DPRINTF(k_DBG_SPECIAL_ACTION, ("DIAG: clearing JUST_NOW (deduct branch, order %d) on unit id 0x%lx\n",
+				DPRINTF(k_DBG_SPECIAL_ACTION, ("SPECIAL_ACTION: clearing JUST_NOW (deduct branch, order %d) on unit id 0x%lx\n",
 				                          (sint32) order->m_order, m_array[i].m_id));
 				m_array[i].ClearFlag(k_UDF_USED_SPECIAL_ACTION_JUST_NOW);
 				if(order_rec)
@@ -9957,7 +9957,7 @@ bool ArmyData::ExecuteSpecialOrder(Order *order, bool &keepGoing)
 
 void ArmyData::AddSpecialActionUsed(Unit &who)
 {
-	DPRINTF(k_DBG_SPECIAL_ACTION, ("DIAG: AddSpecialActionUsed on unit id 0x%lx, type %s, owner %d\n%s\n",
+	DPRINTF(k_DBG_SPECIAL_ACTION, ("SPECIAL_ACTION: AddSpecialActionUsed on unit id 0x%lx, type %s, owner %d\n%s\n",
 	                          who.m_id, g_theStringDB->GetIdStr(g_theUnitDB->GetName(who.GetType())),
 	                          who.GetOwner(), c3debug_StackTrace()));
 	who.SetFlag(k_UDF_USED_SPECIAL_ACTION_THIS_TURN);

--- a/ctp2_code/gs/gameobj/CityData.cpp
+++ b/ctp2_code/gs/gameobj/CityData.cpp
@@ -9729,7 +9729,14 @@ void CityData::CollectOtherGold(const bool projectedOnly)
 
 	if(!projectedOnly)
 	{
-		g_player[m_owner]->m_gold->AddIncome(m_net_gold);
+		if (m_net_gold < 0)
+		{
+			g_player[m_owner]->m_gold->SubIncome(-m_net_gold);
+		}
+		else
+		{
+			g_player[m_owner]->m_gold->AddIncome(m_net_gold);
+		}
 	}
 }
 

--- a/ctp2_code/gs/gameobj/UnitData.cpp
+++ b/ctp2_code/gs/gameobj/UnitData.cpp
@@ -3002,7 +3002,7 @@ void UnitData::BeginTurn()
 
 	Assert(!Flag(k_UDF_USED_SPECIAL_ACTION_JUST_NOW));
 	if(Flag(k_UDF_USED_SPECIAL_ACTION_JUST_NOW)) {
-		DPRINTF(k_DBG_SPECIAL_ACTION, ("DIAG: stuck k_UDF_USED_SPECIAL_ACTION_JUST_NOW on unit id 0x%lx, type %s, owner %d\n",
+		DPRINTF(k_DBG_SPECIAL_ACTION, ("SPECIAL_ACTION: stuck k_UDF_USED_SPECIAL_ACTION_JUST_NOW on unit id 0x%lx, type %s, owner %d\n",
 		                          m_id, g_theStringDB->GetIdStr(g_theUnitDB->GetName(m_type)), m_owner));
 		ClearFlag(k_UDF_USED_SPECIAL_ACTION_JUST_NOW);
 		needsEnqueue = true;

--- a/ctp2_code/gs/gameobj/UnitData.cpp
+++ b/ctp2_code/gs/gameobj/UnitData.cpp
@@ -3002,6 +3002,8 @@ void UnitData::BeginTurn()
 
 	Assert(!Flag(k_UDF_USED_SPECIAL_ACTION_JUST_NOW));
 	if(Flag(k_UDF_USED_SPECIAL_ACTION_JUST_NOW)) {
+		DPRINTF(k_DBG_SPECIAL_ACTION, ("DIAG: stuck k_UDF_USED_SPECIAL_ACTION_JUST_NOW on unit id 0x%lx, type %s, owner %d\n",
+		                          m_id, g_theStringDB->GetIdStr(g_theUnitDB->GetName(m_type)), m_owner));
 		ClearFlag(k_UDF_USED_SPECIAL_ACTION_JUST_NOW);
 		needsEnqueue = true;
 	}

--- a/ctp2_code/gs/gameobj/armyevent.cpp
+++ b/ctp2_code/gs/gameobj/armyevent.cpp
@@ -1519,8 +1519,6 @@ STDEHANDLER(LawsuitEvent)
 		}
 	}
 
-	a->AddSpecialActionUsed(lawyer);
-
 	if(utype >= 0) {
 		SlicObject *so = new SlicObject("161SueCompleteVictim");
 		so->AddRecipient(victim);

--- a/ctp2_code/gs/gameobj/unitevent.cpp
+++ b/ctp2_code/gs/gameobj/unitevent.cpp
@@ -25,8 +25,8 @@
 // Modifications from the original Activision code:
 //
 // - AddUnitToArmyEvent does not crash in the debug version if the unit to
-//   be is transported and has therefore no army. This makes slic code save. (7-Nov-2007 Martin Gühmann)
-// - Added an upgrade unit event. (13-Sep-2008 Martin Gühmann)
+//   be is transported and has therefore no army. This makes slic code save. (7-Nov-2007 Martin Gï¿½hmann)
+// - Added an upgrade unit event. (13-Sep-2008 Martin Gï¿½hmann)
 //
 //----------------------------------------------------------------------------
 
@@ -276,7 +276,6 @@ STDEHANDLER(UndergroundRailwayUnitEvent)
 		Assert(hc.m_id != 0);
 		return GEV_HD_Continue;
 	}
-	u->GetArmy()->AddSpecialActionUsed(u);
 
 	MapPoint cpos;
 	hc.GetPos(cpos);

--- a/ctp2_code/gs/slic/SlicSegment.cpp
+++ b/ctp2_code/gs/slic/SlicSegment.cpp
@@ -262,6 +262,42 @@ SlicSegment::SlicSegment(CivArchive &archive)
 	Serialize(archive);
 }
 
+namespace {
+
+//----------------------------------------------------------------------------
+//
+// Name       : ClearPointerField
+//
+// Description: Helper function for destructor
+//
+// Parameters : pointer of any type T
+//
+// Globals    : none
+//
+// Returns    : none
+//
+// Remark(s)  : Assigns NULL to a pointer, even with compiler optimizations
+//              enabled.
+//
+//              With optimizations enabled, the compiler may skip the
+//              assignment in the destructor because it assumes the destructor
+//              will only be called once, and therefore no code will ever look
+//              at the modified field.
+//
+//              In this case, Pool manages the memory, and the memory is not
+//              actually freed. When the program quits, the destructor is
+//              called again, and the pointer in the unmodified field is freed
+//              again. "volatile" prevents the compiler from skipping the
+//              assignment.
+//
+//----------------------------------------------------------------------------
+template <typename T>
+inline void ClearPointerField(T * volatile & p) {
+	p = NULL;
+}
+
+}
+
 //----------------------------------------------------------------------------
 //
 // Name       : SlicSegment::~SlicSegment
@@ -283,25 +319,25 @@ SlicSegment::~SlicSegment()
 	if(m_id)
 	{
 		free(m_id);
-		m_id = NULL;
+		ClearPointerField(m_id);
 	}
 
 	if(m_code)
 	{
 		free(m_code);
-		m_code = NULL;
+		ClearPointerField(m_code);
 	}
 
 	if(m_uiComponent)
 	{
 		free(m_uiComponent);
-		m_uiComponent = NULL;
+		ClearPointerField(m_uiComponent);
 	}
 
 	if(m_filename)
 	{
 		free(m_filename);
-		m_filename = NULL;
+		ClearPointerField(m_filename);
 	}
 
 	delete [] m_trigger_symbols_indices;
@@ -312,10 +348,10 @@ SlicSegment::~SlicSegment()
 	// Has to be set to NULL, because SlicSegments are deleted twice,
 	// first from the StringHashNode and then from the pool. Actuially,
 	// not a very nice design, but with this extra stuff it should be harmless.
-	m_trigger_symbols_indices = NULL;
-	m_trigger_symbols         = NULL;
-	m_parameter_indices       = NULL;
-	m_parameter_symbols       = NULL;
+	ClearPointerField(m_trigger_symbols_indices);
+	ClearPointerField(m_trigger_symbols);
+	ClearPointerField(m_parameter_indices);
+	ClearPointerField(m_parameter_symbols);
 }
 
 //----------------------------------------------------------------------------

--- a/ctp2_code/gs/utility/newturncount.cpp
+++ b/ctp2_code/gs/utility/newturncount.cpp
@@ -256,7 +256,7 @@ void NewTurnCount::ChooseNextActivePlayer()
 		count++;
 	} while( g_player[g_selected_item->GetCurPlayer()] == NULL );
 
-	DPRINTF(k_DBG_SCHEDULER, ("DIAG: ChooseNextActivePlayer: %d -> %d\n",
+	DPRINTF(k_DBG_SCHEDULER, ("PLAYER_SYNC: ChooseNextActivePlayer: %d -> %d\n",
 	                          oldPlayer, g_selected_item->GetCurPlayer()));
 
 	g_director->FlushPendingBeginScheduler();

--- a/ctp2_code/gs/utility/newturncount.cpp
+++ b/ctp2_code/gs/utility/newturncount.cpp
@@ -248,12 +248,18 @@ void NewTurnCount::StartNextPlayer(bool stop)
 void NewTurnCount::ChooseNextActivePlayer()
 {
 	sint32 count = 0;
+	sint32 const oldPlayer = g_selected_item->GetCurPlayer();
 
 	do {
 		g_selected_item->NextPlayer();
 		g_director->NextPlayer();
 		count++;
 	} while( g_player[g_selected_item->GetCurPlayer()] == NULL );
+
+	DPRINTF(k_DBG_SCHEDULER, ("DIAG: ChooseNextActivePlayer: %d -> %d\n",
+	                          oldPlayer, g_selected_item->GetCurPlayer()));
+
+	g_director->FlushPendingBeginScheduler();
 }
 
 void NewTurnCount::StartNewYear()

--- a/ctp2_code/robot/pathing/Astar.h
+++ b/ctp2_code/robot/pathing/Astar.h
@@ -75,6 +75,17 @@ protected:
 
 	virtual sint32 GetMaxDir(MapPoint &pos) const = 0;
 
+	// Used to restrict diagnostic logging (AI_DPRINTF) to a single debug
+	// player. Subclasses that track an owner (e.g. UnitAstar) override
+	// this; subclasses that don't (e.g. CityAstar, TradeAstar) keep the
+	// -1 default, which AI_DPRINTF treats as "don't filter by player".
+	virtual PLAYER_INDEX GetOwner() const { return -1; }
+
+	// Same idea as GetOwner(), but for filtering diagnostics down to a
+	// single debug army (CtpAiDebug::SetDebugArmies) instead of/as well
+	// as a single player.
+	virtual sint32 GetArmyId() const { return -1; }
+
 	virtual void RecalcEntryCost(AstarPoint *parent,
 	    AstarPoint *node, float &new_entery_cost,
 	    bool &new_is_zoc, ASTAR_ENTRY_TYPE &entry);

--- a/ctp2_code/robot/pathing/CityAstar.cpp
+++ b/ctp2_code/robot/pathing/CityAstar.cpp
@@ -192,6 +192,11 @@ sint32 CityAstar::GetMaxDir(MapPoint &pos) const
 	return SOUTH;
 }
 
+sint32 CityAstar::GetArmyId() const
+{
+	return g_theWorld->GetCity(m_start).m_id;
+}
+
 bool CityAstar::IsConnected
 (
     PLAYER_INDEX        owner,

--- a/ctp2_code/robot/pathing/CityAstar.h
+++ b/ctp2_code/robot/pathing/CityAstar.h
@@ -43,6 +43,11 @@ class CityAstar : public Astar
 	bool EntryCost(const MapPoint &prev, const MapPoint &pos,
 	                        float &cost, bool &is_zoc, ASTAR_ENTRY_TYPE &entry);
 	sint32 GetMaxDir(MapPoint &pos) const;
+	PLAYER_INDEX GetOwner() const { return m_owner; }
+
+	// The city at m_start, if any - lets diagnostics filter by the city
+	// this search is being run for, the same way UnitAstar filters by army.
+	sint32 GetArmyId() const;
 
 public:
 	CityAstar()

--- a/ctp2_code/robot/pathing/TradeAstar.cpp
+++ b/ctp2_code/robot/pathing/TradeAstar.cpp
@@ -82,7 +82,13 @@ bool TradeAstar::FindPath(const PLAYER_INDEX owner, const MapPoint &start, const
 	sint32 cutoff = Astar_MaxSearchNodes();
 	sint32 nodes_opened=0;
 	m_owner = owner;
+	m_start = start;
 
 	return Astar::FindPath(start, dest, a_path, total_cost, isunit,
 	        cutoff, nodes_opened);
+}
+
+sint32 TradeAstar::GetArmyId() const
+{
+	return g_theWorld->GetCity(m_start).m_id;
 }

--- a/ctp2_code/robot/pathing/TradeAstar.h
+++ b/ctp2_code/robot/pathing/TradeAstar.h
@@ -38,12 +38,20 @@
 class TradeAstar : public Astar
 {
 	PLAYER_INDEX m_owner;
+	MapPoint m_start;
 
 	bool EntryCost(const MapPoint &prev, const MapPoint &pos,
 	                        float &cost, bool &is_zoc,
 	                        ASTAR_ENTRY_TYPE &entry);
 
 	sint32 GetMaxDir(MapPoint &pos) const;
+
+	PLAYER_INDEX GetOwner() const { return m_owner; }
+
+	// The city at m_start, if any - lets diagnostics filter by the city
+	// this trade route search started from, the same way UnitAstar
+	// filters by army.
+	sint32 GetArmyId() const;
 
 public:
 

--- a/ctp2_code/robot/pathing/UnitAstar.h
+++ b/ctp2_code/robot/pathing/UnitAstar.h
@@ -86,6 +86,13 @@ public:
 				ASTAR_ENTRY_TYPE & entry);
 	virtual sint32 GetMaxDir(MapPoint & pos) const;
 
+	// Wraps g_theWorld->IsMoveZOC() so a subclass (RobotAstar2) can change
+	// how AI pathfinding treats ZOC without touching the underlying game
+	// rule used everywhere else (e.g. move-execution validation). Always
+	// checks m_owner with is_check_only_visible set, the only way this
+	// class's callers use it.
+	virtual bool IsMoveZOC(const MapPoint & start, const MapPoint & dest) const;
+
 	bool FindPath(Army & army, const MapPoint & start, PLAYER_INDEX owner, const MapPoint & dest, Path & new_path,
 				bool & is_broken_path, Path & bad_path, float & total_cost);
 

--- a/ctp2_code/robot/pathing/UnitAstar.h
+++ b/ctp2_code/robot/pathing/UnitAstar.h
@@ -86,6 +86,9 @@ public:
 				ASTAR_ENTRY_TYPE & entry);
 	virtual sint32 GetMaxDir(MapPoint & pos) const;
 
+	virtual PLAYER_INDEX GetOwner() const { return m_owner; }
+	virtual sint32 GetArmyId() const { return m_army.m_id; }
+
 	// Wraps g_theWorld->IsMoveZOC() so a subclass (RobotAstar2) can change
 	// how AI pathfinding treats ZOC without touching the underlying game
 	// rule used everywhere else (e.g. move-execution validation). Always

--- a/ctp2_code/robot/pathing/astar.cpp
+++ b/ctp2_code/robot/pathing/astar.cpp
@@ -37,6 +37,7 @@
 #include "AVLHeap.h"
 #include "Path.h"
 #include "World.h"
+#include "ctpaidebug.h"
 
 #ifdef PRINT_COSTS
 #include "gfx_options.h"
@@ -368,7 +369,7 @@ bool Astar::FindPath
 						// floods the log with routine, uninteresting reopens.
 						if (c->m_point->m_reopen_count > maxReopens - 5)
 						{
-							DPRINTF(k_DBG_ASTAR,
+							AI_DPRINTF(k_DBG_ASTAR, GetOwner(), -1, GetArmyId(),
 							    ("REOPEN_DIAG: tile (%d,%d) reopen #%d via parent (%d,%d): oldG=%.3f bestG=%.3f rawEdgeCost=%.3f decayedEdgeCost=%.3f pastCostAtParent=%.3f\n",
 							     next_pos.x, next_pos.y, c->m_point->m_reopen_count + 1,
 							     best->m_pos.x, best->m_pos.y, oldG, bestG, rawMove, bMove, past_cost));
@@ -380,6 +381,15 @@ bool Astar::FindPath
 						// than normal progress. Trips the debugger right here,
 						// on the offending tile, instead of at some arbitrary
 						// later iteration count.
+						if (c->m_point->m_reopen_count + 1 >= maxReopens)
+						{
+							// If you only want to track the army/city from that the path originated
+							// then feed the ID reported here into CtpAiDebug::SetDebugArmy in
+							// CtpAi::Initialize
+							DPRINTF(k_DBG_FIX,
+							    ("Astar::FindPath: reopen cap about to trip, player %d, army 0x%x\n",
+							     GetOwner(), GetArmyId()));
+						}
 						Assert(++c->m_point->m_reopen_count < maxReopens);
 
 						if (c->m_point->GetExpanded())
@@ -476,7 +486,8 @@ bool Astar::FindPath
 
 		if (best)
 		{
-			DPRINTF(k_DBG_ASTAR,("\tCheckBest , StartPos (%d, %d), DestPos (%d, %d), BestPos (%d, %d)\n", start.x, start.y, dest.x, dest.y, best->m_pos.x, best->m_pos.y));
+			AI_DPRINTF(k_DBG_ASTAR, GetOwner(), -1, GetArmyId(),
+			    ("\tCheckBest , StartPos (%d, %d), DestPos (%d, %d), BestPos (%d, %d)\n", start.x, start.y, dest.x, dest.y, best->m_pos.x, best->m_pos.y));
 			if (best->m_pos == dest)
 			{
 				float               cost;
@@ -503,7 +514,8 @@ bool Astar::FindPath
 	Assert(nodes_opened < cutoff);
 
 	bool const r =  Cleanup(dest, a_path, total_cost, isunit, best);
-	DPRINTF(k_DBG_ASTAR, ("\tFinalPathCosts: %f , StartPos (%d, %d), DestPos (%d, %d), BestPos (%d, %d)\n", total_cost, start.x, start.y, dest.x, dest.y, best->m_pos.x, best->m_pos.y));
+	AI_DPRINTF(k_DBG_ASTAR, GetOwner(), -1, GetArmyId(),
+	    ("\tFinalPathCosts: %f , StartPos (%d, %d), DestPos (%d, %d), BestPos (%d, %d)\n", total_cost, start.x, start.y, dest.x, dest.y, best->m_pos.x, best->m_pos.y));
 
 #ifdef TRACK_ASTAR_NODES
 	g_paths_found++;

--- a/ctp2_code/robot/pathing/astar.cpp
+++ b/ctp2_code/robot/pathing/astar.cpp
@@ -287,10 +287,11 @@ bool Astar::FindPath
 
 	// A long-distance search over uniform-cost terrain legitimately ties a
 	// huge number of tiles, so any one of them can end up reopened many
-	// times as the frontier of near-equal-cost candidates expands - that's
-	// normal, not a runaway. Scale the safety cap with distance instead of
-	// using one flat number for every search, short or long.
-	sint32 const    maxReopens  = k_ASTAR_MAX_REOPENS + start.NormalizedDistance(dest);
+	// times as the frontier of near-equal-cost candidates expands. The
+	// number of tied candidates in an open 2D area grows roughly with the
+	// square of the distance, not linearly with it, so scale the safety
+	// cap the same way instead of using one flat number for every search.
+	sint32 const    maxReopens  = k_ASTAR_MAX_REOPENS + MapPoint::GetSquaredDistance(start, dest);
 
 	Cell *          c           = g_theWorld->GetCell(start);
 	Assert(c);

--- a/ctp2_code/robot/pathing/astar.cpp
+++ b/ctp2_code/robot/pathing/astar.cpp
@@ -100,7 +100,12 @@ void Astar::DecayOrtho(AstarPoint *parent, AstarPoint *point, float &new_entry_c
 
 	if (is_ortho)
 	{
-		new_entry_cost = point->m_entry_cost * 0.95f;
+		// Decay the freshly computed edge cost, not the node's old stored
+		// m_entry_cost - reading the stale value here made every reopen of
+		// an orthogonal neighbor shrink its cost by another 5% regardless
+		// of the actual new edge cost, always looking like an improvement
+		// and reopening the same tile until it hit k_ASTAR_MAX_REOPENS.
+		new_entry_cost = new_entry_cost * 0.95f;
 	}
 }
 

--- a/ctp2_code/robot/pathing/astar.cpp
+++ b/ctp2_code/robot/pathing/astar.cpp
@@ -285,6 +285,13 @@ bool Astar::FindPath
 		return Cleanup(dest, a_path, total_cost, isunit, best);
 	}
 
+	// A long-distance search over uniform-cost terrain legitimately ties a
+	// huge number of tiles, so any one of them can end up reopened many
+	// times as the frontier of near-equal-cost candidates expands - that's
+	// normal, not a runaway. Scale the safety cap with distance instead of
+	// using one flat number for every search, short or long.
+	sint32 const    maxReopens  = k_ASTAR_MAX_REOPENS + start.NormalizedDistance(dest);
+
 	Cell *          c           = g_theWorld->GetCell(start);
 	Assert(c);
 	if (!c)
@@ -342,6 +349,7 @@ bool Astar::FindPath
 				ASTAR_ENTRY_TYPE	bType;		// entry type from best
 				if (EntryCost(best->m_pos, next_pos, bMove, bZoc, bType))
 				{
+					float const		rawMove	= bMove;
 					DecayOrtho(best, c->m_point, bMove);
 
 					float const		oldG	=
@@ -350,13 +358,28 @@ bool Astar::FindPath
 
 					if (bestG < oldG && (c->m_point->m_parent == NULL || c->m_point != best->m_parent))
 					{
-						// A tile that gets reopened far more than a healthy
-						// search ever needs is the signature of a cost-
-						// decreasing cycle (e.g. via DecayOrtho) rather than
-						// normal progress. Trips the debugger right here,
-						// on the offending tile, instead of at some
-						// arbitrary later iteration count.
-						Assert(++c->m_point->m_reopen_count < k_ASTAR_MAX_REOPENS);
+						// Only log the final few reopens right before the
+						// Assert below trips, showing the exact cost sequence
+						// (raw vs decayed edge cost, oldG vs bestG) that pushed
+						// it over the edge. Plenty of searches reopen a tile
+						// more than a handful of times without ever being a
+						// real problem, so logging from a low threshold
+						// floods the log with routine, uninteresting reopens.
+						if (c->m_point->m_reopen_count > maxReopens - 5)
+						{
+							DPRINTF(k_DBG_ASTAR,
+							    ("REOPEN_DIAG: tile (%d,%d) reopen #%d via parent (%d,%d): oldG=%.3f bestG=%.3f rawEdgeCost=%.3f decayedEdgeCost=%.3f pastCostAtParent=%.3f\n",
+							     next_pos.x, next_pos.y, c->m_point->m_reopen_count + 1,
+							     best->m_pos.x, best->m_pos.y, oldG, bestG, rawMove, bMove, past_cost));
+						}
+
+						// A tile that gets reopened far more than this search's
+						// distance-scaled cap ever needs is the signature of a
+						// cost-decreasing cycle (e.g. via DecayOrtho) rather
+						// than normal progress. Trips the debugger right here,
+						// on the offending tile, instead of at some arbitrary
+						// later iteration count.
+						Assert(++c->m_point->m_reopen_count < maxReopens);
 
 						if (c->m_point->GetExpanded())
 						{

--- a/ctp2_code/robot/pathing/robotastar2.cpp
+++ b/ctp2_code/robot/pathing/robotastar2.cpp
@@ -290,7 +290,7 @@ bool RobotAstar2::FindPath( const PathType & pathType,
 			m_army_minmax_move);
 	}
 
-	AI_DPRINTF(k_DBG_ASTAR, -1, -1, -1,("\n"));
+	AI_DPRINTF(k_DBG_ASTAR, army.GetOwner(), -1, army.m_id,("\n"));
 	if(!UnitAstar::FindPath(army,
 	                        nUnits + additionalUnits,
 	                        move_intersection,
@@ -354,7 +354,8 @@ bool RobotAstar2::EntryCost( const MapPoint &prev,
 			}
 		}
 
-		DPRINTF(k_DBG_ASTAR,("\tCheckEnter, StartPos (%d, %d), DestPos (%d, %d), ThisPos (%d, %d), NextPos (%d, %d), IsZoc: %d, EntryType: %d, Cost: %f\n", m_start.x, m_start.y, m_dest.x, m_dest.y, prev.x, prev.y, pos.x, pos.y, is_zoc, entry, cost));
+		AI_DPRINTF(k_DBG_ASTAR, m_owner, -1, m_army.m_id,
+		    ("\tCheckEnter, StartPos (%d, %d), DestPos (%d, %d), ThisPos (%d, %d), NextPos (%d, %d), IsZoc: %d, EntryType: %d, Cost: %f\n", m_start.x, m_start.y, m_dest.x, m_dest.y, prev.x, prev.y, pos.x, pos.y, is_zoc, entry, cost));
 
 		if (cost < 1.0)
 		{

--- a/ctp2_code/robot/pathing/robotastar2.cpp
+++ b/ctp2_code/robot/pathing/robotastar2.cpp
@@ -38,6 +38,7 @@
 #include "World.h"          // g_theWorld
 #include "ArmyData.h"
 #include "Diplomat.h"
+#include "player.h"
 #include "ctpaidebug.h"
 
 uint32 const    INCURSION_PERMISSION_ALL    = 0xffffffffu;
@@ -47,6 +48,16 @@ RobotAstar2 RobotAstar2::s_aiPathing;
 RobotAstar2::RobotAstar2()
 {
 	m_pathType = PATH_TYPE_DEFAULT;
+}
+
+bool RobotAstar2::IsMoveZOC(const MapPoint & start, const MapPoint & dest) const
+{
+	if (g_player[m_owner]->IsRobot() && !g_player[m_owner]->IsVisible(dest))
+	{
+		return false;
+	}
+
+	return UnitAstar::IsMoveZOC(start, dest);
 }
 
 bool RobotAstar2::TransportPathCallback (const bool & can_enter,

--- a/ctp2_code/robot/pathing/robotastar2.h
+++ b/ctp2_code/robot/pathing/robotastar2.h
@@ -86,6 +86,11 @@ private:
 	bool EntryCost(const MapPoint & prev, const MapPoint & pos,
 	               float &cost, bool & is_zoc, ASTAR_ENTRY_TYPE & entry);
 
+	// A robot can't actually know what's exerting ZOC on a tile it
+	// currently can't see, so don't let UnitAstar::IsMoveZOC's always-
+	// omniscient robot shortcut block AI pathfinding toward it.
+	bool IsMoveZOC(const MapPoint & start, const MapPoint & dest) const;
+
 	void RecalcEntryCost(AstarPoint *parent, AstarPoint *node,
 	                     float &new_entry_cost, bool &new_is_zoc,
 	                     ASTAR_ENTRY_TYPE &new_entry);

--- a/ctp2_code/robot/pathing/unitastar.cpp
+++ b/ctp2_code/robot/pathing/unitastar.cpp
@@ -80,6 +80,11 @@ UnitAstar::UnitAstar()
 	ClearMem();
 }
 
+bool UnitAstar::IsMoveZOC(const MapPoint & start, const MapPoint & dest) const
+{
+	return g_theWorld->IsMoveZOC(m_owner, start, dest, true);
+}
+
 //----------------------------------------------------------------------------
 //
 // Name       : UnitAstar::StraightLine
@@ -497,7 +502,7 @@ bool UnitAstar::CheckMoveUnion(const MapPoint & prev, const MapPoint & pos, cons
 			}
 		}
 
-		if (can_be_zoc && g_theWorld->IsMoveZOC (m_owner, prev, pos, true) &&
+		if (can_be_zoc && IsMoveZOC(prev, pos) &&
 		    !IsBeachLanding(prev,pos,m_move_intersection)
 		   )
 		{
@@ -528,7 +533,7 @@ bool UnitAstar::CheckMoveIntersection(const MapPoint & prev, const MapPoint & po
 	}
 	else if (the_pos_cell.CanEnter(m_move_intersection))
 	{
-		if (can_be_zoc && g_theWorld->IsMoveZOC (m_owner, prev, pos, true) &&
+		if (can_be_zoc && IsMoveZOC(prev, pos) &&
 			!IsBeachLanding(prev,pos,m_move_intersection))
 		{
 			is_zoc = true;
@@ -1074,7 +1079,7 @@ bool UnitAstar::PretestDest_ZocEnterable(const MapPoint &start, const MapPoint &
 			}
 		}
 
-		if (!g_theWorld->IsMoveZOC (m_owner, neighbor, dest, true))
+		if (!IsMoveZOC(neighbor, dest))
 		{
 			return true;
 		}
@@ -1089,15 +1094,36 @@ bool UnitAstar::PretestDest(const MapPoint &start, const MapPoint &dest)
 	{
 		if (!g_player[m_owner]->IsExplored(dest))
 		{
+			DPRINTF(k_DBG_ASTAR, ("PATHFIND_DIAG: PretestDest rejected dest (%d,%d): not explored\n", dest.x, dest.y));
 			return false;
 		}
 	}
 
-	if (!PretestDest_Enterable         (start, dest)) return false;
-	if (!PretestDest_HasRoom           (start, dest)) return false;
-	if (!PretestDest_SameLandContinent (start, dest)) return false;
-	if (!PretestDest_SameWaterContinent(start, dest)) return false;
-	if (!PretestDest_ZocEnterable      (start, dest)) return false;
+	if (!PretestDest_Enterable(start, dest))
+	{
+		DPRINTF(k_DBG_ASTAR, ("PATHFIND_DIAG: PretestDest rejected dest (%d,%d): not enterable\n", dest.x, dest.y));
+		return false;
+	}
+	if (!PretestDest_HasRoom(start, dest))
+	{
+		DPRINTF(k_DBG_ASTAR, ("PATHFIND_DIAG: PretestDest rejected dest (%d,%d): no room\n", dest.x, dest.y));
+		return false;
+	}
+	if (!PretestDest_SameLandContinent(start, dest))
+	{
+		DPRINTF(k_DBG_ASTAR, ("PATHFIND_DIAG: PretestDest rejected dest (%d,%d): different land continent\n", dest.x, dest.y));
+		return false;
+	}
+	if (!PretestDest_SameWaterContinent(start, dest))
+	{
+		DPRINTF(k_DBG_ASTAR, ("PATHFIND_DIAG: PretestDest rejected dest (%d,%d): different water continent\n", dest.x, dest.y));
+		return false;
+	}
+	if (!PretestDest_ZocEnterable(start, dest))
+	{
+		DPRINTF(k_DBG_ASTAR, ("PATHFIND_DIAG: PretestDest rejected dest (%d,%d): every approach is zone-of-control blocked\n", dest.x, dest.y));
+		return false;
+	}
 
 	return true;
 }
@@ -1159,10 +1185,16 @@ bool UnitAstar::FindPath(
 	Assert(VerifyMem());
 
 	bool result;
-	if (PretestDest(start, dest) &&
-			Astar::FindPath(start, dest, good_path, total_cost, false, cutoff, nodes_opened)) {
+	bool const pretestPassed = PretestDest(start, dest);
+	bool const searchSucceeded = pretestPassed &&
+			Astar::FindPath(start, dest, good_path, total_cost, false, cutoff, nodes_opened);
+	if (searchSucceeded) {
 		result = true;
 	} else {
+		DPRINTF(k_DBG_ASTAR, ("PATHFIND_DIAG: UnitAstar::FindPath failed from (%d,%d) to (%d,%d): %s\n",
+		                                 start.x, start.y, dest.x, dest.y,
+		                                 pretestPassed ? "PretestDest passed, full A* search failed"
+		                                               : "rejected by PretestDest before searching"));
 		if (no_bad_path) {
 			result = false;
 		} else {

--- a/ctp2_code/sound/civsound.cpp
+++ b/ctp2_code/sound/civsound.cpp
@@ -57,9 +57,14 @@ CivSound::CivSound(const uint32 &associatedObject, const sint32 &soundID)
     m_associatedObject(associatedObject)
 
 {
+	// Initialize fields in case of early return.
+	m_soundFilename[0] = 0;
+	m_dataptr = NULL;
+	m_datasize = 0;
+
     const char *fname;
 	if(soundID < 0)
-		fname = 0;
+		fname = NULL;
 	else
 		fname = g_theSoundDB->Get(soundID)->GetValue();
 
@@ -67,18 +72,28 @@ CivSound::CivSound(const uint32 &associatedObject, const sint32 &soundID)
     m_isPlaying = FALSE;
     m_isLooping = FALSE;
 
-    if (0 == fname) {
-        m_soundFilename[0] = 0;
-        m_dataptr = NULL;
-        m_datasize = 0;
+    if (!fname) {
         return;
     }
 
-    strcpy(m_soundFilename, fname);
+	// "NULL.WAV" contains no audio data, and for this file SDL 2.x
+	// returns a pointer that it has already freed. It later tries to
+	// free it again in Mix_FreeChunk.
+	// The file is located inside an archive, and archive look-up is
+	// case-insensitive, however "NULL.WAV" is what appears in the
+	// sound configuration files, so that is what we check here.
+	if (strcmp(fname, "NULL.WAV") == 0) {
+		return;
+	}
 
     size_t      l_dataSize = 0;
-    m_dataptr   = g_SoundPF->getData(m_soundFilename, l_dataSize);
-    m_datasize  = static_cast<sint32>(l_dataSize);
+    m_dataptr   = g_SoundPF->getData(fname, l_dataSize);
+	if (!m_dataptr) {
+		return;
+	}
+
+    strcpy(m_soundFilename, fname);
+    m_datasize = static_cast<sint32>(l_dataSize);
 
 #if !defined(USE_SDL)
 	m_hAudio = AIL_quick_load_mem(m_dataptr, m_datasize);
@@ -87,7 +102,9 @@ CivSound::CivSound(const uint32 &associatedObject, const sint32 &soundID)
     // Argh, audio format mismatch!!!
 	m_Audio = Mix_QuickLoad_RAW((Uint8 *) m_dataptr, (Uint32) m_datasize);
 # else
-    m_Audio = Mix_LoadWAV_RW(SDL_RWFromMem(m_dataptr, static_cast<int>(m_datasize)), 1);
+	m_Audio = Mix_LoadWAV_RW(SDL_RWFromMem(m_dataptr, static_cast<int>(m_datasize)), 1);
+	// If alen=0, then abuf may have been freed by realloc inside SDL 2.x.
+	Assert(m_Audio->alen);
 # endif
 #endif
 }

--- a/ctp2_code/ui/aui_ctp2/SelItem.cpp
+++ b/ctp2_code/ui/aui_ctp2/SelItem.cpp
@@ -2795,6 +2795,11 @@ void SelectedItem::ForceDirectorSelect(const Army &army)
 	if(army.IsValid() && IsPlayerVisible(army.GetOwner()))
 	{
 		m_force_select_army = army;
+
+		// DirectorUnitSelection only honors m_force_select_army when this is
+		// false; otherwise it assumes a manual selection already happened
+		// and does nothing at all. A forced select should always win.
+		m_selected_something_since_director_select = false;
 	}
 }
 

--- a/ctp2_code/ui/interface/chatbox.cpp
+++ b/ctp2_code/ui/interface/chatbox.cpp
@@ -318,12 +318,12 @@ BOOL ChatWindow::CheckForEasterEggs(const MBCHAR *s)
 
 		for (sint32 i = 0; i < n && !gDone; i++)
 		{
-			DPRINTF(k_DBG_SCHEDULER, ("PLAYER_SYNC: /rnd iteration %d/%d before StartNextPlayer, curPlayer=%d, visPlayer=%d\n",
+			DPRINTF(k_DBG_SCHEDULER_DETAIL, ("PLAYER_SYNC: /rnd iteration %d/%d before StartNextPlayer, curPlayer=%d, visPlayer=%d\n",
 			                          i, n, g_selected_item->GetCurPlayer(), g_selected_item->GetVisiblePlayer()));
 
 			NewTurnCount::StartNextPlayer(false);
 
-			DPRINTF(k_DBG_SCHEDULER, ("PLAYER_SYNC: /rnd iteration %d/%d after StartNextPlayer, curPlayer=%d, visPlayer=%d\n",
+			DPRINTF(k_DBG_SCHEDULER_DETAIL, ("PLAYER_SYNC: /rnd iteration %d/%d after StartNextPlayer, curPlayer=%d, visPlayer=%d\n",
 			                          i, n, g_selected_item->GetCurPlayer(), g_selected_item->GetVisiblePlayer()));
 
 			g_director->NextPlayer();
@@ -332,10 +332,10 @@ BOOL ChatWindow::CheckForEasterEggs(const MBCHAR *s)
 				g_controlPanel->Idle();
 				if (g_civApp)
 				{
-					DPRINTF(k_DBG_SCHEDULER, ("PLAYER_SYNC: /rnd calling g_civApp->Process(), curPlayer=%d\n",
+					DPRINTF(k_DBG_SCHEDULER_DETAIL, ("PLAYER_SYNC: /rnd calling g_civApp->Process(), curPlayer=%d\n",
 					                          g_selected_item->GetCurPlayer()));
 					g_civApp->Process();
-					DPRINTF(k_DBG_SCHEDULER, ("PLAYER_SYNC: /rnd returned from g_civApp->Process(), curPlayer=%d\n",
+					DPRINTF(k_DBG_SCHEDULER_DETAIL, ("PLAYER_SYNC: /rnd returned from g_civApp->Process(), curPlayer=%d\n",
 					                          g_selected_item->GetCurPlayer()));
 				}
 

--- a/ctp2_code/ui/interface/chatbox.cpp
+++ b/ctp2_code/ui/interface/chatbox.cpp
@@ -386,6 +386,13 @@ BOOL ChatWindow::CheckForEasterEggs(const MBCHAR *s)
 			           // StartNextPlayer() doesn't advance the cursor out from under
 			           // still-queued turn-begin events for the player just reached.
 			           ||  g_gevManager->EventsPending()
+			           // DirectorImpl's own action queue (e.g. a queued
+			           // DQActionBeginScheduler) is a separate queue from
+			           // GameEventManager's, and executing an action from it can
+			           // itself queue further GEV events (e.g. GEV_BeginScheduler) -
+			           // wait for it too, and let repeated Process() calls drain
+			           // whatever that refills in either queue.
+			           ||  !g_director->CaughtUp()
 			          )
 			      && !gDone
 			     );

--- a/ctp2_code/ui/interface/chatbox.cpp
+++ b/ctp2_code/ui/interface/chatbox.cpp
@@ -318,14 +318,26 @@ BOOL ChatWindow::CheckForEasterEggs(const MBCHAR *s)
 
 		for (sint32 i = 0; i < n && !gDone; i++)
 		{
+			DPRINTF(k_DBG_SCHEDULER, ("PLAYER_SYNC: /rnd iteration %d/%d before StartNextPlayer, curPlayer=%d, visPlayer=%d\n",
+			                          i, n, g_selected_item->GetCurPlayer(), g_selected_item->GetVisiblePlayer()));
+
 			NewTurnCount::StartNextPlayer(false);
+
+			DPRINTF(k_DBG_SCHEDULER, ("PLAYER_SYNC: /rnd iteration %d/%d after StartNextPlayer, curPlayer=%d, visPlayer=%d\n",
+			                          i, n, g_selected_item->GetCurPlayer(), g_selected_item->GetVisiblePlayer()));
 
 			g_director->NextPlayer();
 			do
 			{
 				g_controlPanel->Idle();
 				if (g_civApp)
+				{
+					DPRINTF(k_DBG_SCHEDULER, ("PLAYER_SYNC: /rnd calling g_civApp->Process(), curPlayer=%d\n",
+					                          g_selected_item->GetCurPlayer()));
 					g_civApp->Process();
+					DPRINTF(k_DBG_SCHEDULER, ("PLAYER_SYNC: /rnd returned from g_civApp->Process(), curPlayer=%d\n",
+					                          g_selected_item->GetCurPlayer()));
+				}
 
 #if defined(__AUI_USE_SDL__)
 				SDL_Event event;
@@ -367,7 +379,14 @@ BOOL ChatWindow::CheckForEasterEggs(const MBCHAR *s)
 			while
 			     (
 			          g_selected_item != NULL
-			      &&  g_selected_item->GetCurPlayer() != g_selected_item->GetVisiblePlayer()
+			      &&  (   g_selected_item->GetCurPlayer() != g_selected_item->GetVisiblePlayer()
+			           // The cursor reaching the visible player doesn't mean the event
+			           // queue for that transition (and any earlier one) has actually
+			           // drained yet - keep going until it has, so the next iteration's
+			           // StartNextPlayer() doesn't advance the cursor out from under
+			           // still-queued turn-begin events for the player just reached.
+			           ||  g_gevManager->EventsPending()
+			          )
 			      && !gDone
 			     );
 		}

--- a/ctp2_data/chinese/gamedata/ldl_str.txt
+++ b/ctp2_data/chinese/gamedata/ldl_str.txt
@@ -2614,6 +2614,8 @@ str_ldl_SV_COUNTDOWN_SEQUENCE		"盖亚控制器在%d回合内开始运转……"
 # Message Box
 str_ldl_MB_OK						"确定"
 str_ldl_MB_CANCEL					"取消"
+str_ldl_MB_Inspect					"检查"
+str_ldl_MB_Continue					"继续"
 
 # Army Management
 str_ldl_ArmyManagement "军务官"

--- a/ctp2_data/chinese/gamedata/ldl_str.txt
+++ b/ctp2_data/chinese/gamedata/ldl_str.txt
@@ -2837,6 +2837,7 @@ str_ldl_CityWinUnitsTab "部队"
 
 # autosave string
 AUTOSAVE_NAME				"自动记录"
+AUTOSAVE_NAME_PREVIOUS				"自动记录2"
 
 TRADE_ROUTE_RESET 			"重设贸易路线！"
 

--- a/ctp2_data/czech/gamedata/ldl_str.txt
+++ b/ctp2_data/czech/gamedata/ldl_str.txt
@@ -2837,6 +2837,7 @@ str_ldl_CityWinUnitsTab "Units"
 
 # autosave string
 AUTOSAVE_NAME				"AUTOSAVE"
+AUTOSAVE_NAME_PREVIOUS				"AUTOSAVE2"
 
 TRADE_ROUTE_RESET 			"Trade route reset!"
 

--- a/ctp2_data/czech/gamedata/ldl_str.txt
+++ b/ctp2_data/czech/gamedata/ldl_str.txt
@@ -2614,6 +2614,8 @@ str_ldl_SV_COUNTDOWN_SEQUENCE		"Gaia Controller online in %d turns..."
 # Message Box
 str_ldl_MB_OK						"OK"
 str_ldl_MB_CANCEL					"Storno"
+str_ldl_MB_Inspect					"Prozkoumat"
+str_ldl_MB_Continue					"Pokraèovat"
 
 # Army Management
 str_ldl_ArmyManagement "Manazer Armády"

--- a/ctp2_data/english/gamedata/ldl_str.txt
+++ b/ctp2_data/english/gamedata/ldl_str.txt
@@ -2614,6 +2614,8 @@ str_ldl_SV_COUNTDOWN_SEQUENCE			"Gaia Controller online in %d turns..."
 # Message Box
 str_ldl_MB_OK					"OK"
 str_ldl_MB_CANCEL				"Cancel"
+str_ldl_MB_Inspect				"Inspect"
+str_ldl_MB_Continue				"Continue"
 
 # Army Management
 str_ldl_ArmyManagement				"Army Manager"

--- a/ctp2_data/english/gamedata/ldl_str.txt
+++ b/ctp2_data/english/gamedata/ldl_str.txt
@@ -2837,6 +2837,7 @@ str_ldl_CityWinUnitsTab				"Units"
 
 # autosave string
 AUTOSAVE_NAME					"AUTOSAVE"
+AUTOSAVE_NAME_PREVIOUS				"AUTOSAVE2"
 
 TRADE_ROUTE_RESET				"Trade route reset!"
 

--- a/ctp2_data/french/gamedata/ldl_str.txt
+++ b/ctp2_data/french/gamedata/ldl_str.txt
@@ -2614,6 +2614,8 @@ str_ldl_SV_COUNTDOWN_SEQUENCE			"Contrôleur Gaia connecté dans %d tours..."
 # Message Box
 str_ldl_MB_OK					"OK"
 str_ldl_MB_CANCEL				"Annuler"
+str_ldl_MB_Inspect				"Inspecter"
+str_ldl_MB_Continue				"Continuer"
 
 # Army Management
 str_ldl_ArmyManagement				"Gest. d'armée"

--- a/ctp2_data/french/gamedata/ldl_str.txt
+++ b/ctp2_data/french/gamedata/ldl_str.txt
@@ -2837,6 +2837,7 @@ str_ldl_CityWinUnitsTab				"Unités"
 
 # autosave string
 AUTOSAVE_NAME					"AUTOSAVE"
+AUTOSAVE_NAME_PREVIOUS					"AUTOSAVE2"
 
 TRADE_ROUTE_RESET				"Restaurer route commerciale !"
 

--- a/ctp2_data/german/gamedata/ldl_str.txt
+++ b/ctp2_data/german/gamedata/ldl_str.txt
@@ -2614,6 +2614,8 @@ str_ldl_SV_COUNTDOWN_SEQUENCE			"Gaia-Controller in %d Runden online ..."
 # Message Box
 str_ldl_MB_OK					"OK"
 str_ldl_MB_CANCEL				"Abbrechen"
+str_ldl_MB_Inspect				"Prüfen"
+str_ldl_MB_Continue				"Weiter"
 
 # Army Management
 str_ldl_ArmyManagement				"Truppenmanager"

--- a/ctp2_data/german/gamedata/ldl_str.txt
+++ b/ctp2_data/german/gamedata/ldl_str.txt
@@ -2837,6 +2837,7 @@ str_ldl_CityWinUnitsTab				"Einheiten"
 
 # autosave string
 AUTOSAVE_NAME					"AUTOSAVE"
+AUTOSAVE_NAME_PREVIOUS					"AUTOSAVE2"
 
 TRADE_ROUTE_RESET				"Handelsweg zurücksetzen!"
 

--- a/ctp2_data/italian/gamedata/ldl_str.txt
+++ b/ctp2_data/italian/gamedata/ldl_str.txt
@@ -2837,6 +2837,7 @@ str_ldl_CityWinUnitsTab				"Unità"
 
 # autosave string
 AUTOSAVE_NAME					"AUTOSAVE"
+AUTOSAVE_NAME_PREVIOUS					"AUTOSAVE2"
 
 TRADE_ROUTE_RESET				"Rotta commerciale ripristinata!"
 

--- a/ctp2_data/italian/gamedata/ldl_str.txt
+++ b/ctp2_data/italian/gamedata/ldl_str.txt
@@ -2614,6 +2614,8 @@ str_ldl_SV_COUNTDOWN_SEQUENCE			"Il Controllore Gaia sarà attivo fra %d turni...
 # Message Box
 str_ldl_MB_OK					"OK"
 str_ldl_MB_CANCEL				"Annulla"
+str_ldl_MB_Inspect				"Ispeziona"
+str_ldl_MB_Continue				"Continua"
 
 # Army Management
 str_ldl_ArmyManagement				"Gestione armate"

--- a/ctp2_data/japanese/gamedata/ldl_str.txt
+++ b/ctp2_data/japanese/gamedata/ldl_str.txt
@@ -2994,6 +2994,7 @@ str_ldl_CityWinUnitsTab "ユニット"
 
 # 自動セーブのストリング
 AUTOSAVE_NAME				"自動セーブ"
+AUTOSAVE_NAME_PREVIOUS				"自動セーブ2"
 
 TRADE_ROUTE_RESET 			"貿易ルートの変更！"
 

--- a/ctp2_data/japanese/gamedata/ldl_str.txt
+++ b/ctp2_data/japanese/gamedata/ldl_str.txt
@@ -2774,6 +2774,8 @@ str_ldl_SV_COUNTDOWN_SEQUENCE		"%dターンでガイア コントローラーのオンライン接続.
 # メッセージ ボックス
 str_ldl_MB_OK						"OK"
 str_ldl_MB_CANCEL					"ｷｬﾝｾﾙ"
+str_ldl_MB_Inspect					"調査"
+str_ldl_MB_Continue					"続行"
 
 # 軍管理
 str_ldl_ArmyManagement "軍管理"

--- a/ctp2_data/polish/gamedata/ldl_str.txt
+++ b/ctp2_data/polish/gamedata/ldl_str.txt
@@ -2837,6 +2837,7 @@ str_ldl_CityWinUnitsTab "Jednostki"
 
 # autosave string
 AUTOSAVE_NAME				"AUTOZAPIS"
+AUTOSAVE_NAME_PREVIOUS				"AUTOZAPIS2"
 
 TRADE_ROUTE_RESET 			"Trade route reset!"
 

--- a/ctp2_data/polish/gamedata/ldl_str.txt
+++ b/ctp2_data/polish/gamedata/ldl_str.txt
@@ -2614,6 +2614,8 @@ str_ldl_SV_COUNTDOWN_SEQUENCE		"Gaia Controller online in %d turns..."
 # Message Box
 str_ldl_MB_OK						"OK"
 str_ldl_MB_CANCEL					"Anuluj"
+str_ldl_MB_Inspect					"Sprawdü"
+str_ldl_MB_Continue					"Kontynuuj"
 
 # Army Management
 str_ldl_ArmyManagement "Zarzadca Wojskowy"

--- a/ctp2_data/spanish/gamedata/ldl_str.txt
+++ b/ctp2_data/spanish/gamedata/ldl_str.txt
@@ -2837,6 +2837,7 @@ str_ldl_CityWinUnitsTab				"Unidades"
 
 # autosave string
 AUTOSAVE_NAME					"AUTOSAVE"
+AUTOSAVE_NAME_PREVIOUS					"AUTOSAVE2"
 
 TRADE_ROUTE_RESET				"¡Restablecer ruta comercial!"
 

--- a/ctp2_data/spanish/gamedata/ldl_str.txt
+++ b/ctp2_data/spanish/gamedata/ldl_str.txt
@@ -2614,6 +2614,8 @@ str_ldl_SV_COUNTDOWN_SEQUENCE			"Controlador Gaia listo en %d turnos..."
 # Message Box
 str_ldl_MB_OK					"SÍ"
 str_ldl_MB_CANCEL				"Cancelar"
+str_ldl_MB_Inspect				"Inspeccionar"
+str_ldl_MB_Continue				"Continuar"
 
 # Army Management
 str_ldl_ArmyManagement				"Administrador del ejército"


### PR DESCRIPTION
## Summary

Most of these were found by chasing down the root cause of Asserts firing in debug builds during extended `/rnd` (debug auto-turn) sessions, rather than from a generic crash report or gameplay complaint — the Assert usually pointed at the exact mechanism (a consistency check failing, a safety cap being hit, a stuck flag), which made root-causing them tractable instead of guesswork.

A common thread runs through a good chunk of this batch: **stale state that quietly drifts out of sync with reality, then trips an Assert once it's used**. `Astar::DecayOrtho` re-decayed a node's *old* stored cost instead of the freshly computed one; `Diplomat::m_desireWarWith` cached a value from before a player slot got reused; the Sue/UndergroundRailway flag stayed set because it was cleared asynchronously instead of synchronously; `ForceDirectorSelect` got silently ignored because of a stale "selected since" flag; and the `/rnd` loop advanced turns before its own queued events had actually drained. In each case, the fix is the same shape — refresh or synchronously update the state at the point it actually changes, instead of letting a stale copy linger until something downstream asserts on the mismatch. A second, smaller cluster is genuine scheduler/pathfinding logic bugs (the outbidding margin, the ZOC visibility change, the transport reporting gaps) found the same way, by reading what the Assert-adjacent diagnostics logged.

## Scheduler / goal-matching fixes

- Fix stuck `k_UDF_USED_SPECIAL_ACTION_JUST_NOW` flag for Sue and UndergroundRailway special actions (made `AddSpecialActionUsed` synchronous instead of deferred to an async GEV handler).
- Fix `Gold::AddIncome` assert when a converted city's net gold goes negative — branch on sign before calling `AddIncome`/`SubIncome`, matching the existing idiom elsewhere in `CityData.cpp`.
- Require a decisive lead before `Scheduler::Match_Resources` evicts an already-committed agent from a goal — without a margin, two near-tied goals sharing the same one or two agents could evict each other's committed agent over noise-level score changes (confirmed via logs: two `GOAL_ESTABLISH_EMBASSY` goals endlessly swapping the same two diplomats, neither ever actually moving).
- Refresh `Diplomat::m_desireWarWith` cache on player slot reuse — a reused player slot could leave a stale cached value from whoever previously occupied it, tripping a consistency assert.
- Fix `ForceDirectorSelect` being silently ignored whenever a manual selection had happened previously that turn.

## `/rnd` turn-advance and diagnostics

- Fix `/rnd`'s auto-turn loop advancing before its own events drain (also wait on `GameEventManager::EventsPending()` and `DirectorImpl`'s action queue, not just player sync).
- Defer, rather than drop, `AddBeginScheduler` for a not-yet-current player.
- Rename `DIAG:` log prefixes to describe what they actually diagnose (`SPECIAL_ACTION:`, `PLAYER_SYNC:`), and move the `/rnd` `PLAYER_SYNC` diagnostics to `k_DBG_SCHEDULER_DETAIL` since they were flooding the log.
- Keep the previous turn's autosave around as a debugging aid.

## Pathfinding: robot ZOC and transport logic

- Let robot (AI) pathfinding ignore Zone-of-Control on tiles it can't currently see — a human player wouldn't have that omniscient knowledge either, and the real, non-visibility-based ZOC rule still applies at actual move-execution time as a safety net (`ArmyData::MoveIntoCell`), so an army that turns out to be wrong just gets its orders cleared and re-planned, same as it always did for occupied destinations.
- Split `Agent::FindPathToBoard` into task-specific wrappers (`FindPathToPickUpCargo`, `FindPathToBoard`, `FindPathToGoalWhileLoaded`), and rename `move_intersection` to `move_union` in `GotoGoalTaskSolution` (it's computed via OR, not AND).
- Replace duplicated city-or-field target-name logic with `Goal::GetTargetName`.
- Add an Inspect/Continue message box for `GotoGoalTaskSolution` pathfind failures, for interactively inspecting a stuck army/goal without derailing the rest of the game.
- Report when a transport is already in position to board cargo — two silent-return paths in `Goal::GotoTransportTaskSolution` never called the code that shows on-screen status text, making a correctly-waiting transport look idle.
- Log diagnostics for `GotoGoalTaskSolution`'s `FindPathToBoard` failures, later enriched with goal name, target unit count, and land/water/adjacency info.

## A* engine

- Fix `Astar::DecayOrtho` decaying a node's stale stored cost instead of the freshly computed one — this made every reopen of an orthogonal neighbor shrink its cost by another 5% regardless of the real edge cost, always looking like an improvement and reopening the same tile until it hit the reopen-count safety cap.
- Scale the reopen-count safety cap by the *square* of the search distance (first tried linear scaling, which wasn't enough headroom) — a long search over open, uniform-cost terrain legitimately ties a huge number of tiles, so multiple tiles getting reopened dozens of times is normal, not a runaway.
- Filter `k_DBG_ASTAR` diagnostics by player and army/city, not just by debug channel — added `Astar::GetOwner()`/`GetArmyId()` virtuals, overridden in `UnitAstar`, `CityAstar`, and `TradeAstar`, so a single debug player/army/city can be isolated instead of drowning in every player's every search.

## Misc

- Keep the AI from ordering armies that can't entrench (e.g. ships) to entrench anyway — a pre-existing `CanEntrench()` guard had been commented out; restored it, and dropped the disabled sleep fallback since sleep is a human-UI convenience the AI scheduler never checks.
- Document `--enable-ffmpeg4movies` in the Linux build instructions — movie playback silently does nothing without it, which looked like a bug rather than a missing build flag.